### PR TITLE
Change NIR documentation

### DIFF
--- a/docs/nir_tutorial.md
+++ b/docs/nir_tutorial.md
@@ -316,14 +316,6 @@ Include all continuous portions within the plant that fall within the area of in
 This step helps to remove any other areas of background that were not removed during any other filtering steps.
 
 ```python
-    device, masked_img = pcv.apply_mask(kept_mask, inv_bx1234_img, 'black', device, args.debug)
-    rgb = cv2.cvtColor(img,cv2.COLOR_GRAY2RGB)
-    # Generate a binary to send to the analysis function
-    device, mask = pcv.binary_threshold(masked_img, 1, 255, 'light', device, args.debug)
-    mask3d = np.copy(mask)
-    plant_objects_2, plant_hierarchy_2 = cv2.findContours(mask3d,cv2.RETR_TREE,cv2.CHAIN_APPROX_NONE)
-    device, o, m = pcv.object_composition(rgb, roi_objects, hierarchy5, device, args.debug)
-    
     # Get final masked image
     device, masked_img = pcv.apply_mask(kept_mask, inv_bx1234_img, 'black', device, args.debug)
     # Obtain a 3 dimensional representation of this grayscale image (for pseudocoloring)

--- a/docs/nir_tutorial.md
+++ b/docs/nir_tutorial.md
@@ -254,7 +254,7 @@ Combining these methods improves our ability to capture more plant and less back
     # mask for the right side of the image
     device, masked3, box3_img, rect_contour3, hierarchy3 = pcv.rectangle_mask(img, (240,1), (318,252), device, args.debug)
     # mask the edges
-    device, box4_img, rect_contour4, hierarchy4 = pcv.border_mask(img, (1,1), (318,252), device, args.debug)
+    device, masked4, box4_img, rect_contour4, hierarchy4 = pcv.rectangle_mask(img, (1,1), (318,252), device, args.debug)
 ```
 
 **Figure 8.** From top to bottom: Make a mask to hide the pot; Make a mask to hide left panel; 


### PR DESCRIPTION
I cannot find border_mask() in the documentation.
Also, running some code with border_mask() creates this error:
AttributeError: 'module' object has no attribute 'border_mask'

Change border_mask() to rectangle_mask() in NIR tutorial documentation.