### PR TITLE
Remove Agg backend in plot

### DIFF
--- a/plantcv/plantcv/plot_image.py
+++ b/plantcv/plantcv/plot_image.py
@@ -11,8 +11,6 @@ def plot_image(img, cmap=None):
     :param cmap: str
     :return:
     """
-    import matplotlib
-    matplotlib.use('Agg', warn=False)
     from matplotlib import pyplot as plt
 
     dimensions = np.shape(img)


### PR DESCRIPTION
Looks like applying the Agg backend in the plot_image function disables displaying images in Jupyter because the Agg backed is a non-GUI backend.

<!--- 
Thanks for contributing! Instructions are in comments, like this.
 
Please edit this template before submitting a new pull request.
-->

<!--- 
Title: Please provide a descriptive title that summarizes your pull request. 
-->

<!---
Labels: Please select one or more relevant tags (menu on the right).
(This only shows up for administrators.)
--->

### Description
<!--- 
Describe your changes, for example:
* What did you change/add and why?
* Does it close an open issue? (if so, please link to the issue)
* Have you tested the changes, and if so, how?
-->

Removed the matplotlib Agg backed in the `pcv.plot_image` function. Using Agg disables image display in Jupyter because it's a non-GUI backend.

### Types of changes
<!---
Is this a: 
* Bug fix?
* New feature?
* Does it change existing functionality?
-->
Bug fix.

### Checklist:

- [ ] Relevant tests (and test data) have been added or updated and passed.
- [x] The documentation was added or updated.
- [x] Relevant issues were updated or added.
