### PR TITLE
removed matplotlib dpi when using cv2.imwrite

### DIFF
--- a/plantcv/plantcv/print_image.py
+++ b/plantcv/plantcv/print_image.py
@@ -22,7 +22,6 @@ def print_image(img, filename):
     # Print numpy array type images
     image_type = type(img)
     if image_type == numpy.ndarray:
-        matplotlib.rcParams['figure.dpi'] = params.dpi
         cv2.imwrite(filename, img)
 
     # Print matplotlib type images

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3091,7 +3091,6 @@ def test_plantcv_morphology_check_cycles():
     os.mkdir(cache_dir)
     pcv.params.debug_outdir = cache_dir
     mask = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_BINARY), -1)
-    pcv.params.line_thickness=10
     pcv.params.debug = "print"
     _ = pcv.morphology.check_cycles(mask)
     pcv.params.debug = "plot"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3091,6 +3091,7 @@ def test_plantcv_morphology_check_cycles():
     os.mkdir(cache_dir)
     pcv.params.debug_outdir = cache_dir
     mask = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_BINARY), -1)
+    pcv.params.line_thickness=10
     pcv.params.debug = "print"
     _ = pcv.morphology.check_cycles(mask)
     pcv.params.debug = "plot"


### PR DESCRIPTION
Removes extraneous matplotlib dpi setting when writing an array to file with `cv2.imwrite()`

closes #406 