### PR TITLE
 standardize argument order/names

### DIFF
--- a/docs/acute_vertex.md
+++ b/docs/acute_vertex.md
@@ -3,16 +3,17 @@
 Perform a heuristic search for sharp angles given an object contour and user specified parameters. The acute (sharp)
 angles are often associated with object tip points. Outputs a python list of points that meet criteria specified in parameters.
 
-**plantcv.acute_vertex**(*obj, window, thresh, sep, img*)
+**plantcv.acute_vertex**(*img, obj, window, thresh, sep*)
 
 **returns** list of points that meet specified criteria 
 
 - **Parameters:**
+    - img - A copy of the original image
     - obj - A contour of the plant object (this should be output from the object_composition.py fxn)
     - window - The pre and post point distances on which to calculate angle of focal point (a value of 30 worked well for a sample image) on which to calculate the angle
     - thresh - Threshold to set for acuteness; keep points with an angle more acute than the threshold (a value of 15 worked well for sample image)
     - sep - The number of contour points to search within for the most acute value
-    - img - A copy of the original image
+
 - **Context:**
     - Used to identify tip points based upon the angle between focal pixel and reference points on contour. 
     
@@ -29,7 +30,7 @@ pcv.params.debug = "print"
 
 # Identify acute vertices (tip points) of an object
 # Results in set of point values that may indicate tip points
-list_of_acute_points = pcv.acute_vertex(obj, 30, 15, 100, img)
+list_of_acute_points = pcv.acute_vertex(img, obj, 30, 15, 100)
 ```
 
 **Image of points selected**

--- a/docs/auto_crop.md
+++ b/docs/auto_crop.md
@@ -2,13 +2,13 @@
 
 Crops image to an object and allows user to specify image padding (if desired)
 
-**plantcv.auto_crop**(*img, objects, padding_x=0, padding_y=0, color='black'*)
+**plantcv.auto_crop**(*img, obj, padding_x=0, padding_y=0, color='black'*)
 
 **returns** image after resizing
 
 - **Parameters:**
     - img - RGB or grayscale image data
-    - object - contour of target object 
+    - obj - contour of target object 
     - padding_x - padding in the x direction (default padding_x=0)
     - padding_y - padding in the y direction (default padding_x=0)
     - color - either 'black' (default), 'white', or 'image'

--- a/docs/canny_edge_detect.md
+++ b/docs/canny_edge_detect.md
@@ -3,19 +3,19 @@
 Creates a binary image from an RGB or grayscale image using a Canny filter from [skimage](http://scikit-image.org/docs/dev/index.html).
 
 
-**plantcv.canny_edge_detect(*img, sigma=1.0, low_thresh=None, high_thresh=None, thickness=1, mask=None, mask_color=None, use_quantiles=False*)**
+**plantcv.canny_edge_detect(*img, mask=None, sigma=1.0, low_thresh=None, high_thresh=None, thickness=1, mask_color=None, use_quantiles=False*)**
 
 **returns** binary image
 
 - **Parameters:**
     - img - RGB or grayscale image data
+    - mask - Optional mask to limit the application of Canny to a certain area, takes a binary img.
     - sigma - Optional standard deviation of the Gaussian filter
     - low_thresh - Optional lower bound for hysteresis thresholding (linking edges). If None (default) then low_thresh is set to
                    10% of the image's max
     - high_thresh - Optional upper bound for hysteresis thresholding (linking edges). If None (default) then high_thresh is set
                     to 20% of the image's max
     - thickness - Optional integer thickness of the edges, default thickness=1
-    - mask - Optional mask to limit the application of Canny to a certain area, takes a binary img.
     - mask_color - Color of the mask provided; either None (default), 'white', or 'black' (cannot be None if mask is provided)
     - use_quantiles - Default is False, if True then treat low_thresh and high_thresh as quantiles of the edge magnitude
                     image, rather than the absolute edge magnitude values. If True then thresholds must be within the range `[0, 1]`.
@@ -32,10 +32,6 @@ Creates a binary image from an RGB or grayscale image using a Canny filter from 
 ```python
 
 from plantcv import plantcv as pcv
-from skimage.feature import greycomatrix, greycoprops
-from scipy.ndimage import generic_filter
-import numpy as np
-import cv2
 
 # Set global debug behavior to None (default), "print" (to file), or "plot" (Jupyter Notebooks or X11)
 

--- a/docs/dilate.md
+++ b/docs/dilate.md
@@ -3,13 +3,13 @@
 Perform morphological 'dilation' filtering. Adds pixel in center of the kernel if 
 conditions set in kernel are true.
 
-**plantcv.dilate**(*gray_img, kernel, i*)
+**plantcv.dilate**(*gray_img, ksize, i*)
 
 **returns** image after dilation
 
 - **Parameters:**
     - gray_img - Grayscale (usually binary) image data.
-    - kernel - An odd integer that is used to build a kernel x kernel matrix using np.ones. Must be greater than 1 to have an effect.
+    - ksize - An odd integer that is used to build a ksize x ksize matrix using np.ones. Must be greater than 1 to have an effect.
     - i - An integer for number of iterations, i.e. the number of consecutive filtering passes.
 - **Context:**
     - Used to perform morphological dilation filtering. Helps expand objects at the edges, particularly after erosion.
@@ -29,7 +29,7 @@ pcv.params.debug = "print"
 
 # Perform dilation
 # Results in addition of pixels to the boundary of object
-dilate_img = pcv.dilate(gray_img=gray_img, kernel=9, i=1)
+dilate_img = pcv.dilate(gray_img=gray_img, ksize=9, i=1)
 ```
 
 **Image after dilation**

--- a/docs/erode.md
+++ b/docs/erode.md
@@ -3,13 +3,13 @@
 Perform morphological 'erosion' filtering. Keeps pixel in center of the kernel if 
 conditions set in kernel are true, otherwise removes pixel.
 
-**plantcv.erode**(*gray_img, kernel, i*)
+**plantcv.erode**(*gray_img, ksize, i*)
 
 **returns** image after erosion
 
 - **Parameters:**
     - gray_img - Grayscale (usually binary) image data
-    - kernel - An odd integer that is used to build a kernel x kernel matrix using np.ones. Must be greater than 1 to have an effect
+    - ksize - Kernel size, an odd integer that is used to build a ksize x ksize matrix using np.ones. Must be greater than 1 to have an effect
     - i - An integer for number of iterations, i.e. the number of consecutive filtering passes
    
 - **Context:**
@@ -30,7 +30,7 @@ pcv.params.debug = "print"
 
 # Perform erosion filtering
 # Results in removal of isolated pixels or boundary of object removal
-er_img = pcv.erode(gray_img, kernel, 1)
+er_img = pcv.erode(gray_img, ksize, 1)
 ```
 
 **Image after erosion**

--- a/docs/gaussian_blur.md
+++ b/docs/gaussian_blur.md
@@ -10,8 +10,8 @@ The function is a wrapper for the OpenCV function [gaussian blur](http://docs.op
 - **Parameters:**
     - img - RGB or grayscale image data
     - ksize - Tuple of kernel dimensions, e.g. (5, 5)
-    - sigmax - standard deviation in X direction; if 0 (default), calculated from kernel size
-    - sigmay - standard deviation in Y direction; if sigmaY is None (default), sigmaY is taken to equal sigmaX
+    - sigma_x - standard deviation in X direction; if 0 (default), calculated from kernel size
+    - sigma_y - standard deviation in Y direction; if sigma_Y is None (default), sigma_Y is taken to equal sigma_X
 - **Context:**
     - Used to reduce image noise
 
@@ -27,7 +27,7 @@ from plantcv import plantcv as pcv
 pcv.params.debug = "print"
 
 # Apply gaussian blur to a binary image that has been previously thresholded.
-gaussian_img = pcv.gaussian_blur(img=img1, ksize=(51, 51), sigmax=0, sigmay=None)
+gaussian_img = pcv.gaussian_blur(img=img1, ksize=(51, 51), sigma_x=0, sigma_y=None)
 ```
 
 **Gaussian blur (ksize = (51,51))**
@@ -41,7 +41,7 @@ from plantcv import plantcv as pcv
 pcv.params.debug = "print"
 
 # Apply gaussian blur to a binary image that has been previously thresholded.
-gaussian_img = pcv.gaussian_blur(img=img1, ksize=(101, 101), sigmax=0, sigmay=None)
+gaussian_img = pcv.gaussian_blur(img=img1, ksize=(101, 101), sigma_x=0, sigma_y=None)
 ```
 
 **Gaussian blur (ksize = (101,101))**

--- a/docs/laplace_filter.md
+++ b/docs/laplace_filter.md
@@ -2,13 +2,13 @@
 
 This is a filtering method used to identify and highlight fine edges based on the 2nd derivative.
 
-**plantcv.laplace_filter**(*gray_img, k, scale*)
+**plantcv.laplace_filter**(*gray_img, ksize, scale*)
 
 **returns** filtered image
 
 - **Parameters:**
     - gray_img - Grayscale image data
-    - k - apertures size used to calculate 2nd derivative filter, specifies the size of the kernel (must be an odd integer: 1,3,5...)
+    - ksize - apertures size used to calculate 2nd derivative filter, specifies the size of the kernel (must be an odd integer: 1,3,5...)
     - scale - scaling factor applied (multiplied) to computed Laplacian values (scale = 1 is unscaled) 
     
 - **Context:**

--- a/docs/median_blur.md
+++ b/docs/median_blur.md
@@ -1,6 +1,6 @@
 ## Median Blur
 
-Applies a median blur filter. Applies median value to central pixel within a kernel size (ksize x ksize). 
+Applies a median blur filter. Applies median value to central pixel within a kernel size. 
 The function is a wrapper for the SciPy function [median filter](https://docs.scipy.org/doc/scipy-0.16.1/reference/generated/scipy.ndimage.filters.median_filter.html).
 
 **plantcv.median_blur**(*gray_img, ksize*)**
@@ -9,7 +9,7 @@ The function is a wrapper for the SciPy function [median filter](https://docs.sc
 
 - **Parameters:**
     - gray_img - Grayscale image data
-    - ksize - kernel size => integer or tuple, ksize x ksize box if integer, (n, m) size box if tuple 
+    - ksize - kernel size => integer or tuple, `ksize` x `ksize` box if integer, (n, m) size box if tuple 
 - **Context:**
     - Used to reduce image noise
 - **Example use:**
@@ -31,7 +31,7 @@ pcv.params.debug = "print"
 blur_5 = pcv.median_blur(gray_img, 5)
 ```
 
-**Median blur (k = 5)**
+**Median blur (ksize = 5)**
 
 ![Screenshot](img/documentation_images/median_blur/median_blur5.jpg)
 
@@ -45,6 +45,6 @@ pcv.params.debug = "print"
 blur_11 = pcv.median_blur(gray_img, (11, 11))
 ```
 
-**Median blur (k = (11,11))**
+**Median blur (ksize = (11,11))**
 
 ![Screenshot](img/documentation_images/median_blur/median_blur11.jpg)

--- a/docs/pseudocolor.md
+++ b/docs/pseudocolor.md
@@ -4,18 +4,18 @@ This function pseudocolors any grayscale image to custom colormap. An optional m
 pseudocolored image. Additionally, optional maximum and minimum values can be specified. When `pcv.params.debug='print'` 
 then the image gets saved to `pcv.params.debug_outdir`. 
 
-**plantcv.pseudocolor**(*gray_img, mask=None, background="image", cmap=None, min_value=0, max_value=255, obj=None, dpi=None, axes=True, colorbar=True*)
+**plantcv.pseudocolor**(*gray_img, obj=None, mask=None, background="image", cmap=None, min_value=0, max_value=255, dpi=None, axes=True, colorbar=True*)
 
 **returns** pseudocolored image that can be saved with `pcv.print_image`
 
 - **Parameters:**
     - gray_img   - Grayscale image data
+    - obj        - Single or grouped contour object (optional), if provided the pseudocolored image gets cropped down to the region of interest.
     - mask       - Binary mask made from selected contours
     - background - Background color/type. Options are "image" (gray_img), "white", or "black". A mask must be supplied.
     - cmap       - Custom colormap, see [here](https://matplotlib.org/tutorials/colors/colormaps.html) for tips on how to choose a colormap in Matplotlib.
     - min_value  - Minimum value (optional) for range of the colorbar.
     - max_value  - Maximum value (optional) for range of the colorbar.
-    - obj        - Single or grouped contour object (optional), if provided the pseudocolored image gets cropped down to the region of interest.
     - dpi        - Dots per inch for image if printed out (optional, if dpi=None then the default is set to 100 dpi).
     - axes       - If False then the title, x-axis, and y-axis won't be displayed (default axes=True).
     - colorbar   - If False then the colorbar won't be displayed (default colorbar=True)
@@ -40,25 +40,25 @@ from plantcv import plantcv as pcv
 pcv.params.debug='plot'
 
 # Pseudocolor an image with 'viridis' colormad
-pseudo_img = pcv.pseudocolor(gray_img=img, mask=None, cmap='viridis', min_value=0, max_value=255)
+pseudo_img = pcv.pseudocolor(gray_img=img, obj=None, mask=None, cmap='viridis', min_value=0, max_value=255)
 
 # Pseudocolor the same image but include the mask and limit the range of values
-pseudo_img_masked = pcv.pseudocolor(gray_img=img, mask=mask, background="white", cmap='viridis', min_value=30, max_value=200)
+pseudo_img_masked = pcv.pseudocolor(gray_img=img, obj=None, mask=mask, background="white", cmap='viridis', min_value=30, max_value=200)
 
 # Save the masked and pseudocolored image
 pcv.print_image(pseudo_img_masked, 'nir_tv_z300_L1_pseudocolored.png')
 
 # Pseudocolor the masked area and plot on the grayscale background
-pseudo_img_on_input = pcv.pseudocolor(gray_img=img, mask=mask, background="image", cmap="viridis")
+pseudo_img_on_input = pcv.pseudocolor(gray_img=img, obj=None, mask=mask, background="image", cmap="viridis")
 
 # Print out a pseudocolored image with cropping enabled, axes disabled, and higher dpi value.
 pcv.params.debug='print'
-pseudo_crop_no_axes = pcv.pseudocolor(gray_img=img, mask=mask, background=="white", obj=obj, cmap='viridis', dpi=200, axes=False)
+pseudo_crop_no_axes = pcv.pseudocolor(gray_img=img, obj=obj, mask=mask, background=="white", cmap='viridis', dpi=200, axes=False)
 
 # Use a black background instead
-pseudo_img_black_bkgd = pcv.pseudocolor(gray_img=img, mask=mask, background="black", cmap='viridis')
+pseudo_img_black_bkgd = pcv.pseudocolor(gray_img=img, obj=None, mask=mask, background="black", cmap='viridis')
 
-simple_pseudo_img = pcv.pseudocolor(gray_img=img, mask=mask, background="image", axes=False, colorbar=False, cmap='viridis')
+simple_pseudo_img = pcv.pseudocolor(gray_img=img, obj=None, mask=mask, background="image", axes=False, colorbar=False, cmap='viridis')
 
 ```
 

--- a/docs/scale_features.md
+++ b/docs/scale_features.md
@@ -3,7 +3,7 @@
 This is a function to to transform the coordiantes of landmark points onto a common scale (0-1.0)
 Scaling is used to remove the influence of size on shape parameters. Returns a list of tuples.
 
-**plantcv.scale_features**(*obj, mask, points, boundary_line*)
+**plantcv.scale_features**(*obj, mask, points, line_position*)
 
 **returns** rescaled landmark points, a rescaled centroid point, a rescaled baseline point
 
@@ -11,7 +11,7 @@ Scaling is used to remove the influence of size on shape parameters. Returns a l
     - obj - A contour of the plant object (this should be output from the object_composition.py fxn)
     - mask - This is a binary image. The object should be white and the background should be black
     - points - A set of landmark points to be rescaled given the centroid of the object
-    - boundary_line - A vertical coordinate (int) that denotes the height of the plant pot, the coordinates of this reference point is also rescaled
+    - line_position - A vertical coordinate (int) that denotes the height of the plant pot, the coordinates of this reference point is also rescaled
 - **Context:**
     - Used to rescale the point coordinates of landmark points, including centroid and boundary line
     

--- a/docs/sobel_filter.md
+++ b/docs/sobel_filter.md
@@ -3,7 +3,7 @@
 This is a filtering method used to identify and highlight coarse changes in pixel intensity based on the 1st derivative.
 Similar results to the [Scharr filter](scharr_filter.md) function.
 
-**plantcv.sobel_filter**(*gray_img, dx, dy, k*)
+**plantcv.sobel_filter**(*gray_img, dx, dy, ksize*)
 
 **returns** filtered image
 
@@ -11,10 +11,10 @@ Similar results to the [Scharr filter](scharr_filter.md) function.
     - gray_img - Grayscale image data
     - dx - derivative of x to analyze
     - dy - derivative of y to analyze
-    - k - apertures size used to calculate 2nd derivative filter, specifies the size of the kernel (must be an odd integer)
+    - ksize - apertures size used to calculate 2nd derivative filter, specifies the size of the kernel (must be an odd integer)
 - **Context:**
     - Used to define edges within and around objects
-    - Aperture size must be greater than the largest derivative (`k >= dx & k >= dy`) in order to run
+    - Aperture size must be greater than the largest derivative (`ksize >= dx & ksize >= dy`) in order to run
 - **Example use:**
     - [Use In NIR Tutorial](nir_tutorial.md)
 

--- a/docs/texture_threshold.md
+++ b/docs/texture_threshold.md
@@ -4,13 +4,13 @@ Creates a binary image from a grayscale image using [skimage](http://scikit-imag
 texture calculation for thresholding.
 
 
-**plantcv.threshold.texture(*gray_img, kernel, threshold, offset=3, texture_method='dissimilarity', borders='nearest', max_value=255*)**
+**plantcv.threshold.texture(*gray_img, ksize, threshold, offset=3, texture_method='dissimilarity', borders='nearest', max_value=255*)**
 
 **returns** thresholded/binary image
 
 - **Parameters:**
     - gray_img - Grayscale image data
-    - kernel - Kernel size for texture measure calculation
+    - ksize - Kernel size for texture measure calculation
     - threshold - Threshold value (0-255)
     - offset - Distance offsets (default offset=3)
     - texture_method - Feature of a grey level co-occurrence matrix, either
@@ -33,17 +33,13 @@ texture calculation for thresholding.
 ```python
 
 from plantcv import plantcv as pcv
-from skimage.feature import greycomatrix, greycoprops
-from scipy.ndimage import generic_filter
-import numpy as np
-import cv2
 
 # Set global debug behavior to None (default), "print" (to file), or "plot" (Jupyter Notebooks or X11)
 
 pcv.params.debug = "print"
 
 # Create binary image from a gray image based on texture values.
-texture_img = pcv.threshold.texture(gray_img, kernel=6, threshold=7, offset=3, texture_method='dissimilarity', borders='nearest', max_value=255)
+texture_img = pcv.threshold.texture(gray_img, ksize=6, threshold=7, offset=3, texture_method='dissimilarity', borders='nearest', max_value=255)
 ```
 
 **Thresholded image**

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -125,11 +125,13 @@ pages for more details on the input and output variable types.
 
 * pre v3.0dev2: device, homolog_pts, start_pts, stop_pts, ptvals, chain, max_dist = **plantcv.acute**(*obj, win, thresh, mask, device, debug=None*)
 * post v3.0dev2: homolog_pts, start_pts, stop_pts, ptvals, chain, max_dist = **plantcv.acute**(*obj, win, thresh, mask*)
+* post v3.2: homolog_pts, start_pts, stop_pts, ptvals, chain, max_dist = **plantcv.acute**(*obj, mask, win, thresh*)
 
 #### plantcv.acute_vertex
 
 * pre v3.0dev2: device, acute = **plantcv.acute_vertex**(*obj, win, thresh, sep, img, device, debug=None*)
 * post v3.0dev2: acute = **plantcv.acute_vertex**(*obj, win, thresh, sep, img*)
+* post v3.2: acute = **plantcv.acute_vertex**(*img, obj, win, thresh, sep*)
 
 #### plantcv.adaptive_threshold
 
@@ -184,6 +186,7 @@ pages for more details on the input and output variable types.
 
 * pre v3.0dev2: device, cropped = **plantcv.auto_crop**(*device, img, objects, padding_x=0, padding_y=0, color='black', debug=None*)
 * post v3.0dev2: cropped = **plantcv.auto_crop**(*img, objects, padding_x=0, padding_y=0, color='black'*)
+* post v3.2: cropped = **plantcv.auto_crop**(*img, obj, padding_x=0, padding_y=0, color='black*) 
 
 #### plantcv.background_subtraction
 
@@ -195,6 +198,11 @@ pages for more details on the input and output variable types.
 * pre v3.0dev2: device, bin_img = **plantcv.binary_threshold**(*img, threshold, maxValue, object_type, device, debug=None*)
 * post v3.0dev2: Deprecated, see:
     * bin_img = **plantcv.threshold.binary**(*gray_img, threshold, max_value, object_type="light"*)
+    
+#### plantcv.canny_edge_detect
+
+** pre v3.2: NA
+** post v3.2: bin_img = **plantcv.canny_edge_detect**(*img, mask = None, sigma=1.0, low_thresh=None, high_thresh=None, thickness=1, mask_color=None, use_quantiles=False*)
 
 #### plantcv.cluster_contour_splitimg
 
@@ -220,15 +228,16 @@ pages for more details on the input and output variable types.
 
 * pre v3.0dev2: device, contour, hierarchy = **plantcv.define_roi**(*img, shape, device, roi=None, roi_input='default', debug=None, adjust=False, x_adj=0, y_adj=0, w_adj=0, h_adj=0*)
 * post v3.0dev2: Deprecated, see:
-    * roi_contour, roi_hierarchy = **plantcv.roi.circle**(*x, y, r, img*)
-    * roi_contour, roi_hierarchy = **plantcv.roi.ellipse**(*x, y, r1, r2, angle, img*)
-    * roi_contour, roi_hierarchy = **plantcv.roi.from_binary_image**(*bin_img, img*)
-    * roi_contour, roi_hierarchy = **plantcv.roi.rectangle**(*x, y, h, w, img*)
+    * roi_contour, roi_hierarchy = **plantcv.roi.circle**(*img, x, y, r*)
+    * roi_contour, roi_hierarchy = **plantcv.roi.ellipse**(*img, x, y, r1, r2, angle*)
+    * roi_contour, roi_hierarchy = **plantcv.roi.from_binary_image**(*img, bin_img*)
+    * roi_contour, roi_hierarchy = **plantcv.roi.rectangle**(*img, x, y, h, w*)
 
 #### plantcv.dilate
 
 * pre v3.0dev2: device, dil_img = **plantcv.dilate**(*img, kernel, i, device, debug=None*)
 * post v3.0dev2: dil_img = **plantcv.dilate**(*gray_img, kernel, i*)
+* post v3.2: dil_img = **plantcv.dilate**(*gray_img, ksize, i*)
 
 #### plantcv.distance_transform
 
@@ -239,6 +248,7 @@ pages for more details on the input and output variable types.
 
 * pre v3.0dev2: device, er_img = **plantcv.erode**(*img, kernel, i, device, debug=None*)
 * post v3.0dev2: er_img = **plantcv.erode**(*gray_img, kernel, i*)
+* post v3.2: er_img = **plantcv.erode**(*gray_img, ksize, i*)
 
 #### plantcv.fill
 
@@ -265,6 +275,7 @@ pages for more details on the input and output variable types.
 
 * pre v3.0dev2: device, img_gblur = **plantcv.gaussian_blur**(*device, img, ksize, sigmax=0, sigmay=None, debug=None*)
 * post v3.0dev2: img_gblur = **plantcv.gaussian_blur**(*img, ksize, sigmax=0, sigmay=None*)
+* post v3.2: img_gblur = **plantcv.gaussian_blur**(*img, ksize, sigma_x=0, sigma_y=None*)
 
 #### plantcv.get_nir
 
@@ -301,6 +312,7 @@ post v3.0: new_img = **plantcv.image_subtract**(*gray_img1, gray_img2*)
 
 * pre v3.0dev2: device, lp_filtered = **plantcv.laplace_filter**(*img, k, scale, device, debug=None*)
 * post v3.0dev2: lp_filtered = **plantcv.laplace_filter**(*gray_img, k, scale*)
+* post v3.2: lp_filtered = **plantcv.laplace_filter**(*gray_img, ksize, scale*)
 
 #### plantcv.logical_and
 
@@ -321,7 +333,7 @@ post v3.0: new_img = **plantcv.image_subtract**(*gray_img1, gray_img2*)
 
 * pre v3.0dev2: device, img_mblur = **plantcv.median_blur**(*img, ksize, device, debug=None*)
 * post v3.0dev2: img_mblur = **plantcv.median_blur**(*gray_img, ksize*)
-* post v3.0: img_blur = **plantcv.median_blur**(*gray_img, ksize*) OR img_blur = **plantcv.median_blur**(*gray_img, (ksize1, ksize2)*)
+* post v3.2: img_blur = **plantcv.median_blur**(*gray_img, ksize*) OR img_blur = **plantcv.median_blur**(*gray_img, (ksize1, ksize2)*)
 
 #### plantcv.naive_bayes_classifier
 
@@ -367,8 +379,7 @@ post v3.0: new_img = **plantcv.image_subtract**(*gray_img1, gray_img2*)
 #### plantcv.pseudocolor
 
 * pre v3.1: NA
-* post v3.1: pseudo_img = **plantcv.pseudocolor**(*gray_img, mask=None, cmap=None, background="image", min_value=0, max_value=255, obj=None, dpi=None,
-                axes=True, colorbar=True, path="."*)
+* post v3.1: pseudo_img = **plantcv.pseudocolor**(*gray_img, obj=None, mask=None, cmap=None, background="image", min_value=0, max_value=255, dpi=None, axes=True, colorbar=True*)
 
 #### plantcv.readbayer
 
@@ -414,22 +425,22 @@ post v3.0: new_img = **plantcv.image_subtract**(*gray_img1, gray_img2*)
 #### plantcv.roi.circle
 
 * pre v3.0dev1: NA
-* post v3.0dev2: roi_contour, roi_hierarchy = **plantcv.roi.circle**(*x, y, r, img*)
+* post v3.0dev2: roi_contour, roi_hierarchy = **plantcv.roi.circle**(*img, x, y, r*)
 
 #### plantcv.roi.ellipse
 
 * pre v3.0dev1: NA
-* post v3.0dev2: roi_contour, roi_hierarchy = **plantcv.roi.ellipse**(*x, y, r1, r2, angle, img*)
+* post v3.0dev2: roi_contour, roi_hierarchy = **plantcv.roi.ellipse**(*img, x, y, r1, r2, angle*)
 
 #### plantcv.roi.from_binary_image
 
 * pre v3.0dev1: NA
-* post v3.0dev2: roi_contour, roi_hierarchy = **plantcv.roi.from_binary_image**(*bin_img, img*)
+* post v3.0dev2: roi_contour, roi_hierarchy = **plantcv.roi.from_binary_image**(*img, bin_img*)
 
 #### plantcv.roi.rectangle
 
 * pre v3.0dev1: NA
-* post v3.0dev2: roi_contour, roi_hierarchy = **plantcv.roi.rectangle**(*x, y, h, w, img*)
+* post v3.0dev2: roi_contour, roi_hierarchy = **plantcv.roi.rectangle**(*img, x, y, h, w*)
 
 #### plantcv.roi.multi
 
@@ -456,6 +467,7 @@ post v3.0: new_img = **plantcv.image_subtract**(*gray_img1, gray_img2*)
 
 * pre v3.0dev2: device, rescaled, centroid_scaled, boundary_line_scaled = **plantcv.scale_features**(*obj, mask, points, boundary_line, device, debug=None*)
 * post v3.0dev2: rescaled, centroid_scaled, boundary_line_scaled = **plantcv.scale_features**(*obj, mask, points, boundary_line*)
+* post v3.2: rescaled, centroid_scaled, boundary_line_scaled = **plantcv.scale_features**(*obj, mask, points, line_position*)
 
 #### plantcv.scharr_filter
 
@@ -471,6 +483,7 @@ post v3.0: new_img = **plantcv.image_subtract**(*gray_img1, gray_img2*)
 
 * pre v3.0dev2: device, sb_img = **plantcv.sobel_filter**(*img, dx, dy, k, device, debug=None*)
 * post v3.0dev2: sb_img = **plantcv.sobel_filter**(*gray_img, dx, dy, k*)
+* post v3.2: sb_img = **plantcv.sobel_filer**(*gray_img, dx, dy, ksize*)
 
 #### plantcv.threshold.binary
 
@@ -495,7 +508,7 @@ post v3.0: new_img = **plantcv.image_subtract**(*gray_img1, gray_img2*)
 #### plantcv.threshold.texture_filter
 
 * pre v3.0: NA
-* post v3.0: bin_img = **plantcv.threshold.texture_filter**(*gray_img, kernel, threshold, offset=3, texture_method='dissimilarity', borders='nearest', max_value=255*)
+* post v3.0: bin_img = **plantcv.threshold.texture_filter**(*gray_img, ksize, threshold, offset=3, texture_method='dissimilarity', borders='nearest', max_value=255*)
 
 #### plantcv.threshold.triangle
 
@@ -573,8 +586,10 @@ post v3.0: new_img = **plantcv.image_subtract**(*gray_img1, gray_img2*)
 
 * pre v3.0dev2: device, top, bottom, center_v = **plantcv.x_axis_pseudolandmarks**(*obj, mask, img, device, debug=None*)
 * post v3.0dev2: top, bottom, center_v = **plantcv.x_axis_pseudolandmarks**(*obj, mask, img*)
+* post v3.2: top, bottom, center_v = **plantcv.x_axis_pseudolandmarks**(*img, obj, mask*)
 
 #### plantcv.y_axis_pseudolandmarks
 
 * pre v3.0dev2: device, left, right, center_h = **plantcv.y_axis_pseudolandmarks**(*obj, mask, img, device, debug=None*)
 * post v3.0dev2: left, right, center_h = **plantcv.y_axis_pseudolandmarks**(*obj, mask, img*)
+* post v3.2: left, right, center_h = **plantcv.y_axis_pseudolandmarks**(*img, obj, mask*)

--- a/docs/x_axis_pseudolandmarks.md
+++ b/docs/x_axis_pseudolandmarks.md
@@ -3,14 +3,14 @@
 Divide plant object into twenty equidistant bins and assign pseudolandmark points based upon their actual (not scaled) position.
 Once this data is scaled this approach may provide some information regarding shape independent of size.
 
-**plantcv.x_axis_pseudolandmarks**(*obj, mask, img*)
+**plantcv.x_axis_pseudolandmarks**(*img, obj, mask*)
 
 **returns** landmarks_on_top (top), landmarks_on_bottom (bottom), landmarks_at_center_along_the_vertical_axis (center_V)
 
 - **Parameters:**
+    - img - A copy of the original image (RGB or grayscale) generated using np.copy
     - obj - A contour of the plant object (this should be output from the object_composition.py fxn)
     - mask - This is a binary image. The object should be white and the background should be black.
-    - img - A copy of the original image (RGB or grayscale) generated using np.copy
 - **Context:**
     - Used to identify a set of sixty equidistant landmarks on the horizontal axis. Once scaled these can be used for shape analysis.
     
@@ -26,7 +26,7 @@ pcv.params.debug = "plot"
 
 # Identify a set of land mark points
 # Results in set of point values that may indicate tip points
-top, bottom, center_v = pcv.x_axis_pseudolandmarks(obj, mask, img)
+top, bottom, center_v = pcv.x_axis_pseudolandmarks(img, obj, mask)
 ```
 
 **Image of points selected**

--- a/docs/y_axis_pseudolandmarks.md
+++ b/docs/y_axis_pseudolandmarks.md
@@ -4,14 +4,14 @@ Divide plant object into twenty equidistant bins along the y-axis and assign pse
 actual (not scaled) position. Once this data is scaled this approach may provide some information regarding shape 
 independent of size.
 
-**plantcv.y_axis_pseudolandmarks**(*obj, mask, img*)
+**plantcv.y_axis_pseudolandmarks**(*img, obj, mask*)
 
 **returns** landmarks_on_leftside (left), landmarks_on_right (right), landmarks_at_center_along_the_horizontal_axis (center_h)
 
 - **Parameters:**
+    - img - A copy of the original image (RGB or grayscale) generated using np.copy
     - obj - A contour of the plant object (this should be output from the object_composition.py fxn)
     - mask - This is a binary image. The object should be white and the background should be black.
-    - img - A copy of the original image (RGB or grayscale) generated using np.copy
 - **Context:**
     - Used to identify a set of sixty equidistant landmarks on the vertical axis. Once scaled these can be used for shape analysis.
     
@@ -28,7 +28,7 @@ pcv.params.debug = "plot"
 
 # Identify a set of land mark points
 # Results in set of point values that may indicate tip points
-left, right, center_h  = pcv.y_axis_pseudolandmarks(obj, mask, img)
+left, right, center_h  = pcv.y_axis_pseudolandmarks(img, obj, mask)
 ```
 
 **Image of points selected**

--- a/plantcv/plantcv/acute.py
+++ b/plantcv/plantcv/acute.py
@@ -5,16 +5,17 @@ import math
 import cv2
 from plantcv.plantcv import params
 
-def acute(obj, win, thresh, mask):
+def acute(obj, mask, win, thresh):
     """acute: identify landmark positions within a contour for morphometric analysis
 
     Inputs:
     obj         = An opencv contour array of interest to be scanned for landmarks
+    mask        = binary mask used to generate contour array (necessary for ptvals)
     win         = maximum cumulative pixel distance window for calculating angle
                   score; 1 cm in pixels often works well
     thresh      = angle score threshold to be applied for mapping out landmark
                   coordinate clusters within each contour
-    mask        = binary mask used to generate contour array (necessary for ptvals)
+
 
     Outputs:
     homolog_pts = pseudo-landmarks selected from each landmark cluster
@@ -29,9 +30,9 @@ def acute(obj, win, thresh, mask):
                   in troubleshooting.
 
     :param obj: ndarray
+    :param mask: ndarray
     :param win: int
     :param thresh: int
-    :param mask: ndarray
     :return homolog_pts:
     """
 

--- a/plantcv/plantcv/acute_vertex.py
+++ b/plantcv/plantcv/acute_vertex.py
@@ -10,25 +10,25 @@ from plantcv.plantcv import params
 from plantcv.plantcv import outputs
 
 
-def acute_vertex(obj, win, thresh, sep, img):
+def acute_vertex(img, obj, win, thresh, sep):
     """acute_vertex: identify corners/acute angles of an object
 
     For each point in contour, get a point before (pre) and after (post) the point of interest,
     calculate the angle between the pre and post point.
 
     Inputs:
+    img    = the original image
     obj    = a contour of the plant object (this should be output from the object_composition.py fxn)
     win    = win argument specifies the pre and post point distances (a value of 30 worked well for a sample image)
     thresh = an threshold to set for acuteness; keep points with an angle more acute than the threshold (a value of 15
              worked well for sample image)
     sep    = the number of contour points to search within for the most acute value
-    img    = the original image
 
+    :param img: ndarray
     :param obj: ndarray
     :param win: int
     :param thresh: int
     :param sep: int
-    :param img: ndarray
     :return acute: ndarray
     """
     params.device += 1

--- a/plantcv/plantcv/auto_crop.py
+++ b/plantcv/plantcv/auto_crop.py
@@ -9,12 +9,12 @@ from plantcv.plantcv import params
 from plantcv.plantcv import fatal_error
 
 
-def auto_crop(img, objects, padding_x=0, padding_y=0, color='black'):
+def auto_crop(img, obj, padding_x=0, padding_y=0, color='black'):
     """Resize image.
 
     Inputs:
     img       = RGB or grayscale image data
-    objects   = contours
+    obj       = contours
     padding_x = padding in the x direction
     padding_y = padding in the y direction
     color     = either 'black', 'white', or 'image'
@@ -23,7 +23,7 @@ def auto_crop(img, objects, padding_x=0, padding_y=0, color='black'):
     cropped   = cropped image
 
     :param img: numpy.ndarray
-    :param objects: list
+    :param obj: list
     :param padding_x: int
     :param padding_y: int
     :param color: str
@@ -34,7 +34,7 @@ def auto_crop(img, objects, padding_x=0, padding_y=0, color='black'):
     img_copy = np.copy(img)
     img_copy2 = np.copy(img)
 
-    x, y, w, h = cv2.boundingRect(objects)
+    x, y, w, h = cv2.boundingRect(obj)
     cv2.rectangle(img_copy, (x, y), (x + w, y + h), (0, 255, 0), 5)
 
     crop_img = img[y:y + h, x:x + w]

--- a/plantcv/plantcv/canny_edge_detect.py
+++ b/plantcv/plantcv/canny_edge_detect.py
@@ -11,19 +11,19 @@ import cv2
 import os
 
 
-def canny_edge_detect(img, sigma=1.0, low_thresh=None, high_thresh=None, thickness=1,
-                      mask=None, mask_color=None, use_quantiles=False):
+def canny_edge_detect(img, mask = None, sigma=1.0, low_thresh=None, high_thresh=None, thickness=1,
+                      mask_color=None, use_quantiles=False):
     """Edge filter an image using the Canny algorithm.
 
     Inputs:
     img           = RGB or grayscale image data
+    mask          = Mask to limit the application of Canny to a certain area, takes a binary img. (OPTIONAL)
     sigma         = Standard deviation of the Gaussian filter
     low_thresh    = Lower bound for hysteresis thresholding (linking edges). If None (default) then low_thresh is set to
                     10% of the image's max (OPTIONAL)
     high_thresh   = Upper bound for hysteresis thresholding (linking edges). If None (default) then high_thresh is set
                     to 20% of the image's max (OPTIONAL)
     thickness     = How thick the edges should appear, default thickness=1 (OPTIONAL)
-    mask          = Mask to limit the application of Canny to a certain area, takes a binary img. (OPTIONAL)
     mask_color    = Color of the mask provided; either None (default), 'white', or 'black'
     use_quantiles = Default is False, if True then treat low_thresh and high_thresh as quantiles of the edge magnitude
                     image, rather than the absolute edge magnitude values. If True then thresholds range is [0,1].
@@ -33,11 +33,11 @@ def canny_edge_detect(img, sigma=1.0, low_thresh=None, high_thresh=None, thickne
     bin_img      = Thresholded, binary image
 
     :param img: numpy.ndarray
+    :param mask: numpy.ndarray
     :param sigma = float
     :param low_thresh: float
     :param high_thresh: float
     :param thickness: int
-    :param mask: numpy.ndarray
     :param mask_color: str
     :param use_quantiles: bool
     :return bin_img: numpy.ndarray

--- a/plantcv/plantcv/dilate.py
+++ b/plantcv/plantcv/dilate.py
@@ -8,24 +8,24 @@ from plantcv.plantcv import plot_image
 from plantcv.plantcv import params
 
 
-def dilate(gray_img, kernel, i):
+def dilate(gray_img, ksize, i):
     """Performs morphological 'dilation' filtering. Adds pixel to center of kernel if conditions set in kernel are true.
 
     Inputs:
     gray_img = Grayscale (usually binary) image data
-    kernel   = Kernel size (int). A k x k kernel will be built. Must be greater than 1 to have an effect.
+    ksize   = Kernel size (int). A k x k kernel will be built. Must be greater than 1 to have an effect.
     i        = iterations, i.e. number of consecutive filtering passes
 
     Returns:
     dil_img = dilated image
 
     :param gray_img: numpy.ndarray
-    :param kernel: int
+    :param ksize: int
     :param i: int
     :return dil_img: numpy.ndarray
     """
 
-    kernel1 = int(kernel)
+    kernel1 = int(ksize)
     kernel2 = np.ones((kernel1, kernel1), np.uint8)
     dil_img = cv2.dilate(src=gray_img, kernel=kernel2, iterations=i)
     params.device += 1

--- a/plantcv/plantcv/erode.py
+++ b/plantcv/plantcv/erode.py
@@ -8,25 +8,25 @@ from plantcv.plantcv import plot_image
 from plantcv.plantcv import params
 
 
-def erode(gray_img, kernel, i):
+def erode(gray_img, ksize, i):
     """Perform morphological 'erosion' filtering. Keeps pixel in center of the kernel if conditions set in kernel are
        true, otherwise removes pixel.
 
     Inputs:
     gray_img = Grayscale (usually binary) image data
-    kernel   = Kernel size (int). A k x k kernel will be built. Must be greater than 1 to have an effect.
+    ksize   = Kernel size (int). A ksize x ksize kernel will be built. Must be greater than 1 to have an effect.
     i        = interations, i.e. number of consecutive filtering passes
 
     Returns:
     er_img = eroded image
 
     :param gray_img: numpy.ndarray
-    :param kernel: int
+    :param ksize: int
     :param i: int
     :return er_img: numpy.ndarray
     """
 
-    kernel1 = int(kernel)
+    kernel1 = int(ksize)
     kernel2 = np.ones((kernel1, kernel1), np.uint8)
     er_img = cv2.erode(src=gray_img, kernel=kernel2, iterations=i)
     params.device += 1

--- a/plantcv/plantcv/gaussian_blur.py
+++ b/plantcv/plantcv/gaussian_blur.py
@@ -8,7 +8,7 @@ from plantcv.plantcv import plot_image
 from plantcv.plantcv import params
 
 
-def gaussian_blur(img, ksize, sigmax=0, sigmay=None):
+def gaussian_blur(img, ksize, sigma_x=0, sigma_y=None):
     """Applies a Gaussian blur filter.
 
     Inputs:
@@ -27,7 +27,7 @@ def gaussian_blur(img, ksize, sigmax=0, sigmay=None):
     :return img_gblur: numpy.ndarray
     """
 
-    img_gblur = cv2.GaussianBlur(img, ksize, sigmax, sigmay)
+    img_gblur = cv2.GaussianBlur(img, ksize, sigma_x, sigma_y)
 
     params.device += 1
     if params.debug == 'print':

--- a/plantcv/plantcv/laplace_filter.py
+++ b/plantcv/plantcv/laplace_filter.py
@@ -7,14 +7,14 @@ from plantcv.plantcv import plot_image
 from plantcv.plantcv import params
 
 
-def laplace_filter(gray_img, k, scale):
+def laplace_filter(gray_img, ksize, scale):
     """This is a filtering method used to identify and highlight fine edges based on the 2nd derivative. A very
        sensetive method to highlight edges but will also amplify background noise. ddepth = -1 specifies that the
        dimensions of output image will be the same as the input image.
 
     Inputs:
     gray_img    = Grayscale image data
-    k           = apertures size used to calculate 2nd derivative filter, specifies the size of the kernel
+    ksize       = apertures size used to calculate 2nd derivative filter, specifies the size of the kernel
                   (must be an odd integer: 1,3,5...)
     scale       = scaling factor applied (multiplied) to computed Laplacian values (scale = 1 is unscaled)
 
@@ -22,17 +22,17 @@ def laplace_filter(gray_img, k, scale):
     lp_filtered = laplacian filtered image
 
     :param gray_img: numpy.ndarray
-    :param k: int
+    :param kernel: int
     :param scale: int
     :return lp_filtered: numpy.ndarray
     """
 
-    lp_filtered = cv2.Laplacian(src=gray_img, ddepth=-1, ksize=k, scale=scale)
+    lp_filtered = cv2.Laplacian(src=gray_img, ddepth=-1, ksize=ksize, scale=scale)
     params.device += 1
     if params.debug == 'print':
         print_image(lp_filtered,
                     os.path.join(params.debug_outdir,
-                                 str(params.device) + '_lp_out_k' + str(k) + '_scale' + str(scale) + '.png'))
+                                 str(params.device) + '_lp_out_k' + str(ksize) + '_scale' + str(scale) + '.png'))
     elif params.debug == 'plot':
         plot_image(lp_filtered, cmap='gray')
     return lp_filtered

--- a/plantcv/plantcv/pseudocolor.py
+++ b/plantcv/plantcv/pseudocolor.py
@@ -9,37 +9,35 @@ from plantcv.plantcv import plot_image
 from plantcv.plantcv import fatal_error
 
 
-def pseudocolor(gray_img, mask=None, cmap=None, background="image", min_value=0, max_value=255, obj=None, dpi=None,
+def pseudocolor(gray_img, obj=None, mask=None, cmap=None, background="image", min_value=0, max_value=255, dpi=None,
                 axes=True, colorbar=True):
     """Pseudocolor any grayscale image to custom colormap
 
     Inputs:
     gray_img    = grayscale image data
+    obj         = if provided, the pseudocolored image gets cropped down to the region of interest
     mask        = binary mask
     cmap        = colormap
     background  = background color/type, options are "image" (gray_img), "white", or "black"
                   (a mask must be supplied)
     min_value   = minimum value for range of interest
     max_value   = maximum value for range of interest
-    obj         = if provided, the pseudocolored image gets cropped down to the region of interest
     dpi         = dots per inch, (optional, if dpi=None then the matplotlib default is used, 100 dpi)
     axes        = if False then x- and y-axis won't be displayed, nor will the title
     colorbar    = if False then colorbar won't be displayed
-    path        = location for saving the image
 
     Returns:
     pseudo_image = pseudocolored image
 
     :param gray_img: numpy.ndarray
+    :param obj: numpy.ndarray
     :param mask: numpy.ndarray
     :param cmap: str
     :param background: str
     :param min_value: numeric
     :param max_value: numeric
-    :param obj: numpy.ndarray
     :param dpi: int
     :param axes: bool
-    :param path: str
     :return pseudo_image: numpy.ndarray
     """
 

--- a/plantcv/plantcv/readimage.py
+++ b/plantcv/plantcv/readimage.py
@@ -26,7 +26,7 @@ def readimage(filename, mode="native"):
     :return path: str
     :return img_name: str
     """
-    if mode.upper() == "GRAY":
+    if mode.upper() == "GRAY" or mode.upper() == "GREY":
         img = cv2.imread(filename, 0)
     elif mode.upper() == "RGB":
         img = cv2.imread(filename)

--- a/plantcv/plantcv/rectangle_mask.py
+++ b/plantcv/plantcv/rectangle_mask.py
@@ -69,7 +69,6 @@ def rectangle_mask(img, p1, p2, color="black"):
 
     if params.debug == 'print':
         print_image(bnk, os.path.join(params.debug_outdir, str(params.device) + '_roi.png'))
-
     elif params.debug == 'plot':
         plot_image(bnk, cmap="gray")
         plot_image(img1, cmap="gray")

--- a/plantcv/plantcv/roi/roi_methods.py
+++ b/plantcv/plantcv/roi/roi_methods.py
@@ -10,19 +10,19 @@ from plantcv.plantcv import params
 
 
 # Create an ROI from a binary mask
-def from_binary_image(bin_img, img):
+def from_binary_image(img, bin_img):
     """Create an ROI from a binary image
 
     Inputs:
-    bin_img       = Binary image to extract an ROI contour from.
     img           = An RGB or grayscale image to plot the ROI on.
+    bin_img       = Binary image to extract an ROI contour from.
 
     Outputs:
     roi_contour   = An ROI set of points (contour).
     roi_hierarchy = The hierarchy of ROI contour(s).
 
-    :param bin_img: numpy.ndarray
     :param img: numpy.ndarray
+    :param bin_img: numpy.ndarray
     :return roi_contour: list
     :return roi_hierarchy: numpy.ndarray
     """
@@ -41,25 +41,25 @@ def from_binary_image(bin_img, img):
 
 
 # Create a rectangular ROI
-def rectangle(x, y, h, w, img):
+def rectangle(img, x, y, h, w):
     """Create a rectangular ROI.
 
     Inputs:
+    img           = An RGB or grayscale image to plot the ROI on in debug mode.
     x             = The x-coordinate of the upper left corner of the rectangle.
     y             = The y-coordinate of the upper left corner of the rectangle.
     h             = The height of the rectangle.
     w             = The width of the rectangle.
-    img           = An RGB or grayscale image to plot the ROI on in debug mode.
 
     Outputs:
     roi_contour   = An ROI set of points (contour).
     roi_hierarchy = The hierarchy of ROI contour(s).
 
+    :param img: numpy.ndarray
     :param x: int
     :param y: int
     :param h: int
     :param w: int
-    :param img: numpy.ndarray
     :return roi_contour: list
     :return roi_hierarchy: numpy.ndarray
     """
@@ -91,23 +91,23 @@ def rectangle(x, y, h, w, img):
 
 
 # Create a circular ROI
-def circle(x, y, r, img):
+def circle(img, x, y, r):
     """Create a circular ROI.
 
     Inputs:
+    img           = An RGB or grayscale image to plot the ROI on in debug mode.
     x             = The x-coordinate of the center of the circle.
     y             = The y-coordinate of the center of the circle.
     r             = The radius of the circle.
-    img           = An RGB or grayscale image to plot the ROI on in debug mode.
 
     Outputs:
     roi_contour   = An ROI set of points (contour).
     roi_hierarchy = The hierarchy of ROI contour(s).
 
+    :param img: numpy.ndarray
     :param x: int
     :param y: int
     :param r: int
-    :param img: numpy.ndarray
     :return roi_contour: list
     :return roi_hierarchy: numpy.ndarray
     """
@@ -137,27 +137,27 @@ def circle(x, y, r, img):
 
 
 # Create an elliptical ROI
-def ellipse(x, y, r1, r2, angle, img):
+def ellipse(img, x, y, r1, r2, angle):
     """Create an elliptical ROI.
 
     Inputs:
+    img           = An RGB or grayscale image to plot the ROI on in debug mode.
     x             = The x-coordinate of the center of the ellipse.
     y             = The y-coordinate of the center of the ellipse.
     r1            = The radius of the major axis.
     r2            = The radius of the minor axis.
     angle         = The angle of rotation of the major axis.
-    img           = An RGB or grayscale image to plot the ROI on in debug mode.
 
     Outputs:
     roi_contour   = An ROI set of points (contour).
     roi_hierarchy = The hierarchy of ROI contour(s).
 
+    :param img: numpy.ndarray
     :param x: int
     :param y: int
     :param r1: int
     :param r2: int
     :param angle: int
-    :param img: numpy.ndarray
     :return roi_contour: list
     :return roi_hierarchy: numpy.ndarray
     """

--- a/plantcv/plantcv/scale_features.py
+++ b/plantcv/plantcv/scale_features.py
@@ -8,7 +8,7 @@ from plantcv.plantcv import print_image
 from plantcv.plantcv import params
 
 
-def scale_features(obj, mask, points, boundary_line):
+def scale_features(obj, mask, points, line_position):
     """scale_features: returns feature scaled points
 
     This is a function to transform the coordinates of landmark points onto a common scale (0 - 1.0).
@@ -17,13 +17,13 @@ def scale_features(obj, mask, points, boundary_line):
     obj           = a contour of the plant object (this should be output from the object_composition.py fxn)
     mask          = this is a binary image. The object should be white and the background should be black
     points        = the points to scale
-    boundary_line = A vertical coordinate that denotes the height of the plant pot, the coordinates of this reference
+    line_position = A vertical coordinate that denotes the height of the plant pot, the coordinates of this reference
                     point is also rescaled
 
     :param obj: ndarray
     :param mask: ndarray
     :param points: ndarray
-    :param boundary_line: int
+    :param line_position: int
     :return rescaled: list
     :return centroid_scaled: tuple
     :return boundary_line_scaled: tuple
@@ -40,9 +40,9 @@ def scale_features(obj, mask, points, boundary_line):
     m = cv2.moments(mask, binaryImage=True)
     cmx, cmy = (m['m10'] / m['m00'], m['m01'] / m['m00'])
     # Convert the boundary line position (top of the pot) into a coordinate on the image
-    if boundary_line != 'NA':
-        line_position = int(iy) - int(boundary_line)
-        bly = line_position
+    if line_position != 'NA':
+        line_pos = int(iy) - int(line_position)
+        bly = line_pos
     else:
         bly = cmy
     blx = cmx

--- a/plantcv/plantcv/shift_img.py
+++ b/plantcv/plantcv/shift_img.py
@@ -43,18 +43,18 @@ def shift_img(img, number, side="right"):
         top = np.zeros((number, iy, 3), dtype=np.uint8)
         adjust = ix - number
         adjusted_img = np.vstack((top, ori_img[0:adjust, 0:]))
-
-    if side.upper() == 'BOTTOM':
+    elif side.upper() == 'BOTTOM':
         bottom = np.zeros((number, iy, 3), dtype=np.uint8)
         adjusted_img = np.vstack((ori_img[number:, 0:], bottom))
-
-    if side.upper() == 'RIGHT':
+    elif side.upper() == 'RIGHT':
         right = np.zeros((ix, number, 3), dtype=np.uint8)
         adjusted_img = np.hstack((ori_img[0:, number:], right))
-    if side.upper() == 'LEFT':
+    elif side.upper() == 'LEFT':
         left = np.zeros((ix, number, 3), dtype=np.uint8)
         adjust = iy - number
         adjusted_img = np.hstack((left, ori_img[0:, 0:adjust]))
+    else:
+        fatal_error("side must be 'top', 'bottom', 'right', or 'left'")
 
     if len(np.shape(img)) == 2:
         adjusted_img = adjusted_img[:,:,0]

--- a/plantcv/plantcv/sobel_filter.py
+++ b/plantcv/plantcv/sobel_filter.py
@@ -7,7 +7,7 @@ from plantcv.plantcv import plot_image
 from plantcv.plantcv import params
 
 
-def sobel_filter(gray_img, dx, dy, k):
+def sobel_filter(gray_img, dx, dy, ksize):
     """This is a filtering method used to identify and highlight gradient edges/features using the 1st derivative.
        Typically used to identify gradients along the x-axis (dx = 1, dy = 0) and y-axis (dx = 0, dy = 1) independently.
        Performance is quite similar to Scharr filter. Used to detect edges / changes in pixel intensity. ddepth = -1
@@ -17,7 +17,7 @@ def sobel_filter(gray_img, dx, dy, k):
     gray_img = Grayscale image data
     dx       = derivative of x to analyze
     dy       = derivative of x to analyze
-    k        = specifies the size of the kernel (must be an odd integer: 1,3,5, ... , 31)
+    ksize        = specifies the size of the kernel (must be an odd integer: 1,3,5, ... , 31)
 
     Returns:
     sb_img   = Sobel filtered image
@@ -25,16 +25,16 @@ def sobel_filter(gray_img, dx, dy, k):
     :param gray_img: numpy.ndarray
     :param dx: int
     :param dy: int
-    :param k: int
+    :param ksize: int
     :param scale: int
     :return sb_img: numpy.ndarray
     """
     params.device += 1
-    sb_img = cv2.Sobel(src=gray_img, ddepth=-1, dx=dx, dy=dy, ksize=k)
+    sb_img = cv2.Sobel(src=gray_img, ddepth=-1, dx=dx, dy=dy, ksize=ksize)
 
     if params.debug == 'print':
         name = os.path.join(params.debug_outdir,
-                            str(params.device) + '_sb_img_dx' + str(dx) + '_dy' + str(dy) + '_k' + str(k) + '.png')
+                            str(params.device) + '_sb_img_dx' + str(dx) + '_dy' + str(dy) + '_kernel' + str(ksize) + '.png')
         print_image(sb_img, name)
     elif params.debug == 'plot':
         plot_image(sb_img, cmap='gray')

--- a/plantcv/plantcv/threshold/threshold_methods.py
+++ b/plantcv/plantcv/threshold/threshold_methods.py
@@ -37,9 +37,9 @@ def binary(gray_img, threshold, max_value, object_type="light"):
 
     # Set the threshold method
     threshold_method = ""
-    if object_type == "light":
+    if object_type.upper() == "LIGHT":
         threshold_method = cv2.THRESH_BINARY
-    elif object_type == "dark":
+    elif object_type.upper() == "DARK":
         threshold_method = cv2.THRESH_BINARY_INV
     else:
         fatal_error('Object type ' + str(object_type) + ' is not "light" or "dark"!')
@@ -73,9 +73,9 @@ def gaussian(gray_img, max_value, object_type="light"):
 
     # Set the threshold method
     threshold_method = ""
-    if object_type == "light":
+    if object_type.upper() == "LIGHT":
         threshold_method = cv2.THRESH_BINARY
-    elif object_type == "dark":
+    elif object_type.upper() == "DARK":
         threshold_method = cv2.THRESH_BINARY_INV
     else:
         fatal_error('Object type ' + str(object_type) + ' is not "light" or "dark"!')
@@ -109,9 +109,9 @@ def mean(gray_img, max_value, object_type="light"):
 
     # Set the threshold method
     threshold_method = ""
-    if object_type == "light":
+    if object_type.upper() == "LIGHT":
         threshold_method = cv2.THRESH_BINARY
-    elif object_type == "dark":
+    elif object_type.upper() == "DARK":
         threshold_method = cv2.THRESH_BINARY_INV
     else:
         fatal_error('Object type ' + str(object_type) + ' is not "light" or "dark"!')
@@ -145,9 +145,9 @@ def otsu(gray_img, max_value, object_type="light"):
 
     # Set the threshold method
     threshold_method = ""
-    if object_type == "light":
+    if object_type.upper() == "LIGHT":
         threshold_method = cv2.THRESH_BINARY + cv2.THRESH_OTSU
-    elif object_type == "dark":
+    elif object_type.upper() == "DARK":
         threshold_method = cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU
     else:
         fatal_error('Object type ' + str(object_type) + ' is not "light" or "dark"!')
@@ -231,9 +231,9 @@ def triangle(gray_img, max_value, object_type="light", xstep=1):
 
     # Set the threshold method
     threshold_method = ""
-    if object_type == "light":
+    if object_type.upper() == "LIGHT":
         threshold_method = cv2.THRESH_BINARY + cv2.THRESH_OTSU
-    elif object_type == "dark":
+    elif object_type.upper() == "DARK":
         threshold_method = cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU
     else:
         fatal_error('Object type ' + str(object_type) + ' is not "light" or "dark"!')
@@ -264,14 +264,14 @@ def triangle(gray_img, max_value, object_type="light", xstep=1):
     return bin_img
 
 
-def texture(gray_img, kernel, threshold, offset=3, texture_method='dissimilarity', borders='nearest',
+def texture(gray_img, ksize, threshold, offset=3, texture_method='dissimilarity', borders='nearest',
             max_value=255):
     """Creates a binary image from a grayscale image using skimage texture calculation for thresholding.
     This function is quite slow.
 
     Inputs:
     gray_img       = Grayscale image data
-    kernel         = Kernel size for texture measure calculation
+    ksize          = Kernel size for texture measure calculation
     threshold      = Threshold value (0-255)
     offset         = Distance offsets
     texture_method = Feature of a grey level co-occurrence matrix, either
@@ -286,7 +286,7 @@ def texture(gray_img, kernel, threshold, offset=3, texture_method='dissimilarity
     bin_img        = Thresholded, binary image
 
     :param gray_img: numpy.ndarray
-    :param kernel: int
+    :param ksize: int
     :param threshold: int
     :param offset: int
     :param texture_method: str
@@ -297,7 +297,7 @@ def texture(gray_img, kernel, threshold, offset=3, texture_method='dissimilarity
 
     # Function that calculates the texture of a kernel
     def calc_texture(inputs):
-        inputs = np.reshape(a=inputs, newshape=[kernel, kernel])
+        inputs = np.reshape(a=inputs, newshape=[ksize, ksize])
         inputs = inputs.astype(np.uint8)
         # Greycomatrix takes image, distance offset, angles (in radians), symmetric, and normed
         # http://scikit-image.org/docs/dev/api/skimage.feature.html#skimage.feature.greycomatrix
@@ -309,7 +309,7 @@ def texture(gray_img, kernel, threshold, offset=3, texture_method='dissimilarity
     output = np.zeros(gray_img.shape, dtype=gray_img.dtype)
 
     # Apply the texture function over the whole image
-    generic_filter(gray_img, calc_texture, size=kernel, output=output, mode=borders)
+    generic_filter(gray_img, calc_texture, size=ksize, output=output, mode=borders)
 
     # Threshold so higher texture measurements stand out
     bin_img = binary(gray_img=output, threshold=threshold, max_value=max_value, object_type='light')

--- a/plantcv/plantcv/white_balance.py
+++ b/plantcv/plantcv/white_balance.py
@@ -104,6 +104,8 @@ def white_balance(img, mode='hist', roi=None):
             channel1 = _max(c1, hmax, mask, x, y, h, w, type)
             channel2 = _max(c2, hmax, mask, x, y, h, w, type)
             channel3 = _max(c3, hmax, mask, x, y, h, w, type)
+        else:
+            fatal_error('Mode must be either "hist" or "max" but ' + mode + ' was input.')
 
         finalcorrected = np.dstack((channel1, channel2, channel3))
 

--- a/plantcv/plantcv/x_axis_pseudolandmarks.py
+++ b/plantcv/plantcv/x_axis_pseudolandmarks.py
@@ -10,22 +10,22 @@ from plantcv.plantcv import outputs
 from plantcv.plantcv import fatal_error
 
 
-def x_axis_pseudolandmarks(obj, mask, img):
+def x_axis_pseudolandmarks(img, obj, mask):
     """Divide up object contour into 20 equidistance segments and generate landmarks for each
 
     Inputs:
+    img      = This is a copy of the original plant image generated using np.copy if debug is true it will be drawn on
     obj      = a contour of the plant object (this should be output from the object_composition.py fxn)
     mask     = this is a binary image. The object should be white and the background should be black
-    img      = This is a copy of the original plant image generated using np.copy if debug is true it will be drawn on
 
     Returns:
     top      =
     bottom   =
     center_v =
 
+    :param img: numpy.ndarray
     :param obj: list
     :param mask: numpy.ndarray
-    :param img: numpy.ndarray
     :return top:
     :return bottom:
     :return center_v:

--- a/plantcv/plantcv/y_axis_pseudolandmarks.py
+++ b/plantcv/plantcv/y_axis_pseudolandmarks.py
@@ -10,22 +10,22 @@ from plantcv.plantcv import outputs
 from plantcv.plantcv import fatal_error
 
 
-def y_axis_pseudolandmarks(obj, mask, img):
+def y_axis_pseudolandmarks(img, obj, mask):
     """Divide up object contour into 19 equidistant segments and generate landmarks for each
 
     Inputs:
+    img      = This is a copy of the original plant image generated using np.copy if debug is true it will be drawn on
     obj      = a contour of the plant object (this should be output from the object_composition.py fxn)
     mask     = this is a binary image. The object should be white and the background should be black
-    img      = This is a copy of the original plant image generated using np.copy if debug is true it will be drawn on
 
     Returns:
     top      =
     bottom   =
     center_v =
 
+    :param img: numpy.ndarray
     :param obj: list
     :param mask: numpy.ndarray
-    :param img: numpy.ndarray
     :return left:
     :return right:
     :return center_h:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -541,13 +541,13 @@ def test_plantcv_auto_crop():
     roi_contours = contours['arr_0']
     # Test with debug = "print"
     pcv.params.debug = "print"
-    _ = pcv.auto_crop(img=img1, objects=roi_contours[1], padding_x=20, padding_y=20, color='black')
+    _ = pcv.auto_crop(img=img1, obj=roi_contours[1], padding_x=20, padding_y=20, color='black')
     # Test with debug = "plot"
     pcv.params.debug = "plot"
-    _ = pcv.auto_crop(img=img1, objects=roi_contours[1], padding_x=20, padding_y=20, color='image')
+    _ = pcv.auto_crop(img=img1, obj=roi_contours[1], padding_x=20, padding_y=20, color='image')
     # Test with debug = None
     pcv.params.debug = None
-    cropped = pcv.auto_crop(img=img1, objects=roi_contours[1], padding_x=20, padding_y=20, color='black')
+    cropped = pcv.auto_crop(img=img1, obj=roi_contours[1], padding_x=20, padding_y=20, color='black')
     x, y, z = np.shape(img1)
     x1, y1, z1 = np.shape(cropped)
     assert x > x1
@@ -565,7 +565,7 @@ def test_plantcv_auto_crop_grayscale_input():
     roi_contours = contours['arr_0']
     # Test with debug = "plot"
     pcv.params.debug = "plot"
-    cropped = pcv.auto_crop(img=gray_img, objects=roi_contours[1], padding_x=20, padding_y=20, color='white')
+    cropped = pcv.auto_crop(img=gray_img, obj=roi_contours[1], padding_x=20, padding_y=20, color='white')
     x, y = np.shape(gray_img)
     x1, y1 = np.shape(cropped)
     assert x > x1
@@ -579,7 +579,7 @@ def test_plantcv_auto_crop_bad_input():
     roi_contours = contours['arr_0']
     with pytest.raises(RuntimeError):
         pcv.params.debug = "plot"
-        _ = pcv.auto_crop(img=gray_img, objects=roi_contours[1], padding_x=20, padding_y=20, color='wite')
+        _ = pcv.auto_crop(img=gray_img, obj=roi_contours[1], padding_x=20, padding_y=20, color='wite')
 
 
 def test_plantcv_canny_edge_detect():
@@ -839,13 +839,13 @@ def test_plantcv_dilate():
     img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_BINARY), -1)
     # Test with debug = "print"
     pcv.params.debug = "print"
-    _ = pcv.dilate(gray_img=img, kernel=5, i=1)
+    _ = pcv.dilate(gray_img=img, ksize=5, i=1)
     # Test with debug = "plot"
     pcv.params.debug = "plot"
-    _ = pcv.dilate(gray_img=img, kernel=5, i=1)
+    _ = pcv.dilate(gray_img=img, ksize=5, i=1)
     # Test with debug = None
     pcv.params.debug = None
-    dilate_img = pcv.dilate(gray_img=img, kernel=5, i=1)
+    dilate_img = pcv.dilate(gray_img=img, ksize=5, i=1)
     # Assert that the output image has the dimensions of the input image
     if all([i == j] for i, j in zip(np.shape(dilate_img), TEST_BINARY_DIM)):
         # Assert that the image is binary
@@ -866,13 +866,13 @@ def test_plantcv_erode():
     img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_BINARY), -1)
     # Test with debug = "print"
     pcv.params.debug = "print"
-    _ = pcv.erode(gray_img=img, kernel=5, i=1)
+    _ = pcv.erode(gray_img=img, ksize=5, i=1)
     # Test with debug = "plot"
     pcv.params.debug = "plot"
-    _ = pcv.erode(gray_img=img, kernel=5, i=1)
+    _ = pcv.erode(gray_img=img, ksize=5, i=1)
     # Test with debug = None
     pcv.params.debug = None
-    erode_img = pcv.erode(gray_img=img, kernel=5, i=1)
+    erode_img = pcv.erode(gray_img=img, ksize=5, i=1)
     # Assert that the output image has the dimensions of the input image
     if all([i == j] for i, j in zip(np.shape(erode_img), TEST_BINARY_DIM)):
         # Assert that the image is binary
@@ -1062,14 +1062,14 @@ def test_plantcv_gaussian_blur():
     img_color = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_COLOR), -1)
     # Test with debug = "print"
     pcv.params.debug = "print"
-    _ = pcv.gaussian_blur(img=img, ksize=(51, 51), sigmax=0, sigmay=None)
+    _ = pcv.gaussian_blur(img=img, ksize=(51, 51), sigma_x=0, sigma_y=None)
     # Test with debug = "plot"
     pcv.params.debug = "plot"
-    _ = pcv.gaussian_blur(img=img, ksize=(51, 51), sigmax=0, sigmay=None)
-    _ = pcv.gaussian_blur(img=img_color, ksize=(51, 51), sigmax=0, sigmay=None)
+    _ = pcv.gaussian_blur(img=img, ksize=(51, 51), sigma_x=0, sigma_y=None)
+    _ = pcv.gaussian_blur(img=img_color, ksize=(51, 51), sigma_x=0, sigma_y=None)
     # Test with debug = None
     pcv.params.debug = None
-    gaussian_img = pcv.gaussian_blur(img=img, ksize=(51, 51), sigmax=0, sigmay=None)
+    gaussian_img = pcv.gaussian_blur(img=img, ksize=(51, 51), sigma_x=0, sigma_y=None)
     imgavg = np.average(img)
     gavg = np.average(gaussian_img)
     assert gavg != imgavg
@@ -1226,13 +1226,13 @@ def test_plantcv_laplace_filter():
     img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_GRAY), -1)
     # Test with debug = "print"
     pcv.params.debug = "print"
-    _ = pcv.laplace_filter(gray_img=img, k=1, scale=1)
+    _ = pcv.laplace_filter(gray_img=img, ksize=1, scale=1)
     # Test with debug = "plot"
     pcv.params.debug = "plot"
-    _ = pcv.laplace_filter(gray_img=img, k=1, scale=1)
+    _ = pcv.laplace_filter(gray_img=img, ksize=1, scale=1)
     # Test with debug = None
     pcv.params.debug = None
-    lp_img = pcv.laplace_filter(gray_img=img, k=1, scale=1)
+    lp_img = pcv.laplace_filter(gray_img=img, ksize=1, scale=1)
     # Assert that the output image has the dimensions of the input image
     assert all([i == j] for i, j in zip(np.shape(lp_img), TEST_GRAY_DIM))
 
@@ -1579,6 +1579,7 @@ def test_plantcv_readimage_native():
 
 def test_plantcv_readimage_grayscale():
     pcv.params.debug = None
+    img, path, img_name = pcv.readimage(filename=os.path.join(TEST_DATA, TEST_INPUT_GRAY), mode="grey")
     img, path, img_name = pcv.readimage(filename=os.path.join(TEST_DATA, TEST_INPUT_GRAY), mode="gray")
     assert len(np.shape(img)) == 2
 
@@ -2049,15 +2050,15 @@ def test_plantcv_scale_features():
     obj_contour = contours_npz['arr_0']
     # Test with debug = "print"
     pcv.params.debug = "print"
-    _ = pcv.scale_features(obj=obj_contour, mask=mask, points=TEST_ACUTE_RESULT, boundary_line=50)
+    _ = pcv.scale_features(obj=obj_contour, mask=mask, points=TEST_ACUTE_RESULT, line_position=50)
     # Test with debug = "plot"
     pcv.params.debug = "plot"
-    _ = pcv.scale_features(obj=obj_contour, mask=mask, points=TEST_ACUTE_RESULT, boundary_line='NA')
+    _ = pcv.scale_features(obj=obj_contour, mask=mask, points=TEST_ACUTE_RESULT, line_position='NA')
     # Test with debug = None
     pcv.params.debug = None
     points_rescaled, centroid_rescaled, bottomline_rescaled = pcv.scale_features(obj=obj_contour, mask=mask,
                                                                                  points=TEST_ACUTE_RESULT,
-                                                                                 boundary_line=50)
+                                                                                 line_position=50)
     assert len(points_rescaled) == 23
 
 
@@ -2065,7 +2066,7 @@ def test_plantcv_scale_features_bad_input():
     mask = np.array([])
     obj_contour = np.array([])
     pcv.params.debug = None
-    result = pcv.scale_features(obj=obj_contour, mask=mask, points=TEST_ACUTE_RESULT, boundary_line=50)
+    result = pcv.scale_features(obj=obj_contour, mask=mask, points=TEST_ACUTE_RESULT, line_position=50)
     assert all([i == j] for i, j in zip(result, [("NA", "NA"), ("NA", "NA"), ("NA", "NA")]))
 
 
@@ -2125,6 +2126,14 @@ def test_plantcv_shift_img_bad_input():
         _ = pcv.shift_img(img=img, number=-300, side="top")
 
 
+def test_plantcv_shift_img_bad_side_input():
+    # Read in test data
+    img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_COLOR))
+    with pytest.raises(RuntimeError):
+        pcv.params.debug = None
+        _ = pcv.shift_img(img=img, number=300, side="starboard")
+
+
 def test_plantcv_sobel_filter():
     # Test cache directory
     cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_sobel_filter")
@@ -2134,13 +2143,13 @@ def test_plantcv_sobel_filter():
     img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_GRAY), -1)
     # Test with debug = "print"
     pcv.params.debug = "print"
-    _ = pcv.sobel_filter(gray_img=img, dx=1, dy=0, k=1)
+    _ = pcv.sobel_filter(gray_img=img, dx=1, dy=0, ksize=1)
     # Test with debug = "plot"
     pcv.params.debug = "plot"
-    _ = pcv.sobel_filter(gray_img=img, dx=1, dy=0, k=1)
+    _ = pcv.sobel_filter(gray_img=img, dx=1, dy=0, ksize=1)
     # Test with debug = None
     pcv.params.debug = None
-    sobel_img = pcv.sobel_filter(gray_img=img, dx=1, dy=0, k=1)
+    sobel_img = pcv.sobel_filter(gray_img=img, dx=1, dy=0, ksize=1)
     # Assert that the output image has the dimensions of the input image
     assert all([i == j] for i, j in zip(np.shape(sobel_img), TEST_GRAY_DIM))
 
@@ -2248,6 +2257,15 @@ def test_plantcv_white_balance_bad_input():
     with pytest.raises(RuntimeError):
         pcv.params.debug = "plot"
         _ = pcv.white_balance(img=img, mode='hist', roi=(5, 5, 5, 5, 5))
+
+
+def test_plantcv_white_balance_bad_mode_input():
+    # Read in test data
+    img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_MARKER))
+    # Test with debug = None
+    with pytest.raises(RuntimeError):
+        pcv.params.debug = "plot"
+        _ = pcv.white_balance(img=img, mode='histogram', roi=(5, 5, 80, 80))
 
 
 def test_plantcv_white_balance_bad_input_int():
@@ -3254,7 +3272,7 @@ def test_plantcv_threshold_texture():
     os.mkdir(cache_dir)
     pcv.params.debug_outdir = cache_dir
     gray_img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_GRAY_SMALL), -1)
-    binary_img = pcv.threshold.texture(gray_img, kernel=6, threshold=7, offset=3, texture_method='dissimilarity',
+    binary_img = pcv.threshold.texture(gray_img, ksize=6, threshold=7, offset=3, texture_method='dissimilarity',
                                        borders='nearest', max_value=255)
     # Assert that the output image has the dimensions of the input image
     if all([i == j] for i, j in zip(np.shape(binary_img), TEST_GRAY_DIM)):


### PR DESCRIPTION
Standardize names of arguments and the order in which functions take commonly used arguments 

### Description
- If a function takes img/rgb_img/gray_img, it should be the first argument
- Functions that take img, obj, mask should all be in that order
- Functions with img & mask should take those first
- Updated auto_crop to take 'obj' rather than 'objects' to match other functions
- Update kernel arguments to ksize since it's more accurate
- Update lablace_filter arg from k to ksize to match
- Update scale_features function boundary_line to line_position to match analyze_bound* functions
- Updated all ROI functions to take 'img' argument first
- Updated each unit test for functions that were changed


### Checklist:

- [x] Relevant tests (and test data) have been added or updated and passed.
- [x] The documentation was added or updated.
- [x] Relevant issues were updated or added.
