### PR TITLE
Disabled warnings for matplotlib.use

### DIFF
--- a/plantcv/analyze_NIR_intensity.py
+++ b/plantcv/analyze_NIR_intensity.py
@@ -116,7 +116,7 @@ def analyze_NIR_intensity(img, rgbimg, mask, bins, device, histplot=False, debug
 
     if histplot is True:
         import matplotlib
-        matplotlib.use('Agg')
+        matplotlib.use('Agg', warn=False)
         from matplotlib import pyplot as plt
 
         # plot hist percent

--- a/plantcv/analyze_color.py
+++ b/plantcv/analyze_color.py
@@ -248,7 +248,7 @@ def analyze_color(img, imgname, mask, bins, device, debug=None, hist_plot_type=N
 
     if hist_plot_type is not None and filename:
         import matplotlib
-        matplotlib.use('Agg')
+        matplotlib.use('Agg', warn=False)
         from matplotlib import pyplot as plt
 
         # Create Histogram Plot

--- a/plantcv/fluor_fvfm.py
+++ b/plantcv/fluor_fvfm.py
@@ -111,7 +111,7 @@ def fluor_fvfm(fdark, fmin, fmax, mask, device, filename, bins=1000, debug=None)
 
     if filename:
         import matplotlib
-        matplotlib.use('Agg')
+        matplotlib.use('Agg', warn=False)
         from matplotlib import pyplot as plt
         from matplotlib import cm as cm
 

--- a/plantcv/learn/naive_bayes.py
+++ b/plantcv/learn/naive_bayes.py
@@ -182,7 +182,7 @@ def _plot_pdf(channel, outdir, **kwargs):
     :param kwargs: dict
     """
     import matplotlib
-    matplotlib.use("Agg")
+    matplotlib.use("Agg", warn=False)
     from matplotlib import pyplot as plt
     for class_name, pdf in kwargs.items():
         plt.plot(pdf, label=class_name)

--- a/plantcv/plot_colorbar.py
+++ b/plantcv/plot_colorbar.py
@@ -15,7 +15,7 @@ def plot_colorbar(outdir, filename, bins):
     :return:
     """
     import matplotlib
-    matplotlib.use('Agg')
+    matplotlib.use('Agg', warn=False)
     from matplotlib import pyplot as plt
     from matplotlib import cm as cm
     from matplotlib import colors as colors

--- a/plantcv/plot_hist.py
+++ b/plantcv/plot_hist.py
@@ -16,7 +16,7 @@ def plot_hist(img, name=False):
     """
 
     import matplotlib
-    matplotlib.use('Agg')
+    matplotlib.use('Agg', warn=False)
     from matplotlib import pyplot as plt
 
     # get histogram

--- a/plantcv/triangle_auto_threshold.py
+++ b/plantcv/triangle_auto_threshold.py
@@ -267,7 +267,7 @@ def triangle_auto_threshold(device, img, maxvalue, object_type, xstep=1, debug=N
 
     if debug is not None:
         import matplotlib
-        matplotlib.use('Agg')
+        matplotlib.use('Agg', warn=False)
         from matplotlib import pyplot as plt
 
     if debug == 'print':

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -10,7 +10,7 @@ import plantcv.learn
 # Import matplotlib and use a null Template to block plotting to screen
 # This will let us test debug = "plot"
 import matplotlib
-matplotlib.use('Template')
+matplotlib.use('Template', warn=False)
 
 TEST_DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 TEST_TMPDIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".cache")


### PR DESCRIPTION
### Description

Addresses issue #223. Quiets matplotlib warnings when attempting to change the plotting backend more than once in the same scope.

### Types of changes

Annoyance fix.

### Checklist:

- [x] Relevant tests (and test data) have been added or updated and passed.
- [x] The documentation was added or updated.
- [x] Relevant issues were updated or added.
