### PR TITLE
Fixes bug where missing RGB data causes plantcv-train.py to crash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
+#  - conda update -q conda
   - conda info -a
   # These are the packages we need
   - conda create -q -c menpo -n test-environment python=$TRAVIS_PYTHON_VERSION opencv=2.4.11

--- a/plantcv/learn/naive_bayes.py
+++ b/plantcv/learn/naive_bayes.py
@@ -115,12 +115,13 @@ def naive_bayes_multiclass(samples_file, outfile, mkplots=False):
             points = row.split("\t")
             # For each point per class
             for i, point in enumerate(points):
-                # Split the point into red, green, and blue integer values
-                red, green, blue = map(int, point.split(","))
-                # Append each intensity value into the appropriate class list
-                sample_points[class_list[i]]["red"].append(red)
-                sample_points[class_list[i]]["green"].append(green)
-                sample_points[class_list[i]]["blue"].append(blue)
+                if len(point) > 0:
+                    # Split the point into red, green, and blue integer values
+                    red, green, blue = map(int, point.split(","))
+                    # Append each intensity value into the appropriate class list
+                    sample_points[class_list[i]]["red"].append(red)
+                    sample_points[class_list[i]]["green"].append(green)
+                    sample_points[class_list[i]]["blue"].append(blue)
     f.close()
     # Initialize a dictionary to store probability density functions per color channel in HSV colorspace
     pdfs = {"hue": {}, "saturation": {}, "value": {}}


### PR DESCRIPTION
<!--- 
Thanks for contributing! Instructions are in comments, like this.
 
Please edit this template before submitting a new pull request.
-->

<!--- 
Title: Please provide a descriptive title that summarizes your pull request. 
-->

<!---
Labels: Please select one or more relevant tags (menu on the right).
(This only shows up for administrators.)
--->

### Description
<!--- 
Describe your changes, for example:
* What did you change/add and why?
* Does it close an open issue? (if so, please link to the issue)
* Have you tested the changes, and if so, how?
-->
The naive_bayes_multiclass training method now skips cells in the RGB pixel sample table that don't contain any data.

### Types of changes
<!---
Is this a: 
* Bug fix?
* New feature?
* Does it change existing functionality?
-->
Bug fix

### Checklist:

- [x] Relevant tests (and test data) have been added or updated and passed.
- [x] The documentation was added or updated.
- [x] Relevant issues were updated or added.
