### PR TITLE
Restore pseudocolor mask functionality

### DIFF
--- a/plantcv/plantcv/visualize/pseudocolor.py
+++ b/plantcv/plantcv/visualize/pseudocolor.py
@@ -112,7 +112,7 @@ def pseudocolor(gray_img, obj=None, mask=None, cmap=None, background="image", mi
                 "Background type {0} is not supported. Please use 'white', 'black', or 'image'.".format(background))
 
         # Pseudocolor the image, plot the background first
-        pseudo_img1 = plt.imshow(bkg_img, cmap=bkg_cmap, vmin=min_value, vmax=max_value)
+        pseudo_img1 = plt.imshow(bkg_img, cmap=bkg_cmap)
         # Overlay the masked grayscale image with the user input colormap
         plt.imshow(masked_img, cmap=cmap, vmin=min_value, vmax=max_value)
 

--- a/plantcv/plantcv/visualize/pseudocolor.py
+++ b/plantcv/plantcv/visualize/pseudocolor.py
@@ -90,7 +90,7 @@ def pseudocolor(gray_img, obj=None, mask=None, cmap=None, background="image", mi
                                       value=(0, 0, 0))
 
         # Apply the mask
-        masked_img = np.ma.array(gray_img1, mask=mask.astype(np.bool))
+        masked_img = np.ma.array(gray_img1, mask=~mask.astype(np.bool))
 
         # Set the background color or type
         if background.upper() == "BLACK":


### PR DESCRIPTION
<!--- 
Thanks for contributing! Instructions are in comments, like this.
 
Please edit this template before submitting a new pull request.
-->

<!--- 
Title: Please provide a descriptive title that summarizes your pull request. 
-->

<!---
Labels: Please select one or more relevant tags (menu on the right).
(This only shows up for administrators.)
--->

### Description
<!--- 
Describe your changes, for example:
* What did you change/add and why?
* Does it close an open issue? (if so, please link to the issue)
* Have you tested the changes, and if so, how?
-->

In the pseudocolor function the mask needs to be inverted, this pull request restores the previous functionality. Scaling (using vmin and vmax) of the background image is removed.

### Types of changes
<!---
Is this a: 
* Bug fix?
* New feature?
* Does it change existing functionality?
-->
Bug fix.


### Checklist:

- [x] Relevant tests (and test data) have been added or updated and passed.
- [x] The documentation was added or updated.
- [x] Relevant issues were updated or added.
