### PR TITLE
Create color card mask ROI update

### DIFF
--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -8,7 +8,7 @@ from plantcv.plantcv import print_image
 from plantcv.plantcv import plot_image
 from plantcv.plantcv import fatal_error
 from plantcv.plantcv import params
-from plantcv.plantcv.roi import rectangle
+from plantcv.plantcv.roi import circle
 
 
 def get_color_matrix(rgb_img, mask):

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -345,11 +345,11 @@ def correct_color(target_img, target_mask, source_img, source_mask, output_direc
     return target_matrix, source_matrix, transformation_matrix, corrected_img
 
 
-def create_color_card_mask(rgb_img, chip_dims, start_coord, spacing, nrows, ncols, exclude=[]):
+def create_color_card_mask(rgb_img, radius, start_coord, spacing, nrows, ncols, exclude=[]):
     """Create a labeled mask for color card chips
     Inputs:
     rgb_img        = Input RGB image data containing a color card.
-    chip_dims      = Two-element tuple of the chip masks width and height.
+    radius         = Radius of color masks.
     start_coord    = Two-element tuple of the first chip mask starting x and y coordinate.
     spacing        = Two-element tuple of the horizontal and vertical spacing between chip masks.
     nrows          = Number of chip rows.
@@ -360,7 +360,7 @@ def create_color_card_mask(rgb_img, chip_dims, start_coord, spacing, nrows, ncol
     mask           = Labeled mask of chips
 
     :param rgb_img: numpy.ndarray
-    :param chip_dims: tuple
+    :param radius: int
     :param start_coord: tuple
     :param spacing: tuple
     :param nrows: int
@@ -384,7 +384,7 @@ def create_color_card_mask(rgb_img, chip_dims, start_coord, spacing, nrows, ncol
             # horizontal spacing between chips
             x = start_coord[0] + j * spacing[0]
             # Create a chip ROI
-            chips.append(rectangle(img=rgb_img, x=x, y=y, w=chip_dims[0], h=chip_dims[1]))
+            chips.append(circle(img=rgb_img, x=x, y=y, r=radius))
     # Remove any excluded chips
     for chip in exclude:
         del chips[chip]

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2513,15 +2513,15 @@ def test_plantcv_transform_create_color_card_mask():
     pcv.params.debug_outdir = cache_dir
     # Test with debug = "print"
     pcv.params.debug = "print"
-    _ = pcv.transform.create_color_card_mask(rgb_img=rgb_img, chip_dims=(10, 10), start_coord=(166, 166),
+    _ = pcv.transform.create_color_card_mask(rgb_img=rgb_img, radius=6, start_coord=(166, 166),
                                              spacing=(21, 21), nrows=6, ncols=4, exclude=[20, 0])
     # Test with debug = "plot"
     pcv.params.debug = "plot"
-    _ = pcv.transform.create_color_card_mask(rgb_img=rgb_img, chip_dims=(10, 10), start_coord=(166, 166),
+    _ = pcv.transform.create_color_card_mask(rgb_img=rgb_img, radius=6, start_coord=(166, 166),
                                              spacing=(21, 21), nrows=6, ncols=4, exclude=[20, 0])
     # Test with debug = None
     pcv.params.debug = None
-    mask = pcv.transform.create_color_card_mask(rgb_img=rgb_img, chip_dims=(10, 10), start_coord=(166, 166),
+    mask = pcv.transform.create_color_card_mask(rgb_img=rgb_img, radius=6, start_coord=(166, 166),
                                                 spacing=(21, 21), nrows=6, ncols=4, exclude=[20, 0])
     assert all([i == j] for i, j in zip(np.unique(mask), np.array([0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110,
                                                                    120, 130, 140, 150, 160, 170, 180, 190, 200, 210,


### PR DESCRIPTION

<!--- 
Title: Updated create_color_card_mask to use circle ROI's
-->

<!---
Labels: enhancement
--->

### Description
<!--- 

* The create color card mask function will now create circle ROI's rather than rectangles for easier fitting within square color card chips, and users will only need to input a radius rather than a tuple of (x, y) dimensions for the ROI.
-->



### Checklist:

- [x] Relevant tests (and test data) have been added or updated and passed.
- [x] The documentation was added or updated.
- [x] Relevant issues were updated or added.
