### PR TITLE
changed method for removing file extensions

### DIFF
--- a/plantcv/plantcv/analyze_bound_horizontal.py
+++ b/plantcv/plantcv/analyze_bound_horizontal.py
@@ -132,7 +132,7 @@ def analyze_bound_horizontal(img, obj, mask, line_position, filename=False):
                 cv2.line(wback, (int(cmx), y_coor - 2), (int(cmx), y_coor + height_below_bound), (0, 255, 0), 3)
         if filename:
             # Output images with boundary line, above/below bound area
-            out_file = str(filename[0:-4]) + '_boundary' + str(line_position) + '.jpg'
+            out_file = os.path.splitext(filename)[0] + '_boundary' + str(line_position) + '.jpg'
             print_image(ori_img, out_file)
             analysis_images = ['IMAGE', 'boundary', out_file]
 

--- a/plantcv/plantcv/analyze_bound_vertical.py
+++ b/plantcv/plantcv/analyze_bound_vertical.py
@@ -133,7 +133,7 @@ def analyze_bound_vertical(img, obj, mask, line_position, filename=False):
                 cv2.line(wback, (x_coor + 2, int(cmy)), (x_coor - width_right_bound, int(cmy)), (0, 255, 0), 3)
         if filename:
             # Output images with boundary line, above/below bound area
-            out_file = str(filename[0:-4]) + '_boundary' + str(line_position) + '.jpg'
+            out_file = os.path.splitext(filename)[0] + '_boundary' + str(line_position) + '.jpg'
             print_image(ori_img, out_file)
             analysis_images = ['IMAGE', 'boundary', out_file]
 

--- a/plantcv/plantcv/analyze_color.py
+++ b/plantcv/plantcv/analyze_color.py
@@ -69,7 +69,7 @@ def _pseudocolored_image(histogram, bins, img, mask, background, channel, filena
     if filename:
         for key in output_imgs:
             if output_imgs[key]["img"] is not None:
-                fig_name_pseudo = str(filename[0:-4]) + '_' + str(channel) + '_pseudo_on_' + \
+                fig_name_pseudo = os.path.splitext(filename)[0] + '_' + str(channel) + '_pseudo_on_' + \
                                   output_imgs[key]["background"] + '.jpg'
                 path = os.path.dirname(filename)
                 print_image(output_imgs[key]["img"], fig_name_pseudo)
@@ -249,7 +249,7 @@ def analyze_color(rgb_img, mask, bins, hist_plot_type=None, pseudo_channel='v',
             plt.legend()
 
         # Print plot
-        fig_name = (str(filename[0:-4]) + '_' + str(hist_plot_type) + '_hist.svg')
+        fig_name = (os.path.splitext(filename)[0] + '_' + str(hist_plot_type) + '_hist.svg')
         plt.savefig(fig_name)
         analysis_images.append(['IMAGE', 'hist', fig_name])
         if params.debug == 'print':

--- a/plantcv/plantcv/analyze_nir_intensity.py
+++ b/plantcv/plantcv/analyze_nir_intensity.py
@@ -96,7 +96,7 @@ def analyze_nir_intensity(gray_img, mask, bins, histplot=False, filename=False):
         if not os.path.isfile(path + '/' + fig_name):
             plot_colorbar(path, fig_name, bins)
 
-        fig_name_pseudo = (str(filename[0:-4]) + '_nir_pseudo_col.jpg')
+        fig_name_pseudo = (os.path.splitext(filename)[0] + '_nir_pseudo_col.jpg')
         print_image(cplant_back, fig_name_pseudo)
         analysis_img.append(['IMAGE', 'pseudo', fig_name_pseudo])
 
@@ -121,7 +121,7 @@ def analyze_nir_intensity(gray_img, mask, bins, histplot=False, filename=False):
         plt.ylabel('Proportion of pixels (%)')
 
         if filename:
-            fig_name_hist = (str(filename[0:-4]) + '_nir_hist.svg')
+            fig_name_hist = (os.path.splitext(filename)[0] + '_nir_hist.svg')
             plt.savefig(fig_name_hist)
             analysis_img.append(['IMAGE', 'hist', fig_name_hist])
         if params.debug == "print":

--- a/plantcv/plantcv/analyze_object.py
+++ b/plantcv/plantcv/analyze_object.py
@@ -226,8 +226,8 @@ def analyze_object(img, obj, mask, filename=False):
         cv2.line(ori_img, (tuple(caliper_transpose[caliper_length - 1])), (tuple(caliper_transpose[0])), (0, 0, 255), 5)
         cv2.circle(ori_img, (int(cmx), int(cmy)), 10, (0, 0, 255), 5)
         # Output images with convex hull, extent x and y
-        out_file = str(filename[0:-4]) + '_shapes.jpg'
-        out_file1 = str(filename[0:-4]) + '_mask.jpg'
+        out_file = os.path.splitext(filename)[0] + '_shapes.jpg'
+        out_file1 = os.path.splitext(filename)[0] + '_mask.jpg'
 
         print_image(ori_img, out_file)
         analysis_images.append(['IMAGE', 'shapes', out_file])

--- a/plantcv/plantcv/cluster_contour_splitimg.py
+++ b/plantcv/plantcv/cluster_contour_splitimg.py
@@ -53,7 +53,7 @@ def cluster_contour_splitimg(rgb_img, grouped_contour_indexes, contours, hierarc
     if file is None:
         filebase = timenow
     else:
-        filebase = file[:-4]
+        filebase = os.path.splitext(file)[0]
 
     if filenames is None:
         l = len(grouped_contour_indexes)

--- a/plantcv/plantcv/fluor_fvfm.py
+++ b/plantcv/plantcv/fluor_fvfm.py
@@ -111,8 +111,8 @@ def fluor_fvfm(fdark, fmin, fmax, mask, filename, bins=1000):
         from matplotlib import cm as cm
 
         # Print F-variable image
-        print_image(fv, (str(filename[0:-4]) + '_fv_img.png'))
-        print('\t'.join(map(str, ('IMAGE', 'fv', str(filename[0:-4]) + '_fv_img.png'))))
+        print_image(fv, (os.path.splitext(filename)[0] + '_fv_img.png'))
+        print('\t'.join(map(str, ('IMAGE', 'fv', os.path.splitext(filename)[0] + '_fv_img.png'))))
 
         # Create Histogram Plot, if you change the bin number you might need to change binx so that it prints
         # an appropriate number of labels
@@ -124,8 +124,8 @@ def fluor_fvfm(fdark, fmin, fmax, mask, filename, bins=1000):
         ax.set_ylabel('Plant Pixels')
         ax.text(0.05, 0.95, ('Peak Bin Value: ' + str(max_bin)), transform=ax.transAxes, verticalalignment='top')
         plt.grid()
-        plt.title('Fv/Fm of ' + str(filename[0:-4]))
-        fig_name = (str(filename[0:-4]) + '_fvfm_hist.svg')
+        plt.title('Fv/Fm of ' + os.path.splitext(filename)[0])
+        fig_name = (os.path.splitext(filename)[0] + '_fvfm_hist.svg')
         plt.savefig(fig_name)
         plt.clf()
         print('\t'.join(map(str, ('IMAGE', 'hist', fig_name))))
@@ -140,7 +140,7 @@ def fluor_fvfm(fdark, fmin, fmax, mask, filename, bins=1000):
         my_cmap = plt.get_cmap('binary_r')
         plt.imshow(background, cmap=my_cmap)
         plt.axis('off')
-        fig_name = (str(filename[0:-4]) + '_pseudo_fvfm.png')
+        fig_name = (os.path.splitext(filename)[0] + '_pseudo_fvfm.png')
         plt.savefig(fig_name, dpi=600, bbox_inches='tight')
         plt.clf()
         print('\t'.join(map(str, ('IMAGE', 'pseudo', fig_name))))

--- a/plantcv/plantcv/report_size_marker_area.py
+++ b/plantcv/plantcv/report_size_marker_area.py
@@ -115,7 +115,7 @@ def report_size_marker_area(img, roi_contour, roi_hierarchy, marker='define', ob
     analysis_images = []
     cv2.drawContours(ref_img, marker_contour, -1, (255, 0, 0), 5)
     if filename:
-        out_file = str(filename[0:-4]) + '_sizemarker.jpg'
+        out_file = os.path.splitext(filename)[0] + '_sizemarker.jpg'
         print_image(ref_img, out_file)
         analysis_images.append(['IMAGE', 'marker', out_file])
     if params.debug is 'print':

--- a/plantcv/plantcv/watershed.py
+++ b/plantcv/plantcv/watershed.py
@@ -64,7 +64,7 @@ def watershed_segmentation(rgb_img, mask, distance=10, filename=False):
 
     analysis_images = []
     if filename != False:
-        out_file = str(filename[0:-4]) + '_watershed.jpg'
+        out_file = os.path.splitext(filename)[0] + '_watershed.jpg'
         print_image(joined, out_file)
         analysis_images.append(['IMAGE', 'watershed', out_file])
 


### PR DESCRIPTION
changed method to remove file extensions from file names from string slicing to `os.path.splitext()` to accurately handle different length extensions

addresses:
https://github.com/danforthcenter/plantcv/issues/277
https://github.com/danforthcenter/plantcv/issues/279#issue-386409066



