### PR TITLE
tutorial_docs_correction

### DIFF
--- a/docs/multi-plant_tutorial.md
+++ b/docs/multi-plant_tutorial.md
@@ -321,10 +321,11 @@ Cluster plants based on defined grid, for more info see [here](cluster_contours.
 #Inputs:
 #    img - An RGB image array
 #    roi_objects - object contours in an image that are needed to be clustered.
+#    roi_obj_hierarchy       = object hierarchy
 #    nrow - number of rows to cluster (this should be the approximate  number of desired rows in the entire image (even if there isn't a literal row of plants)
 #    ncol - number of columns to cluster (this should be the approximate number of desired columns in the entire image (even if there isn't a literal row of plants)
 
-clusters_i, contours = pcv.cluster_contours(img1, roi_objects, 4, 6)
+clusters_i, contours, hierarchies = pcv.cluster_contours(img1, roi_objects, roi_obj_hierarchy, 4, 6)
 
 ```
 

--- a/docs/vis_tutorial.md
+++ b/docs/vis_tutorial.md
@@ -195,7 +195,6 @@ The resulting binary image is used to mask the masked image from Figure 7.
     # Join the thresholded saturation and blue-yellow images (OR)
     ab1 = pcv.logical_or(maskeda_thresh, maskedb_thresh)
     ab = pcv.logical_or(maskeda_thresh1, ab1)
-    ab_cnt = pcv.logical_or(maskeda_thresh1)
     
     # Fill small objects
     ab_fill = pcv.fill(ab, 200)
@@ -309,7 +308,7 @@ and the Boundary tool function [here](analyze_bound_horizontal.md).
     boundary_header, boundary_data, boundary_img1 = pcv.analyze_bound_horizontal(img, obj, mask, 1680, args.outdir + '/' + filename)
     
     # Determine color properties: Histograms, Color Slices and Pseudocolored Images, output color analyzed images (optional)
-    color_header, color_data, color_img = pcv.analyze_color(img, kept_mask, 256, 'all', 'v', 'img', 300, args.outdir + '/' + filename)
+    color_header, color_data, color_img = pcv.analyze_color(img, kept_mask, 256, 'all', 'v', 'img', args.outdir + '/' + filename)
     
     # Write shape and color data to results file
     result=open(args.result,"a")


### PR DESCRIPTION
Issue #257 describes an incorrect portion of the tutorial. Updated docs to match changes that had been made to cluster_contours function.

Issue #255 described errors in documentation for the VIS tutorial. Removed extra parameter from pcv.analyze_color function and removed the line ab_cnt = pcv.logical_or(maskeda_thresh1) since it was missing an argument and wasn't used downstream in the tutorial.

### Description
<!--- 
* Tests are completely unchanged. Documentation for tutorials only things changed.
* Does it close an open issue? Yes: #257 and #255 
-->

### Types of changes
<!---
Is this a: 
* Documentation correction
-->

### Checklist:

- [NA] Relevant tests (and test data) have been added or updated and passed.
- [x] The documentation was added or updated.
- [x] Relevant issues were updated or added.
