### PR TITLE
Fix import typo

### DIFF
--- a/docs/multi-plant_tutorial.md
+++ b/docs/multi-plant_tutorial.md
@@ -55,7 +55,7 @@ import re
 import numpy as np
 import argparse
 import string
-from plantcv import plancv as pcv
+from plantcv import plantcv as pcv
 
 ### Parse command-line arguments
 def options():


### PR DESCRIPTION
Title: Fix typo in `Documentation » Tutorials » Multi plant pipeline`

Labels: Documentation

### Description
There is a typo in import statement 
```python
# old
from plantcv import plancv as pcv
# update
from plantcv import plantcv as pcv`
```

### Types of changes
Bug Fix: Fix typo to prevent error message.

### Checklist:

- [x] Relevant tests (and test data) have been added or updated and passed.
- [x] The documentation was added or updated.
- [x] Relevant issues were updated or added.
