### PR TITLE
Visualize functions options 

### DIFF
--- a/docs/updating.md
+++ b/docs/updating.md
@@ -589,6 +589,7 @@ pages for more details on the input and output variable types.
 
 * pre v3.2: bins, hist = **plantcv.plot_hist**(*img, name=False*)
 * post v3.2: hist_header, hist_data, fig_hist = **plantcv.visualize.histogram**(*gray_img, mask=None, bins=256*)
+* post v3.3: hist_header, hist_data, fig_hist = **plantcv.visualize.histogram**(*gray_img, mask=None, bins=256, color='red', title=None*)
 
 #### plantcv.visualize.pseudocolor
 

--- a/docs/visualize_histogram.md
+++ b/docs/visualize_histogram.md
@@ -2,7 +2,7 @@
 
 This is a plotting method used to examine the distribution of signal within an image.
 
-**plantcv.visualize.histogram**(*gray_img, mask=None, bins=256*)
+**plantcv.visualize.histogram**(*gray_img, mask=None, bins=256, color='red', title=None*)
 
 **returns** hist_header, hist_data, fig_hist
 
@@ -10,7 +10,9 @@ This is a plotting method used to examine the distribution of signal within an i
     - gray_img - Grayscale image data, the original image for analysis.
     - mask - Optional binary mask made from selected contours (default mask=None)
     - bins - Number of class to divide spectrum into (default bins=256)
-- **Context:**
+    - color - The color of the line plot in the histogram (default color='red'). Users can input and color that is accepted by [plotnine ggplot](https://plotnine.readthedocs.io/en/stable/generated/plotnine.ggplot.html#plotnine.ggplot).
+    - title - The title for the histogram (default title=None) 
+**Context:**
     - Examine the distribution of the signal, this can help select a value for binary thresholding.
 - **Example use:**
     - [Use In NIR Tutorial](nir_tutorial.md)
@@ -29,7 +31,7 @@ from plantcv import plantcv as pcv
 
 # Examine signal distribution within an image
 # prints out an image histogram of signal within image
-header, hist_data, hist_figure = pcv.visualize.histogram(gray_img, mask=mask, bins=256)
+header, hist_data, hist_figure = pcv.visualize.histogram(gray_img, mask=mask, bins=256, color='red', title=None)
 ```
 
 **Histogram of signal intensity**

--- a/plantcv/plantcv/__init__.py
+++ b/plantcv/plantcv/__init__.py
@@ -123,7 +123,7 @@ __all__ = ['fatal_error', 'print_image', 'plot_image', 'color_palette', 'apply_m
            'analyze_bound_horizontal', 'analyze_bound_vertical', 'analyze_color', 'analyze_nir_intensity',
            'fluor_fvfm', 'print_results', 'resize', 'flip', 'crop_position_mask', 'get_nir', 'report_size_marker_area',
            'white_balance', 'acute_vertex', 'scale_features', 'landmark_reference_pt_dist', 'outputs',
-           'x_axis_pseudolandmarks', 'y_axis_pseudolandmarks', 'gaussian_blur', 'cluster_contours', 'visualize'
+           'x_axis_pseudolandmarks', 'y_axis_pseudolandmarks', 'gaussian_blur', 'cluster_contours', 'visualize',
            'cluster_contour_splitimg', 'rotate', 'shift_img', 'output_mask', 'auto_crop', 'canny_edge_detect',
            'background_subtraction', 'naive_bayes_classifier', 'acute', 'distance_transform', 'params']
 

--- a/plantcv/plantcv/visualize/colorize_masks.py
+++ b/plantcv/plantcv/visualize/colorize_masks.py
@@ -43,20 +43,18 @@ def colorize_masks(masks, colors):
     ix, iy = np.shape(masks[0])
     colored_img = np.zeros((ix,iy,3), dtype=np.uint8)
     # Assign pixels to the selected color
-    if all(isinstance(x, str) for x in colors):
-        for i in range(0, len(masks)):
-            mask = np.copy(masks[i])
-            mask = cv2.cvtColor(mask, cv2.COLOR_GRAY2BGR)
-            mask[masks[i] > 0] = color_dict[colors[i]]
-            colored_img = colored_img + mask
-    elif all(isinstance(x, tuple) for x in colors):
-        for i in range(0, len(masks)):
-            mask = np.copy(masks[i])
-            mask = cv2.cvtColor(mask, cv2.COLOR_GRAY2BGR)
+
+    for i in range(0, len(masks)):
+        mask = np.copy(masks[i])
+        mask = cv2.cvtColor(mask, cv2.COLOR_GRAY2BGR)
+        if isinstance(colors[i], tuple):
             mask[masks[i] > 0] = colors[i]
-            colored_img = colored_img + mask
-    else:
-        fatal_error("All elements of the 'colors' list must be the same type (all str or all tuples)")
+        elif isinstance(colors[i], str):
+            mask[masks[i] > 0] = color_dict[colors[i]]
+        else:
+            fatal_error("All elements of the 'colors' list must be either str or tuple")
+        colored_img = colored_img + mask
+
 
     if params.debug == 'print':
         print_image(colored_img, os.path.join(params.debug_outdir, str(params.device) + '_classes_plot.png'))

--- a/plantcv/plantcv/visualize/histogram.py
+++ b/plantcv/plantcv/visualize/histogram.py
@@ -6,21 +6,25 @@ import numpy as np
 from plantcv.plantcv.threshold import binary as binary_threshold
 from plantcv.plantcv import params
 import pandas as pd
-from plotnine import ggplot, aes, geom_line, scale_x_continuous
+from plotnine import ggplot, aes, geom_line, scale_x_continuous, labels
 
 
 
-def histogram(gray_img, mask=None, bins=256):
+def histogram(gray_img, mask=None, bins=256, color='red', title=None):
     """Plot a histogram using ggplot.
 
     Inputs:
     gray_img = grayscale image to analyze
     mask     = binary mask made from selected contours
     bins     = number of classes to divide spectrum into
+    color    = color of the line drawn
+    title    = custom title for the plot gets drawn if title is not None
 
     :param gray_img: numpy.ndarray
     :param mask: numpy.ndarray
     :param bins: int
+    :param color: str
+    :param title: str
     :return bins: list
     :return hist: list
     :return fig_hist: ggplot
@@ -70,11 +74,19 @@ def histogram(gray_img, mask=None, bins=256):
     bin_labels = np.arange(0, bins)
     dataset = pd.DataFrame({'Grayscale pixel intensity': bin_labels,
                             'Proportion of pixels (%)': hist_x})
-    fig_hist = (ggplot(data=dataset,
-                       mapping=aes(x='Grayscale pixel intensity',
-                                   y='Proportion of pixels (%)'))
-                + geom_line(color='red')
-                + scale_x_continuous(breaks=list(range(0, bins, 25))))
+    if title is None:
+        fig_hist = (ggplot(data=dataset,
+                           mapping=aes(x='Grayscale pixel intensity',
+                                       y='Proportion of pixels (%)'))
+                    + geom_line(color=color)
+                    + scale_x_continuous(breaks=list(range(0, bins, 25))))
+    elif title is not None:
+        fig_hist = (ggplot(data=dataset,
+                           mapping=aes(x='Grayscale pixel intensity',
+                                       y='Proportion of pixels (%)'))
+                    + geom_line(color=color)
+                    + scale_x_continuous(breaks=list(range(0, bins, 25)))
+                    + labels.ggtitle(title))
     params.debug=debug
     if params.debug is not None:
         if params.debug == "print":

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3332,7 +3332,7 @@ def test_plantcv_visualize_histogram():
     pcv.params.debug = "print"
     img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_GRAY), -1)
     mask = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_BINARY), -1)
-    _ = pcv.visualize.histogram(gray_img=np.uint16(img), mask=mask, bins=200)
+    _ = pcv.visualize.histogram(gray_img=np.uint16(img), mask=mask, bins=200, title='Include Title')
     # Test in plot mode
     pcv.params.debug = "plot"
     hist_header, hist_data, fig_hist = pcv.visualize.histogram(gray_img=img)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3313,14 +3313,14 @@ def test_plantcv_visualize_colorize_masks_bad_input_mismatch_number():
         _ = pcv.visualize.colorize_masks(masks=[mask['plant'], mask['background']], colors=['red', 'green', 'blue'])
 
 
-def test_plantcv_visualize_colorize_masks_bad_input_mismatch_type():
+def test_plantcv_visualize_colorize_masks_bad_color_input():
     # Read in test data
     img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_COLOR))
     # Test with debug = "print"
     pcv.params.debug = "print"
     mask = pcv.naive_bayes_classifier(rgb_img=img, pdf_file=os.path.join(TEST_DATA, TEST_PDFS))
     with pytest.raises(RuntimeError):
-        _ = pcv.visualize.colorize_masks(masks=[mask['plant'], mask['background']], colors=['red', (0,0,0)])
+        _ = pcv.visualize.colorize_masks(masks=[mask['plant'], mask['background']], colors=['red', 1.123])
 
 
 def test_plantcv_visualize_histogram():


### PR DESCRIPTION
## Visualize functions options 

### Description
- I had written colorize_masks to take either a list of strings (from the dictionary of potential colors) or a list of tuples, so users could specify their own colors. But now they can list either type of color.
- Allow users to pick the color of the line plot in their histogram and give them the option to title the histogram plot as well. Update testing to cover new if statement.

### Checklist:

- [x] Relevant tests (and test data) have been added or updated and passed.
- [x] The documentation was added or updated.
- [x] Relevant issues were updated or added.
