### PR TITLE
Extra parentheses were preventing white_balance(debug = 'print')

### DIFF
--- a/plantcv/white_balance.py
+++ b/plantcv/white_balance.py
@@ -113,8 +113,8 @@ def white_balance(device, img, mode='hist',debug=None, roi=None):
             finalcorrected = _max(img, hmax, mask, x, y, h, w, type)
 
     if debug == 'print':
-        print_image(ori_img, (str(device) + '_whitebalance_roi.png'))
-        print_image(finalcorrected, (str(device) + '_whitebalance.png'))
+        print_image(ori_img, str(device) + '_whitebalance_roi.png')
+        print_image(finalcorrected, str(device) + '_whitebalance.png')
 
     elif debug == 'plot':
         plot_image(ori_img, cmap='gray')


### PR DESCRIPTION
<!--- 

### Description

Describe your changes, for example:
* What did you change/add and why?
* Does it close an open issue? (if so, please link to the issue)
* Have you tested the changes, and if so, how?


### Types of changes

Is this a: 
* Bug fix?
* New feature?
* Does it change existing functionality?
-->

This is (hopefully) a trivial bug fix, to enable users testing pipeline scripts at the command line to see the debug output files from the `white_balance` function. I guess the extra parentheses put the concatenated strings into a tuple, which `print_image` cannot handle?
Presumably this problem was not noticed because people have relied on Jupyter (`debug = 'plot'`) instead.
I did not alter `test_plantcv_white_balance_gray_16bit()`, `test_plantcv_white_balance_gray_8bit()`, or `test_plantcv_white_balance_rgb()`, because I do not understand what those are really testing.
I suppose one could add some simple tests to make sure that output files from `debug = 'print'` are at least created. I do not know if you would want to systematically do that for every function though...

### Checklist:

- [See above] Relevant tests (and test data) have been added or updated and passed.
- [NA] The documentation was added or updated.
- [NA] Relevant issues were updated or added.
