### PR TITLE
Remove version restriction

### DIFF
--- a/docs/closing.md
+++ b/docs/closing.md
@@ -8,7 +8,7 @@ Filters out dark noise from an image.
 
 - **Parameters:**
     - gray_img - Grayscale or binary image data
-    - kernel - Optional neighborhood, expressed as an array of 1's and 0's. If None, 
+    - kernel - Optional neighborhood, expressed as an array of 1's and 0's. See the [kernel making](get_kernel.md) function. If None, 
     use cross-shaped structuring element.
   - **Context:**
     - Used to reduce image noise, specifically small dark spots (i.e. "pepper").
@@ -23,8 +23,7 @@ from plantcv import plantcv as pcv
 pcv.params.debug = "print"
 
 # Apply closing
-
-filtered_img = pcv.closing(gray_img)
+filtered_img = pcv.closing(gray_img=gray_img)
 
 ```
 
@@ -35,3 +34,18 @@ filtered_img = pcv.closing(gray_img)
 **Closing**
 
 ![Screenshot](img/documentation_images/closing/after_closing.jpg)
+
+
+In addition to the [kernel making](get_kernel.md) function users can create custom kernel shapes. 
+```python
+
+from plantcv import plantcv as pcv
+import numpy as np
+
+# Set global debug behavior to None (default), "print" (to file), or "plot" (Jupyter Notebooks or X11)
+pcv.params.debug = "print"
+
+# Apply closing with an X-shaped kernel 
+filtered_img = pcv.closing(gray_img=gray_img, kernel=np.array([[1, 0, 1], [0, 1, 0], [1, 0, 1]]))
+
+```

--- a/docs/get_kernel.md
+++ b/docs/get_kernel.md
@@ -1,0 +1,48 @@
+## Get Kernel
+
+Create a kernel structuring element
+
+**plantcv.get_kernel**(*size, shape*)
+
+**returns** filtered_img
+
+- **Parameters:**
+    - size - Kernel size (n,m). A (m x n) kernel will be built. Must be greater than 1 to have an effect.
+    - shape - Element shape, either "rectangle", "cross", or "ellipse".
+  - **Context:**
+    - Create a kernel structuring element to be used in various filter functions i.e. [closing](closing.md) and [opening](opening.md)
+- **Example use:**
+    - See below
+
+```python
+
+from plantcv import plantcv as pcv
+
+# get a rectangular kernel
+rectangle_kernel = pcv.get_kernel(size=(3,4), shape="rectangle")
+print(rectangle_kernel)
+[[1 1 1]
+ [1 1 1]
+ [1 1 1]
+ [1 1 1]]
+ 
+ # get an elliptical kernel
+ellipse_kernel = pcv.get_kernel(size=(7,7), shape="ellipse")
+print(ellipse_kernel)
+[[0 0 0 1 0 0 0]
+ [0 1 1 1 1 1 0]
+ [1 1 1 1 1 1 1]
+ [1 1 1 1 1 1 1]
+ [1 1 1 1 1 1 1]
+ [0 1 1 1 1 1 0]
+ [0 0 0 1 0 0 0]]
+ 
+ # get a cross shaped kernel
+cross_kernel = pcv.get_kernel(size=(5,3), shape="cross")
+print(cross_kernel)
+[[0 0 1 0 0]
+ [1 1 1 1 1]
+ [0 0 1 0 0]]
+
+```
+

--- a/docs/opening.md
+++ b/docs/opening.md
@@ -8,7 +8,7 @@ Filters out bright noise from an image.
 
 - **Parameters:**
     - gray_img - Grayscale or binary image data
-    - kernel - Optional neighborhood, expressed as an array of 1's and 0's. If None, 
+    - kernel - Optional neighborhood, expressed as an array of 1's and 0's. See the [kernel making](get_kernel.md) function. If None, 
     use cross-shaped structuring element.
   - **Context:**
     - Used to reduce image noise, specifically small bright spots (i.e. "salt").
@@ -23,8 +23,7 @@ from plantcv import plantcv as pcv
 pcv.params.debug = "print"
 
 # Apply opening
-
-filtered_img = pcv.opening(gray_img)
+filtered_img = pcv.opening(gray_img=gray_img)
 
 ```
 
@@ -35,3 +34,17 @@ filtered_img = pcv.opening(gray_img)
 **Opening**
 
 ![Screenshot](img/documentation_images/opening/after_opening.jpg)
+
+In addition to the [kernel making](get_kernel.md) function users can create custom kernel shapes. 
+```python
+
+from plantcv import plantcv as pcv
+import numpy as np
+
+# Set global debug behavior to None (default), "print" (to file), or "plot" (Jupyter Notebooks or X11)
+pcv.params.debug = "print"
+
+# Apply opening with an X-shaped kernel 
+filtered_img = pcv.opening(gray_img=gray_img, kernel=np.array([[1, 0, 1], [0, 1, 0], [1, 0, 1]]))
+
+```

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pandas
   - python-dateutil
   - scipy < 1.3
-  - scikit-image<0.15
+  - scikit-image==0.14.2
   - pytest
   - plotnine
   - coveralls

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
       - 'Sobel Filter': sobel_filter.md
       - 'Scharr Filter': scharr_filter.md
     - 'Gaussian Blur': gaussian_blur.md
+    - 'Get Kernel': get_kernel.md
     - 'Get NIR Images': get_nir.md
     - 'Erosion': erode.md
     - 'Fill Objects': fill.md

--- a/plantcv/plantcv/__init__.py
+++ b/plantcv/plantcv/__init__.py
@@ -167,6 +167,7 @@ from plantcv.plantcv.analyze_thermal_values import analyze_thermal_values
 from plantcv.plantcv import visualize
 from plantcv.plantcv import morphology
 from plantcv.plantcv.fill_holes import fill_holes
+from plantcv.plantcv.get_kernel import get_kernel
 
 # add new functions to end of lists
 
@@ -182,7 +183,7 @@ __all__ = ['fatal_error', 'print_image', 'plot_image', 'color_palette', 'apply_m
            'cluster_contour_splitimg', 'rotate', 'shift_img', 'output_mask', 'auto_crop', 'canny_edge_detect',
            'background_subtraction', 'naive_bayes_classifier', 'acute', 'distance_transform', 'params',
            'cluster_contour_mask','analyze_thermal_values', 'opening',
-           'closing','within_frame', 'fill_holes']
+           'closing','within_frame', 'fill_holes', 'get_kernel']
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/plantcv/plantcv/get_kernel.py
+++ b/plantcv/plantcv/get_kernel.py
@@ -30,6 +30,11 @@ def get_kernel(size, shape):
         kernel = getStructuringElement(cv2.MORPH_RECT, size)
     elif shape.upper() == "ELLIPSE ":
         kernel = getStructuringElement(cv2.MORPH_ELLIPSE, size)
+    elif shape.upper() == "CROSS":
+        kernel = getStructuringElement(cv2.MORPH_CROSS, size)
+    else:
+
+
 
 
 

--- a/plantcv/plantcv/get_kernel.py
+++ b/plantcv/plantcv/get_kernel.py
@@ -1,12 +1,7 @@
 # Create a kernel structuring element
 
-from cv2 import getStructuringElement,
-import numpy as np
-import os
-from plantcv.plantcv import print_image
-from plantcv.plantcv import plot_image
-from plantcv.plantcv import params
-
+import cv2
+from plantcv.plantcv import fatal_error
 
 
 def get_kernel(size, shape):
@@ -16,26 +11,23 @@ def get_kernel(size, shape):
     shape  = Element shape, either rectangle, cross, or ellipse.
 
     Returns:
-    kernel = Structuring element kernel
+    kernel = Numpy array structuring element kernel
 
     :param size: tuple
     :param shape: str
     :return kernel: numpy.ndarray
     """
 
-    if size <= 1:
+    if size[0] <= 1 and size[1] <= 1:
         raise ValueError('size needs to be greater than 1 for the function to have an effect')
 
     if shape.upper() == "RECTANGLE":
-        kernel = getStructuringElement(cv2.MORPH_RECT, size)
-    elif shape.upper() == "ELLIPSE ":
-        kernel = getStructuringElement(cv2.MORPH_ELLIPSE, size)
+        kernel = cv2.getStructuringElement(cv2.MORPH_RECT, size)
+    elif shape.upper() == "ELLIPSE":
+        kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, size)
     elif shape.upper() == "CROSS":
-        kernel = getStructuringElement(cv2.MORPH_CROSS, size)
+        kernel = cv2.getStructuringElement(cv2.MORPH_CROSS, size)
     else:
-
-
-
-
+        fatal_error("Shape " + str(shape) + " is not rectangle, ellipse or cross!")
 
     return kernel

--- a/plantcv/plantcv/get_kernel.py
+++ b/plantcv/plantcv/get_kernel.py
@@ -10,16 +10,20 @@ from plantcv.plantcv import params
 
 
 def get_kernel(size, shape):
-    """Performs morphological 'dilation' filtering. Adds pixel to center of kernel if conditions set in kernel are true.
-    Inputs:
-    size   = Kernel size (int). A k x k kernel will be built. Must be greater than 1 to have an effect.
-    shape  = Element shape, either
+    """Creates a kernel structuring element of specified size and shape.
+
+    size   = Kernel size (int). A (m x n) kernel will be built. Must be greater than 1 to have an effect.
+    shape  = Element shape, either rectangle, cross, or ellipse.
 
     Returns:
-    dil_img = dilated image
+    kernel = Structuring element kernel
 
-    :param gray_img: numpy.ndarray
-    :param ksize: int
-    :param i: int
-    :return dil_img: numpy.ndarray
+    :param size: tuple
+    :param shape: str
+    :return kernel: numpy.ndarray
     """
+
+    if size <= 1:
+        raise ValueError('size needs to be greater than 1 for the function to have an effect')
+
+

--- a/plantcv/plantcv/get_kernel.py
+++ b/plantcv/plantcv/get_kernel.py
@@ -1,0 +1,25 @@
+# Create a kernel structuring element
+
+import cv2
+import numpy as np
+import os
+from plantcv.plantcv import print_image
+from plantcv.plantcv import plot_image
+from plantcv.plantcv import params
+
+
+
+def get_kernel(size, shape):
+    """Performs morphological 'dilation' filtering. Adds pixel to center of kernel if conditions set in kernel are true.
+    Inputs:
+    size   = Kernel size (int). A k x k kernel will be built. Must be greater than 1 to have an effect.
+    shape  = Element shape, either
+
+    Returns:
+    dil_img = dilated image
+
+    :param gray_img: numpy.ndarray
+    :param ksize: int
+    :param i: int
+    :return dil_img: numpy.ndarray
+    """

--- a/plantcv/plantcv/get_kernel.py
+++ b/plantcv/plantcv/get_kernel.py
@@ -1,6 +1,6 @@
 # Create a kernel structuring element
 
-import cv2
+from cv2 import getStructuringElement,
 import numpy as np
 import os
 from plantcv.plantcv import print_image
@@ -12,7 +12,7 @@ from plantcv.plantcv import params
 def get_kernel(size, shape):
     """Creates a kernel structuring element of specified size and shape.
 
-    size   = Kernel size (int). A (m x n) kernel will be built. Must be greater than 1 to have an effect.
+    size   = Kernel size (n,m). A (m x n) kernel will be built. Must be greater than 1 to have an effect.
     shape  = Element shape, either rectangle, cross, or ellipse.
 
     Returns:
@@ -26,4 +26,11 @@ def get_kernel(size, shape):
     if size <= 1:
         raise ValueError('size needs to be greater than 1 for the function to have an effect')
 
+    if shape.upper() == "RECTANGLE":
+        kernel = getStructuringElement(cv2.MORPH_RECT, size)
+    elif shape.upper() == "ELLIPSE ":
+        kernel = getStructuringElement(cv2.MORPH_ELLIPSE, size)
 
+
+
+    return kernel

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ numpy>=1.11
 pandas
 python-dateutil
 scipy < 1.3
-scikit-image
+scikit-image==0.14.2
 plotnine
 opencv-python<4, >=3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ numpy>=1.11
 pandas
 python-dateutil
 scipy < 1.3
-scikit-image<0.15
+scikit-image
 plotnine
 opencv-python<4, >=3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pandas
 python-dateutil
 scipy < 1.3
 scikit-image==0.14.2
-plotnine
+plotnine < 0.6
 opencv-python<4, >=3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pandas
 python-dateutil
 scipy < 1.3
 scikit-image==0.14.2
-plotnine < 0.6
+plotnine <= 0.5.1
 opencv-python<4, >=3.4

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1689,6 +1689,31 @@ def test_plantcv_gaussian_blur():
     assert gavg != imgavg
 
 
+def test_plantcv_get_kernel_cross():
+    kernel = pcv.get_kernel(size=(3,3), shape="cross")
+    assert (kernel == np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]])).all()
+
+
+def test_plantcv_get_kernel_rectangle():
+    kernel = pcv.get_kernel(size=(3,3), shape="rectangle")
+    assert (kernel == np.array([[1, 1, 1], [1, 1, 1], [1, 1, 1]])).all()
+
+
+def test_plantcv_get_kernel_ellipse():
+    kernel = pcv.get_kernel(size=(3, 3), shape="ellipse")
+    assert (kernel == np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]])).all()
+
+
+def test_plantcv_get_kernel_bad_input_size():
+    with pytest.raises(ValueError):
+        kernel = pcv.get_kernel(size=(1,1), shape="ellipse")
+
+
+def test_plantcv_get_kernel_bad_input_shape():
+    with pytest.raises(RuntimeError):
+        kernel = pcv.get_kernel(size=(3,1), shape="square")
+
+
 def test_plantcv_get_nir_sv():
     nirpath = pcv.get_nir(TEST_DATA, TEST_VIS)
     nirpath1 = os.path.join(TEST_DATA, TEST_NIR)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3953,7 +3953,8 @@ def test_plantcv_transform_find_color_card():
     cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_transform_find_color_card")
     os.mkdir(cache_dir)
     pcv.params.debug_outdir = cache_dir
-    df, start, space = pcv.transform.find_color_card(rgb_img=rgb_img, threshold_type='adaptgauss', blurry=False)
+    df, start, space = pcv.transform.find_color_card(rgb_img=rgb_img, threshold_type='adaptgauss', blurry=False,
+                                                     threshvalue=90)
     # Test with debug = "print"
     pcv.params.debug = "print"
     _ = pcv.transform.create_color_card_mask(rgb_img=rgb_img, radius=6, start_coord=start,
@@ -3980,7 +3981,7 @@ def test_plantcv_transform_find_color_card_optional_parameters():
     pcv.params.debug_outdir = cache_dir
     # Test with threshold ='normal'
     df1, start1, space1 = pcv.transform.find_color_card(rgb_img=rgb_img, threshold_type='normal', blurry=True,
-                                                        background='light')
+                                                        background='light', threshvalue=90)
     _ = pcv.transform.create_color_card_mask(rgb_img=rgb_img, radius=6, start_coord=start1,
                                              spacing=space1, nrows=6, ncols=4, exclude=[20, 0])
     # Test with threshold='otsu'


### PR DESCRIPTION
Allow scikit-image to use best available version

<!--- 
Thanks for contributing! Instructions are in comments, like this.
 
Please edit this template before submitting a new pull request.
-->

<!--- 
Title: Please provide a descriptive title that summarizes your pull request. 
-->

<!---
Labels: Please select one or more relevant tags (menu on the right).
(This only shows up for administrators.)
--->

### Description
<!--- 
Describe your changes, for example:
* What did you change/add and why?
* Does it close an open issue? (if so, please link to the issue)
* Have you tested the changes, and if so, how?
-->
We currently restrict scikit-image to use version <0.15. This can create an issue on Windows reported in #428 where v0.14.3 is installed but is not working on Windows (https://github.com/pyxem/pyxem/issues/422).

This pull request updates the version limitation in `requirements.txt` to limit the scikit-image version.

Added new function to create structuring elements more easily (`pcv.get_kernel`). Also add example of defining a custom kernel in the documentation. Closes #427 


### Types of changes
<!---
Is this a: 
* Bug fix?
* New feature?
* Does it change existing functionality?
-->
Bug fix (Windows)

### Checklist:

- [x] Relevant tests (and test data) have been added or updated and passed.
- [x] The documentation was added or updated.
- [x] Relevant issues were updated or added.
