### PR TITLE
Bug fix resize and crop position

### DIFF
--- a/plantcv/crop_position_mask.py
+++ b/plantcv/crop_position_mask.py
@@ -241,7 +241,7 @@ def crop_position_mask(img, mask, device, x, y, v_pos="top", h_pos="right", debu
             print_image(newmask, (str(device) + "_newmask.png"))
         elif debug == 'plot':
             plot_image(newmask, cmap='gray')
-        objects, hierarchy = cv2.findContours(newmask, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)
+        objects, hierarchy = cv2.findContours(np.copy(newmask), cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)
         for i, cnt in enumerate(objects):
             cv2.drawContours(ori_img, objects, i, (255, 102, 255), -1, lineType=8, hierarchy=hierarchy)
         if debug == 'print':

--- a/plantcv/crop_position_mask.py
+++ b/plantcv/crop_position_mask.py
@@ -37,8 +37,6 @@ def crop_position_mask(img, mask, device, x, y, v_pos="top", h_pos="right", debu
     :return newmask: numpy array
     """
 
-    ori_mask = np.copy(mask)
-
     device += 1
 
     if x < 0 or y < 0:
@@ -53,18 +51,14 @@ def crop_position_mask(img, mask, device, x, y, v_pos="top", h_pos="right", debu
 
     if len(np.shape(img)) == 3:
         ix, iy, iz = np.shape(img)
-        ori_img = np.copy(img)
     else:
         ix, iy = np.shape(img)
-        ori_img = np.dstack((img, img, img))
 
     if len(np.shape(mask)) == 3:
         mx, my, mz = np.shape(mask)
         mask = mask[0]
     else:
         mx, my = np.shape(mask)
-
-    npimg = np.zeros((ix, iy), dtype=np.uint8)
 
     # resize the images so they are equal in size and centered
     if mx >= ix:

--- a/plantcv/resize.py
+++ b/plantcv/resize.py
@@ -31,10 +31,10 @@ def resize(img, resize_x, resize_y, device, debug=None):
 
     device += 1
 
-    reimg = cv2.resize(img, (0, 0), fx=resize_x, fy=resize_y)
-
     if resize_x <= 0 and resize_y <= 0:
         fatal_error("Resize values both cannot be 0 or negative values!")
+
+    reimg = cv2.resize(img, (0, 0), fx=resize_x, fy=resize_y)
 
     if debug == 'print':
         print_image(reimg, (str(device) + "_resize1.png"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas
 python-dateutil
 scipy
 scikit-image
+pytest

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -165,7 +165,7 @@ def test_plantcv_analyze_bound():
                           debug="plot", filename=False)
     # Test with debug='plot', line position that will trigger -y, and two channel object
     _ = pcv.analyze_bound(img=img, imgname="img", obj=object_contours[0], mask=mask, line_position=1, device=0,
-                           debug="plot", filename=False)
+                          debug="plot", filename=False)
     # Test with debug = None
     device, boundary_header, boundary_data, boundary_img1 = pcv.analyze_bound(img=img, imgname="img",
                                                                               obj=object_contours[0], mask=mask,
@@ -394,7 +394,7 @@ def test_plantcv_cluster_contours_splitimg():
     img1 = cv2.imread(os.path.join(TEST_DATA, TEST_INTPUT_MULTI), -1)
     contours = np.load(os.path.join(TEST_DATA, TEST_INPUT_MULTI_CONTOUR))
     clusters = np.load(os.path.join(TEST_DATA, TEST_INPUT_ClUSTER_CONTOUR))
-    cluster_names=os.path.join(TEST_DATA,TEST_INPUT_GENOTXT)
+    cluster_names = os.path.join(TEST_DATA, TEST_INPUT_GENOTXT)
     roi_contours = contours['arr_0']
     cluster_contours = clusters['arr_0']
     # Test with debug = "print"
@@ -406,7 +406,8 @@ def test_plantcv_cluster_contours_splitimg():
         os.rename(str(i) + "_wmasked.png", os.path.join(cache_dir, str(i) + "_wmasked.png"))
     # Test with debug = "plot"
     _ = pcv.cluster_contour_splitimg(device=0, img=img1, grouped_contour_indexes=cluster_contours,
-                                     contours=roi_contours, outdir=None, file=None, filenames=cluster_names,debug="plot")
+                                     contours=roi_contours, outdir=None, file=None, filenames=cluster_names,
+                                     debug="plot")
     # Test with debug = None
     device, output_path = pcv.cluster_contour_splitimg(device=0, img=img1, grouped_contour_indexes=cluster_contours,
                                                        contours=roi_contours, outdir=None, file=None,
@@ -1001,7 +1002,7 @@ def test_plantcv_object_composition():
     device, contours, mask = pcv.object_composition(img=img, contours=object_contours, hierarchy=object_hierarchy,
                                                     device=0, debug=None)
     # Assert that the objects have been combined
-    contour_shape = np.shape(contours)
+    contour_shape = np.shape(contours)  # type: tuple
     assert contour_shape[1] == 1
 
 
@@ -1626,11 +1627,11 @@ def test_plantcv_background_subtraction_bad_img_type():
 def test_plantcv_background_subtraction_different_sizes():
     fg_img = cv2.imread(os.path.join(TEST_DATA, TEST_FOREGROUND))
     bg_img = cv2.imread(os.path.join(TEST_DATA, TEST_BACKGROUND))
-    bg_shp = np.shape(bg_img)
+    bg_shp = np.shape(bg_img)  # type: tuple
     bg_img_resized = cv2.resize(bg_img, (bg_shp[0] / 2, bg_shp[1] / 2), interpolation=cv2.INTER_AREA)
     device, fgmask = pcv.background_subtraction(background_image=bg_img_resized, foreground_image=fg_img, device=0,
                                                 debug=None)
-    assert np.sum(fgmask > 0)
+    assert np.sum(fgmask) > 0
 
 # ##############################
 # Tests for the learn subpackage

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1186,6 +1186,14 @@ def test_plantcv_resize():
     assert ix > rx
 
 
+def test_plantcv_resize_bad_inputs():
+    # Read in test data
+    img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_COLOR))
+    # Test for fatal error caused by two negative resize values
+    with pytest.raises(RuntimeError):
+        _ = pcv.resize(img=img, resize_x=-1, resize_y=-1, device=0, debug=None)
+
+
 def test_plantcv_rgb2gray_hsv():
     # Test cache directory
     cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_rgb2gray_hsv")
@@ -1443,9 +1451,9 @@ def test_plantcv_white_balance_gray_16bit():
     os.rename("1_whitebalance_roi.png", os.path.join(cache_dir, "1_whitebalance_roi.png"))
     os.rename("1_whitebalance.png", os.path.join(cache_dir, "1_whitebalance.png"))
     # Test with debug = "plot"
-    _ = pcv.white_balance(device=0, img=img, mode ='max', debug="plot", roi=(5, 5, 80, 80))
+    _ = pcv.white_balance(device=0, img=img, mode='max', debug="plot", roi=(5, 5, 80, 80))
     # Test without an ROI
-    _ = pcv.white_balance(device=0, img=img, mode = 'hist', debug=None, roi=None)
+    _ = pcv.white_balance(device=0, img=img, mode='hist', debug=None, roi=None)
     # Test with debug = None
     device, white_balanced = pcv.white_balance(device=0, img=img, debug=None, roi=(5, 5, 80, 80))
     imgavg = np.average(img)


### PR DESCRIPTION
<!--- 
Thanks for contributing! Instructions are in comments, like this.
 
Please edit this template before submitting a new pull request.
-->

<!--- 
Title: Please provide a descriptive title that summarizes your pull request. 
-->

<!---
Labels: Please select one or more relevant tags (menu on the right).
--->

### Description
<!--- 
Describe your changes, for example:
* What did you change/add and why?
* Does it close an open issue? (if so, please link to the issue)
* Have you tested the changes, and if so, how?
-->
This pull request primarily fixes a bug in the function crop_position_mask where the mask image that is returned by the function is destroyed by a call to cv2.findContours in debug mode only (in normal mode, findContours is not used). A new test was added for the resize function as well.

### Types of changes
<!---
Is this a: 
* Bug fix?
* New feature?
* Does it change existing functionality?
-->
Bug fix

### Checklist:

- [x] Relevant tests (and test data) have been added or updated and passed.
- [x] The documentation was added or updated.
- [x] Relevant issues were updated or added.
