### PR TITLE
Added debug to readimage

### DIFF
--- a/docs/read_image.md
+++ b/docs/read_image.md
@@ -2,12 +2,13 @@
 
 Reads image into numpy ndarray and splits the path and image filename. This is a wrapper for the OpenCV function [imread](http://docs.opencv.org/modules/highgui/doc/reading_and_writing_images_and_video.html).
 
-**readimage**(*filename*)
+**readimage**(*filename, debug=None*)
 
 **returns** img, path, image filename
 
 - **Parameters:**
-    - filename- image file to be read (possibly including a path)
+    - filename - image file to be read (possibly including a path)
+    - debug - None, "print", or "plot". Print = save to file, Plot = print to screen. Default = None
 - **Context:**
     - Reads in file to be processed
 - **Example use:**

--- a/plantcv/readimage.py
+++ b/plantcv/readimage.py
@@ -3,13 +3,16 @@
 import os
 import cv2
 from . import fatal_error
+from . import print_image
+from . import plot_image
 
 
-def readimage(filename):
+def readimage(filename, debug=None):
     """Read image from file.
 
     Inputs:
     filename = name of image file
+    debug    = None, print, or plot. Print = save to file, Plot = print to screen.
 
     Returns:
     img      = image object as numpy array
@@ -17,6 +20,7 @@ def readimage(filename):
     img_name = name of image file
 
     :param filename: str
+    :param debug: str
     :return img: numpy array
     :return path: str
     :return img_name: str
@@ -29,5 +33,10 @@ def readimage(filename):
 
     # Split path from filename
     path, img_name = os.path.split(filename)
+
+    if debug == "print":
+        print_image(img, "input_image.png")
+    elif debug == "plot":
+        plot_image(img)
 
     return img, path, img_name

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -902,6 +902,11 @@ def test_plantcv_print_results():
 
 
 def test_plantcv_readimage():
+    # Test with debug = "print"
+    _ = pcv.readimage(filename=os.path.join(TEST_DATA, TEST_INPUT_COLOR), debug="print")
+    os.rename("input_image.png", os.path.join(TEST_TMPDIR, "input_image.png"))
+    # Test with debug = "plot"
+    _ = pcv.readimage(filename=os.path.join(TEST_DATA, TEST_INPUT_COLOR), debug="plot")
     img, path, img_name = pcv.readimage(filename=os.path.join(TEST_DATA, TEST_INPUT_COLOR))
     # Assert that the image name returned equals the name of the input image
     # Assert that the path of the image returned equals the path of the input image


### PR DESCRIPTION
This commit adds an input parameter to `readimage`, but it has a
default value so it will not break the existing API. The main purpose
is to add the ability to automatically plot input images in Jupyter.

<!--- 
Thanks for contributing! Instructions are in comments, like this.
 
Please edit this template before submitting a new pull request.
-->

<!--- 
Title: Please provide a descriptive title that summarizes your pull request. 
-->

<!---
Labels: Please select one or more relevant tags (menu on the right).
--->

### Description
<!--- 
Describe your changes, for example:
* What did you change/add and why?
* Does it close an open issue? (if so, please link to the issue)
* Have you tested the changes, and if so, how?
-->
A debug option was added to `readimage` so that the input image can be automatically plotted in Jupyter notebooks. Because debug=None is the default, this change will not break existing usage of readimage without the debug option set. The unit test and documentation page were updated accordingly.

### Types of changes
<!---
Is this a: 
* Bug fix?
* New feature?
* Does it change existing functionality?
-->
New minor feature.

### Checklist:

- [x] Relevant tests (and test data) have been added or updated and passed.
- [x] The documentation was added or updated.
- [x] Relevant issues were updated or added.
