### PR TITLE
update roi_objects

### DIFF
--- a/plantcv/plantcv/roi_objects.py
+++ b/plantcv/plantcv/roi_objects.py
@@ -60,19 +60,23 @@ def roi_objects(img, roi_contour, roi_hierarchy, object_contour, obj_hierarchy, 
                 if int(pptest) != -1:
                     keep = True
             if keep:
-                # Color the "gap contours" white
+                # Color the "gap contours" black
                 if obj_hierarchy[0][c][3] > -1:
                     cv2.drawContours(mask, object_contour, c, (0), -1, lineType=8, hierarchy=obj_hierarchy)
                 else:
-                    # Color the plant contour parts black
+                    # Color the plant contour parts white
                     cv2.drawContours(mask, object_contour, c, (255), -1, lineType=8, hierarchy=obj_hierarchy)
             else:
-                # If the contour isn't overlapping with the ROI, color it white
+                # If the contour isn't overlapping with the ROI, color it black
                 cv2.drawContours(mask, object_contour, c, (0), -1, lineType=8, hierarchy=obj_hierarchy)
 
         # Find the kept contours and area
         kept_cnt, kept_hierarchy = cv2.findContours(np.copy(mask), cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
         obj_area = cv2.countNonZero(mask)
+
+        # If no objects were found partially within the ROI then fail
+        if obj_area == 0:
+            fatal_error("No objects found are within or overlap with the ROI")
 
         # Find the largest contour if roi_type is set to 'largest'
         if roi_type.upper() == 'LARGEST':
@@ -81,8 +85,9 @@ def roi_objects(img, roi_contour, roi_hierarchy, object_contour, obj_hierarchy, 
                   "subcontours will be dropped.")
             # Find the index of the largest contour in the list of contours
             largest_area = 0
+            index = 0
             for c, cnt in enumerate(kept_cnt):
-                area = cv2.contourArea(cnt)
+                area = len(cnt)
                 if area > largest_area:
                     largest_area = area
                     index = c

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2612,6 +2612,20 @@ def test_plantcv_roi_objects_grayscale_input():
     assert len(kept_contours) == 1046
 
 
+def test_plantcv_roi_objects_no_objects():
+    # Read in test data
+    img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_COLOR), 0)
+    roi_npz = np.load(os.path.join(TEST_DATA, TEST_INPUT_ROI), encoding="latin1")
+    roi_contour = [np.array([[[750, 750]],[[750, 849]],[[799, 849]],[[799, 750]]])]
+    roi_hierarchy = roi_npz['arr_1']
+    contours_npz = np.load(os.path.join(TEST_DATA, TEST_INPUT_CONTOURS1), encoding="latin1")
+    object_contours = contours_npz['arr_0']
+    object_hierarchy = contours_npz['arr_1']
+    with pytest.raises(RuntimeError):
+        _ = pcv.roi_objects(img=img, roi_type="partial", roi_contour=roi_contour, roi_hierarchy=roi_hierarchy,
+                            object_contour=object_contours, obj_hierarchy=object_hierarchy)
+
+
 def test_plantcv_rotate():
     # Test cache directory
     cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_rotate_img")


### PR DESCRIPTION

### Description
* closes #420 
* Update method for determining size of contours
* Add error that will trip if no objects are found within the ROI in order to avoid index error
- change method for comparing size of contours in roi_objects for the functionality where roi_type = 'largest'
-  update comments to be accurate for what is happening while sorting through contours to see if they are within the provided ROI
- add unit test

### Types of changes 
* Bug fix
### Checklist:

- [x] Relevant tests (and test data) have been added or updated and passed.
- [x] The documentation was added or updated.
- [x] Relevant issues were updated or added.
