### PR TITLE
Update the Fv/Fm function to allow 8- or 16-bit images

### DIFF
--- a/docs/fluor_fvfm.md
+++ b/docs/fluor_fvfm.md
@@ -2,7 +2,7 @@
 
 Extract Fv/Fm data of objects and produce pseudocolored images.
 
-**plantcv.fluor_fvfm**(*fdark, fmin, fmax, mask, filename, bins=1000*)
+**plantcv.fluor_fvfm**(*fdark, fmin, fmax, mask, filename, bins=256*)
 
 **returns** Fv/Fm histogram headers, Fv/Fm histogram data, PSII analysis images list
 

--- a/docs/fluor_fvfm.md
+++ b/docs/fluor_fvfm.md
@@ -1,10 +1,10 @@
-## Analyze FLU Signal
+## Analyze PSII Signal
 
 Extract Fv/Fm data of objects and produce pseudocolored images.
 
 **plantcv.fluor_fvfm**(*fdark, fmin, fmax, mask, filename, bins=1000*)
 
-**returns** FLU channel histogram headers, FLU channel histogram data
+**returns** Fv/Fm histogram headers, Fv/Fm histogram data, PSII analysis images list
 
 - **Parameters:**
     - fdark - image object, grayscale
@@ -47,7 +47,7 @@ from plantcv import plantcv as pcv
 pcv.params.debug = "print"
 
 # Analyze Fv/Fm    
- fvfm_header, fvfm_data = pcv.fluor_fvfm(fdark, fmin, fmax, kept_mask, filename, 1000)
+ fvfm_header, fvfm_data, fvfm_images = pcv.fluor_fvfm(fdark, fmin, fmax, kept_mask, filename, 1000)
 ```
 
 **Histogram of Fv/Fm values**

--- a/docs/psII_tutorial.md
+++ b/docs/psII_tutorial.md
@@ -224,7 +224,7 @@ along with the generated mask to calculate Fv/Fm.
     fmin = cv2.imread(args.fmin, -1)
     fmax = cv2.imread(args.fmax, -1)
     
-    fvfm_header, fvfm_data = pcv.fluor_fvfm(fdark,fmin,fmax,kept_mask, args.outdir+'/'+filename, 1000)
+    fvfm_header, fvfm_data, fvfm_images = pcv.fluor_fvfm(fdark,fmin,fmax,kept_mask, args.outdir+'/'+filename, 1000)
     
     # Write shape and nir data to results file
     result=open(args.result,"a")

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -246,7 +246,7 @@ pages for more details on the input and output variable types.
 #### plantcv.fluor_fvfm
 
 * pre v3.0dev2: device, hist_header, hist_data = **plantcv.fluor_fvfm**(*fdark, fmin, fmax, mask, device, filename, bins=1000, debug=None*)
-* post v3.0dev2: hist_header, hist_data, hist_images = **plantcv.fluor_fvfm**(*fdark, fmin, fmax, mask, filename, bins=1000*)
+* post v3.0dev2: hist_header, hist_data, hist_images = **plantcv.fluor_fvfm**(*fdark, fmin, fmax, mask, filename, bins=256*)
 
 #### plantcv.gaussian_blur
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -246,7 +246,7 @@ pages for more details on the input and output variable types.
 #### plantcv.fluor_fvfm
 
 * pre v3.0dev2: device, hist_header, hist_data = **plantcv.fluor_fvfm**(*fdark, fmin, fmax, mask, device, filename, bins=1000, debug=None*)
-* post v3.0dev2: hist_header, hist_data = **plantcv.fluor_fvfm**(*fdark, fmin, fmax, mask, filename, bins=1000*)
+* post v3.0dev2: hist_header, hist_data, hist_images = **plantcv.fluor_fvfm**(*fdark, fmin, fmax, mask, filename, bins=1000*)
 
 #### plantcv.gaussian_blur
 

--- a/plantcv/plantcv/fluor_fvfm.py
+++ b/plantcv/plantcv/fluor_fvfm.py
@@ -104,6 +104,8 @@ def fluor_fvfm(fdark, fmin, fmax, mask, filename, bins=1000):
         qc_fdark
     )
 
+    analysis_images = []
+
     if filename:
         import matplotlib
         matplotlib.use('Agg', warn=False)
@@ -112,7 +114,7 @@ def fluor_fvfm(fdark, fmin, fmax, mask, filename, bins=1000):
 
         # Print F-variable image
         print_image(fv, (os.path.splitext(filename)[0] + '_fv_img.png'))
-        print('\t'.join(map(str, ('IMAGE', 'fv', os.path.splitext(filename)[0] + '_fv_img.png'))))
+        analysis_images.append(['IMAGE', 'fv', os.path.splitext(filename)[0] + '_fv_img.png'])
 
         # Create Histogram Plot, if you change the bin number you might need to change binx so that it prints
         # an appropriate number of labels
@@ -128,26 +130,28 @@ def fluor_fvfm(fdark, fmin, fmax, mask, filename, bins=1000):
         fig_name = (os.path.splitext(filename)[0] + '_fvfm_hist.svg')
         plt.savefig(fig_name)
         plt.clf()
-        print('\t'.join(map(str, ('IMAGE', 'hist', fig_name))))
+        analysis_images.append(['IMAGE', 'fvfm_hist', fig_name])
 
         # Pseudocolored Fv/Fm image
-        fvfm_8bit = fvfm * 255
-        fvfm_8bit = fvfm_8bit.astype(np.uint8)
-        plt.imshow(fvfm_8bit, vmin=0, vmax=1, cmap=cm.jet_r)
-        plt.subplot(111)
-        mask_inv = cv2.bitwise_not(mask)
-        background = np.dstack((mask, mask, mask, mask_inv))
-        my_cmap = plt.get_cmap('binary_r')
-        plt.imshow(background, cmap=my_cmap)
+        plt.imshow(fvfm, vmin=0, vmax=1, cmap="viridis")
+        plt.colorbar()
+        # fvfm_8bit = fvfm * 255
+        # fvfm_8bit = fvfm_8bit.astype(np.uint8)
+        # plt.imshow(fvfm_8bit, vmin=0, vmax=1, cmap=cm.jet_r)
+        # plt.subplot(111)
+        # mask_inv = cv2.bitwise_not(mask)
+        # background = np.dstack((mask, mask, mask, mask_inv))
+        # my_cmap = plt.get_cmap('binary_r')
+        # plt.imshow(background, cmap=my_cmap)
         plt.axis('off')
         fig_name = (os.path.splitext(filename)[0] + '_pseudo_fvfm.png')
         plt.savefig(fig_name, dpi=600, bbox_inches='tight')
         plt.clf()
-        print('\t'.join(map(str, ('IMAGE', 'pseudo', fig_name))))
+        analysis_images.append(['IMAGE', 'fvfm_pseudo', fig_name])
 
         path = os.path.dirname(filename)
         fig_name = 'FvFm_pseudocolor_colorbar.svg'
-        if not os.path.isfile(path + '/' + fig_name):
+        if not os.path.isfile(os.path.join(path, fig_name)):
             plot_colorbar(path, fig_name, 2)
 
     if params.debug == 'print':
@@ -158,5 +162,6 @@ def fluor_fvfm(fdark, fmin, fmax, mask, filename, bins=1000):
         plot_image(fmin_mask, cmap='gray')
         plot_image(fmax_mask, cmap='gray')
         plot_image(fv, cmap='gray')
+        plot_image(fvfm, cmap="jet")
 
-    return hist_header, hist_data
+    return hist_header, hist_data, analysis_images

--- a/plantcv/plantcv/fluor_fvfm.py
+++ b/plantcv/plantcv/fluor_fvfm.py
@@ -41,8 +41,8 @@ def fluor_fvfm(fdark, fmin, fmax, mask, filename, bins=1000):
     if not all(len(np.shape(i)) == 2 for i in [fdark, fmin, fmax]):
         fatal_error("The fdark, fmin, and fmax images must be grayscale images.")
     # Check that fdark, fmin, and fmax are 16-bit images
-    if not all(i.dtype == "uint16" for i in [fdark, fmin, fmax]):
-        fatal_error("The fdark, fmin, and fmax images must be 16-bit images.")
+    # if not all(i.dtype == "uint16" for i in [fdark, fmin, fmax]):
+    #     fatal_error("The fdark, fmin, and fmax images must be 16-bit images.")
 
     # QC Fdark Image
     fdark_mask = cv2.bitwise_and(fdark, fdark, mask=mask)

--- a/plantcv/plantcv/fluor_fvfm.py
+++ b/plantcv/plantcv/fluor_fvfm.py
@@ -10,7 +10,7 @@ from plantcv.plantcv import fatal_error
 from plantcv.plantcv import params
 
 
-def fluor_fvfm(fdark, fmin, fmax, mask, filename, bins=1000):
+def fluor_fvfm(fdark, fmin, fmax, mask, filename, bins=256):
     """Analyze PSII camera images.
 
     Inputs:
@@ -19,7 +19,7 @@ def fluor_fvfm(fdark, fmin, fmax, mask, filename, bins=1000):
     fmax        = grayscale fmax image
     mask        = mask of plant (binary, single channel)
     filename    = name of file
-    bins        = number of bins (1 to 256 for 8-bit; 1 to 65,536 for 16-bit; default is 1000)
+    bins        = number of bins (1 to 256 for 8-bit; 1 to 65,536 for 16-bit; default is 256)
 
     Returns:
     hist_header = fvfm data table headers

--- a/plantcv/plantcv/fluor_fvfm.py
+++ b/plantcv/plantcv/fluor_fvfm.py
@@ -14,12 +14,12 @@ def fluor_fvfm(fdark, fmin, fmax, mask, filename, bins=1000):
     """Analyze PSII camera images.
 
     Inputs:
-    fdark       = 16-bit grayscale fdark image
-    fmin        = 16-bit grayscale fmin image
-    fmax        = 16-bit grayscale fmax image
-    mask        = mask of plant (binary,single channel)
+    fdark       = grayscale fdark image
+    fmin        = grayscale fmin image
+    fmax        = grayscale fmax image
+    mask        = mask of plant (binary, single channel)
     filename    = name of file
-    bins        = number of bins from 0 to 65,536 (default is 1000)
+    bins        = number of bins (1 to 256 for 8-bit; 1 to 65,536 for 16-bit; default is 1000)
 
     Returns:
     hist_header = fvfm data table headers
@@ -40,6 +40,10 @@ def fluor_fvfm(fdark, fmin, fmax, mask, filename, bins=1000):
     # Check that fdark, fmin, and fmax are grayscale (single channel)
     if not all(len(np.shape(i)) == 2 for i in [fdark, fmin, fmax]):
         fatal_error("The fdark, fmin, and fmax images must be grayscale images.")
+    # # Check that fdark, fmin, and fmax are the same bit
+    # if  not (all(i.dtype == "uint16" for i in [fdark, fmin, fmax]) or
+    #         (all(i.dtype == "uint8" for i in [fdark, fmin, fmax]))):
+    #     fatal_error("The fdark, fmin, and fmax images must all be the same bit depth.")
     # Check that fdark, fmin, and fmax are 16-bit images
     # if not all(i.dtype == "uint16" for i in [fdark, fmin, fmax]):
     #     fatal_error("The fdark, fmin, and fmax images must be 16-bit images.")

--- a/plantcv/plantcv/plot_colorbar.py
+++ b/plantcv/plantcv/plot_colorbar.py
@@ -1,5 +1,6 @@
 # Plot colorbar for pseudocolored images
 
+import os
 
 def plot_colorbar(outdir, filename, bins):
     """Plot colorbar for pseudocolored images
@@ -20,12 +21,12 @@ def plot_colorbar(outdir, filename, bins):
     from matplotlib import colors as colors
     from matplotlib import colorbar as colorbar
 
-    fig_name = outdir + '/' + filename
+    fig_name = os.path.join(outdir, filename)
     fig = plt.figure()
     ax1 = fig.add_axes([0.05, 0.80, 0.9, 0.15])
     valmin = -0
     valmax = (bins - 1)
     norm = colors.Normalize(vmin=valmin, vmax=valmax)
-    colorbar.ColorbarBase(ax1, cmap="jet", norm=norm, orientation='horizontal')
+    colorbar.ColorbarBase(ax1, cmap="viridis", norm=norm, orientation='horizontal')
     fig.savefig(fig_name, bbox_inches='tight')
     fig.clf()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -855,7 +855,8 @@ def test_plantcv_fluor_fvfm():
     _ = pcv.fluor_fvfm(fdark=fdark, fmin=fmin, fmax=fmax, mask=fmask, filename=False, bins=1000)
     # Test with debug = None
     pcv.params.debug = None
-    fvfm_header, fvfm_data = pcv.fluor_fvfm(fdark=fdark, fmin=fmin, fmax=fmax, mask=fmask, filename=False, bins=1000)
+    fvfm_header, fvfm_data, fvfm_images = pcv.fluor_fvfm(fdark=fdark, fmin=fmin, fmax=fmax, mask=fmask, filename=False,
+                                                         bins=1000)
     assert fvfm_data[4] > 0.66
 
 


### PR DESCRIPTION
<!--- 
Thanks for contributing! Instructions are in comments, like this.
 
Please edit this template before submitting a new pull request.
-->

<!--- 
Title: Please provide a descriptive title that summarizes your pull request. 
-->

<!---
Labels: Please select one or more relevant tags (menu on the right).
(This only shows up for administrators.)
--->

### Description
<!--- 
Describe your changes, for example:
* What did you change/add and why?
* Does it close an open issue? (if so, please link to the issue)
* Have you tested the changes, and if so, how?
-->
The PSII camera in the LemnaTec system at the Danforth Center outputs 16-bit images so the Fv/Fm analysis function checked that the input images were 16-bit. However, the functionality of the module does not rely on the images being 16-bit, so I removed this check so that 8-bit images could be used. I also updated the pseudocolored image plotting code and documentation.

See issue #285 

### Types of changes
<!---
Is this a: 
* Bug fix?
* New feature?
* Does it change existing functionality?
-->
Updates existing function to use 8-bit images in addition to 16-bit images.

### Checklist:

- [x] Relevant tests (and test data) have been added or updated and passed.
- [x] The documentation was added or updated.
- [x] Relevant issues were updated or added.
