### PR TITLE
Guard rogue debug print statements when out of debug.

### DIFF
--- a/plantcv/analyze_object.py
+++ b/plantcv/analyze_object.py
@@ -235,10 +235,12 @@ def analyze_object(img, imgname, obj, mask, device, debug=None, filename=False):
         out_file = str(filename[0:-4]) + '_shapes.jpg'
         out_file1 = str(filename[0:-4]) + '_mask.jpg'
 
-        print_image(ori_img, out_file)
+        if debug == 'print':
+            print_image(ori_img, out_file)
         analysis_images.append(['IMAGE', 'shapes', out_file])
 
-        print_image(mask, out_file1)
+        if debug == 'print':
+            print_image(mask, out_file1)
         analysis_images.append(['IMAGE', 'mask', out_file1])
 
     else:


### PR DESCRIPTION
### Description

Two `print_image` statements were unconditionally generating input
files. This commit guards the statements according to the debugging
facility logic: File generation happens only when the `debug='print'`
parameter is set.

Note for devops:
This issue is quite important to fix. The unconditional generated
files build up over time, and end up filling deployment disk space.
Production systems suffer from crashes and impossible deployments, as
upgrade packages cannot even be sent to the target machine.

* This PR does not close any open issue, as far as I am aware at opening time.
* Changes are deployed in my production systems, working as expected.

### Types of changes

This is a bug fix.

### Checklist:

- [x] Relevant tests (and test data) have been added or updated and passed.
- [ ] The documentation was added or updated.
- [ ] Relevant issues were updated or added.
