### PR TITLE
Fix documentation for Sobel Filter

### DIFF
--- a/docs/nir_tutorial.md
+++ b/docs/nir_tutorial.md
@@ -149,13 +149,13 @@ Notice the plant is darker in this image than it was in the original image.
 
 ```python
     # Sobel filtering  
-    # 1st derivative sobel filtering along horizontal axis, kernel = 1, unscaled)
-    device, sbx_img = pcv.sobel_filter(img, 1, 0, 1, 1, device, args.debug)
+    # 1st derivative sobel filtering along horizontal axis, kernel = 1)
+    device, sbx_img = pcv.sobel_filter(img, 1, 0, 1, device, args.debug)
     if args.debug:
         pcv.plot_hist(sbx_img, 'hist_sbx')
     
-    # 1st derivative sobel filtering along vertical axis, kernel = 1, unscaled)
-    device, sby_img = pcv.sobel_filter(img, 0, 1, 1, 1, device, args.debug)
+    # 1st derivative sobel filtering along vertical axis, kernel = 1)
+    device, sby_img = pcv.sobel_filter(img, 0, 1, 1, device, args.debug)
     if args.debug:
         pcv.plot_hist(sby_img, 'hist_sby')
     

--- a/docs/sobel_filter.md
+++ b/docs/sobel_filter.md
@@ -8,10 +8,9 @@ This is a filtering method used to identify and highlight coarse changes in pixe
 
 - **Parameters:**
     - img - binary image object. This image will be returned after filling.
-    - dx - derivative of x to analyze (1-3)
-    - dy = derivative of y to analyze (1-3)
+    - dx - derivative of x to analyze (0-3)
+    - dy - derivative of y to analyze (0-3)
     - k - apertures size used to calculate 2nd derivative filter, specifies the size of the kernel (must be an odd integer: 1,3,5...)
-    - scale - scaling factor applied (multiplied) to computed Laplacian values (scale = 1 is unscaled)
     - device - Counter for image processing steps
     - debug - None, "print", or "plot". Print = save to file, Plot = print to screen. Default = None 
 - **Context:**


### PR DESCRIPTION
The sobel filter specifies that "scale" is a parameter, when it is not.
Remove the line conerning "scale"

"dx" and "dy" specify that the derivative can be 1 to 3
Change the documentation to specify the derivative can be from 0 to 3
This is as according to the example usage on the sobel filter documentation.
