### PR TITLE
Typo fixes in docstrings etc.

### DIFF
--- a/docs/vis_tutorial.md
+++ b/docs/vis_tutorial.md
@@ -276,7 +276,7 @@ For more information see [here](roi_objects.md).
 
 The isolated objects now should all be plant material. There, can however, 
 be more than one object that makes up a plant, since sometimes leaves twist 
-making them appear in images as seperate objects. Therefore, in order for 
+making them appear in images as separate objects. Therefore, in order for
 shape analysis to perform properly the plant objects need to be combined into 
 one object using the Combine Objects function (for more info see [here](object_composition.md)).
 

--- a/plantcv/analyze_object.py
+++ b/plantcv/analyze_object.py
@@ -11,7 +11,7 @@ def analyze_object(img, imgname, obj, mask, device, debug=None, filename=False):
 
     Inputs:
     img             = image object (most likely the original), color(RGB)
-    imgname         = name of image
+    imgname         = name of image file.  (No longer used; kept for compatibility)
     obj             = single or grouped contour object
     mask            = binary image to use as mask for moments analysis
     device          = device number. Used to count steps in the pipeline

--- a/plantcv/analyze_object.py
+++ b/plantcv/analyze_object.py
@@ -13,6 +13,7 @@ def analyze_object(img, imgname, obj, mask, device, debug=None, filename=False):
     img             = image object (most likely the original), color(RGB)
     imgname         = name of image
     obj             = single or grouped contour object
+    mask            = binary image to use as mask for moments analysis
     device          = device number. Used to count steps in the pipeline
     debug           = None, print, or plot. Print = save to file, Plot = print to screen.
     filename        = False or image name. If defined print image

--- a/plantcv/roi_objects.py
+++ b/plantcv/roi_objects.py
@@ -13,10 +13,10 @@ def roi_objects(img, roi_type, roi_contour, roi_hierarchy, object_contour, obj_h
     Inputs:
     img            = img to display kept objects
     roi_type       = 'cutto' or 'partial' (for partially inside)
-    roi_contour    = contour of roi, output from "View and Ajust ROI" function
-    roi_hierarchy  = contour of roi, output from "View and Ajust ROI" function
-    object_contour = contours of objects, output from "Identifying Objects" fuction
-    obj_hierarchy  = hierarchy of objects, output from "Identifying Objects" fuction
+    roi_contour    = contour of roi, output from "View and Adjust ROI" function
+    roi_hierarchy  = contour of roi, output from "View and Adjust ROI" function
+    object_contour = contours of objects, output from "Identifying Objects" function
+    obj_hierarchy  = hierarchy of objects, output from "Identifying Objects" function
     device         = device number.  Used to count steps in the pipeline
     debug          = None, print, or plot. Print = save to file, Plot = print to screen.
 
@@ -83,7 +83,7 @@ def roi_objects(img, roi_type, roi_contour, roi_hierarchy, object_contour, obj_h
         cv2.drawContours(ori_img, kept_cnt, -1, (0, 255, 0), -1, lineType=8, hierarchy=hierarchy)
         cv2.drawContours(ori_img, roi_contour, -1, (255, 0, 0), 5, lineType=8, hierarchy=roi_hierarchy)
 
-    # Allows uer to cut objects to the ROI (all objects completely outside ROI will not be kept)
+    # Allows user to cut objects to the ROI (all objects completely outside ROI will not be kept)
     elif roi_type == 'cutto':
         cv2.drawContours(background1, object_contour, -1, (255, 255, 255), -1, lineType=8, hierarchy=obj_hierarchy)
         roi_points = np.vstack(roi_contour[0])


### PR DESCRIPTION
No changes to code, just comments.

You may wish to defer merging the two lines edited in analyze_objects. It may be better to just remove the 'imgname' argument. I did not go ahead and do that, because I do not know how many scripts that might break.
See also issue #121.