### PR TITLE
A quick start on an FAQ page

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -71,3 +71,8 @@ via pull request.
 - Q: How is PlantCV tested?
 - Q: Does PlantCV follow [Semantic Version Numbering](http://semver.org/)
   for stable releases?
+- Q: Is there a naming convention for PlantCV functions?
+    - A: No, not at present.
+    Please see the guide to contributing
+    for some general advice on code style,
+    PEP8 docstrings etc.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -43,7 +43,7 @@ and [updating documentation](documentation.md).
     <!-- https://github.com/danforthcenter/plantcv/issues/137 -->
     As noted in the ['Getting started' section](index.md),
     PlantCV was designed to work flexibly
-    with photos from as many types of camera as is feasible.
+    with many types of imagery as possible.
     Several groups are processing Raspberry Pi images using PlantCV,
     and the developers enthusiastically use Raspberry Pi cameras
     for [outreach and training efforts](https://github.com/danforthcenter/outreach/network)
@@ -51,7 +51,7 @@ and [updating documentation](documentation.md).
     You can even run PlantCV directly on a Pi
     (installation instructions for Ubuntu
     should work well with Raspbian),
-    though this certainly is not required.
+    though this is certainly not required.
     See also tutorials on the [DDPSC Maker Group site](http://maker.danforthcenter.org/).
 - Q: Can PlantCV use information about the temporal relation of images
   for object tracking etc.?

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,26 @@
+
+## Frequently asked questions
+
+<!-- Advice in box:
+http://producingoss.com/en/getting-started.html#documentation -->
+
+- Q: Does PlantCV work with OpenCV 3.x?
+    - A: Not yet, but this is a major goal for future development.
+    Work towards this goal will be coordinated
+    via GitHub [issue #29](https://github.com/danforthcenter/plantcv/issues/21)
+    and/or [milestone #1](https://github.com/danforthcenter/plantcv/milestone/1).
+    <!-- Cf. duplicate, https://github.com/danforthcenter/plantcv/issues/130 -->
+
+- Q: How should I grow plants and acquire images for quantitative processing?
+    - A: This depends on your goal,
+    and is beyond the scope of the current PlantCV documentation.
+    You may be be interested
+    in the general advice offered by [Roeder et al. (2012)](http://doi.org/10.1242/dev.076414)
+
+- Q: Can I use PlantCV to process photos taken with a Raspberry Pi camera?
+    - A: Yes.
+    Several groups are processing Pi images using PlantCV.
+    You can even run PlantCV directly on a Pi,
+    though this is not required.
+    See also previous question.
+    <!-- https://github.com/danforthcenter/plantcv/issues/137 -->

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,26 +1,73 @@
 
-## Frequently asked questions
+Some Frequently Asked Questions are collected here,
+grouped by category.
 
 <!-- Advice in box:
 http://producingoss.com/en/getting-started.html#documentation -->
 
+### Versions
+Related pages: guides to
+[installing PlantCV](installation.md),
+[contributing](CONTRIBUTING.md),
+and [updating documentation](documentation.md).
+
+- Q: Which version of PlantCV should I use?
+    - A: We suggest using the latest code from GitHub ('master' branch),
+    as described in the installation instructions.
+    If you are trying to reproduce the results from a specific manuscript,
+    you may prefer to use one of the [stable releases](https://github.com/danforthcenter/plantcv/releases).
 - Q: Does PlantCV work with OpenCV 3.x?
     - A: Not yet, but this is a major goal for future development.
     Work towards this goal will be coordinated
-    via GitHub [issue #29](https://github.com/danforthcenter/plantcv/issues/21)
+    via GitHub [issue #21](https://github.com/danforthcenter/plantcv/issues/21)
     and/or [milestone #1](https://github.com/danforthcenter/plantcv/milestone/1).
     <!-- Cf. duplicate, https://github.com/danforthcenter/plantcv/issues/130 -->
+- Q: When will the next stable version of PlantCV be released?
+    - A: Please see the [Milestones](https://github.com/danforthcenter/plantcv/milestones)
+    page for target date estimates
+    and the status of selected planned releases.
 
+
+### Image acquisition
 - Q: How should I grow plants and acquire images for quantitative processing?
-    - A: This depends on your goal,
+    - A: This depends on your main question of interest,
     and is beyond the scope of the current PlantCV documentation.
     You may be be interested
-    in the general advice offered by [Roeder et al. (2012)](http://doi.org/10.1242/dev.076414)
-
+    in a [review article](http://doi.org/10.1016/j.pbi.2015.02.006)
+    written by the lead PlantCV developers
+    or in the glossary and general advice
+    offered by [Roeder et al. (2012)](http://doi.org/10.1242/dev.076414)
 - Q: Can I use PlantCV to process photos taken with a Raspberry Pi camera?
     - A: Yes.
-    Several groups are processing Pi images using PlantCV.
-    You can even run PlantCV directly on a Pi,
-    though this is not required.
-    See also previous question.
+    <!-- This is related to the previous question. -->
     <!-- https://github.com/danforthcenter/plantcv/issues/137 -->
+    As noted in the ['Getting started' section](index.md),
+    PlantCV was designed to work flexibly
+    with photos from as many types of camera as is feasible.
+    Several groups are processing Raspberry Pi images using PlantCV,
+    and the developers enthusiastically use Raspberry Pi cameras
+    for [outreach and training efforts](https://github.com/danforthcenter/outreach/network)
+    and timelapse imaging.
+    You can even run PlantCV directly on a Pi
+    (installation instructions for Ubuntu
+    should work well with Raspbian),
+    though this certainly is not required.
+    See also tutorials on the [DDPSC Maker Group site](http://maker.danforthcenter.org/).
+- Q: Can PlantCV use information about the temporal relation of images
+  for object tracking etc.?
+    - A: Not at present.
+    OpenCV includes tools for analyzing video data,
+    so this could be added in the future.
+
+### Other
+We try to continually improve our documentation.
+We have not (necessarily) written answers for the following questions.
+Users are encouraged
+to ask questions by [filing an issue](https://github.com/danforthcenter/plantcv/issues)
+and also to submit candidate questions and answers
+via pull request.
+
+- Q: How is PlantCV structured?
+- Q: How is PlantCV tested?
+- Q: Does PlantCV follow [Semantic Version Numbering](http://semver.org/)
+  for stable releases?

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ previously published on their steady-state fluorescence imaging systems
 
 The documentation defaults to the `latest` version of PlantCV which is the latest
 commit in the `master` code branch.
-Documentation for all major releases from v1.1 on are also available.
+Documentation for all releases from v1.1 on are also available
+via the standard ReadTheDocs popup/pulldown menu.
 
 [Return to the PlantCV homepage](http://plantcv.danforthcenter.org)

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,14 +3,18 @@
 ## Getting started
 
 [PlantCV](http://plantcv.danforthcenter.org) is composed of modular functions in order to be applicable to a 
-variety of plant types and imaging systems. In the following documentation 
+variety of plant types and imaging systems.
+In the following documentation
 we will describe use of each function and provide tutorials on how each 
 function is used in the context of an overall image-processing pipeline. 
-The initial release of PlantCV contains base functions that are required 
-to examine images from an excitation imaging fluorometer (PSII), visible 
-spectrum camera (VIS), and near-infrared camera (NIR). We are continuing 
-to develop PlantCV and encourage input from the greater plant phenomics 
-community. Please post questions and comments [HERE](https://github.com/danforthcenter/plantcv/issues).
+The initial releases of PlantCV have been designed
+for processing images
+from visible spectrum cameras ('VIS'),
+near-infrared cameras ('NIR'),
+and excitation imaging fluorometers ('PSII'; see note below).
+Development of PlantCV is ongoing---we encourage input
+from the greater plant phenomics community.
+Please post questions and comments on the [GitHub issues page](https://github.com/danforthcenter/plantcv/issues).
 
 **Note**: At the Danforth Center we refer to our excitation imaging 
 fluorometer (PSII) camera system as 'FLU' internally. But others have 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ pages:
 - Home: index.md
 - Documentation:
   - 'Installation': installation.md
+  - 'Frequently Asked Questions': faq.md
   - 'Updating PlantCV': updating.md
   - 'Using Jupyter Notebooks': jupyter.md
   - 'Contributing to PlantCV': CONTRIBUTING.md


### PR DESCRIPTION
This is a proposed new documentation page designed to help users in a hurry and preempt questions. There are no changes to code.

I have not tested the new page with `mkdocs build`, so I am not 100% sure that it will render properly.

I would add a 'documentation' label to this, but I do not see the menu alluded to in the PR template.

Let me know if I can make changes, file related issues etc.

### Checklist:

- (NA) Relevant tests (and test data) have been added or updated and passed.

- [X] The documentation was added or updated.

- (NA) Relevant issues were updated or added.