### PR TITLE
Enhance pcv.roi_objects

### DIFF
--- a/docs/multi-plant_tutorial.md
+++ b/docs/multi-plant_tutorial.md
@@ -227,10 +227,10 @@ Use the [binary threshold](binary_threshold.md) function to threshold green-mage
 
     # STEP 7: Fill in small objects (speckles)
     # Inputs:
-    #    gray_img = image object, grayscale. img will be returned after filling
+    #    bin_img  = image object, grayscale. img will be returned after filling
     #    size     = minimum object area size in pixels (integer)
     
-    fill_image = pcv.fill(gray_img=img_binary, size=10)
+    fill_image = pcv.fill(bin_img=img_binary, size=10)
     #                                                ^
     #                                                |
     #                                 adjust this value
@@ -540,10 +540,10 @@ def main():
     
     # STEP 7: Fill in small objects (speckles)
     # Inputs:
-    #    img  = image object, grayscale. img will be returned after filling
+    #    bin_img  = image object, binary. img will be returned after filling
     #    size = minimum object area size in pixels (integer)
     
-    fill_image = pcv.fill(img=img_binary, size=100)
+    fill_image = pcv.fill(bin_img=img_binary, size=100)
     #                                          ^
     #                                          |
     #                           adjust this value

--- a/docs/roi_multi.md
+++ b/docs/roi_multi.md
@@ -71,7 +71,7 @@ for i in range(0, len(rois1)):
     plant_contour, plant_mask = pcv.object_composition(img=img, contours=filtered_contours, hierarchy=filtered_hierarchy)        
     
     # Analyze the shape of each plant 
-    shape_data_headers, shape_data, analysis_images = pcv.analyze_object(img=img_copy, obj=plant_contour, mask=plant_mask)
+    analysis_images = pcv.analyze_object(img=img_copy, obj=plant_contour, mask=plant_mask)
     
     # Save the image with shape characteristics 
     img_copy = analysis_images[0]

--- a/plantcv/plantcv/analyze_color.py
+++ b/plantcv/plantcv/analyze_color.py
@@ -165,51 +165,70 @@ def analyze_color(rgb_img, mask, hist_plot_type=None):
     percent_values = [round((i / 255) * 100, 2) for i in range(0, 256)]
     # Diverging values on a -128 to 127 scale (green-magenta and blue-yellow)
     diverging_values = [i for i in range(-128, 128)]
-    # outputs.measurements['color_data'] = {
-    #     'histograms': {
-    #         'blue': {'signal_values': rgb_values, 'frequency': histograms["b"]["hist"]},
-    #         'green': {'signal_values': rgb_values, 'frequency': histograms["g"]["hist"]},
-    #         'red': {'signal_values': rgb_values, 'frequency': histograms["r"]["hist"]},
-    #         'lightness': {'signal_values': percent_values, 'frequency': histograms["l"]["hist"]},
-    #         'green-magenta': {'signal_values': diverging_values, 'frequency': histograms["m"]["hist"]},
-    #         'blue-yellow': {'signal_values': diverging_values, 'frequency': histograms["y"]["hist"]},
-    #         'hue': {'signal_values': hue_values, 'frequency': histograms["h"]["hist"]},
-    #         'saturation': {'signal_values': percent_values, 'frequency': histograms["s"]["hist"]},
-    #         'value': {'signal_values': percent_values, 'frequency': histograms["v"]["hist"]}
-    #     },
-    #     'color_features': {
-    #         'hue_circular_mean': hue_circular_mean,
-    #         'hue_circular_std': hue_circular_std,
-    #         'hue_median': hue_median
-    #     }
-    # }
-    outputs.add_observation(variable='blue_frequencies', trait='blue frequencies',
-                            method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                            value=histograms["b"]["hist"], label=rgb_values)
-    outputs.add_observation(variable='green_frequencies', trait='green frequencies',
-                            method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                            value=histograms["g"]["hist"], label=rgb_values)
-    outputs.add_observation(variable='red_frequencies', trait='red frequencies',
-                            method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                            value=histograms["r"]["hist"], label=rgb_values)
-    outputs.add_observation(variable='lightness_frequencies', trait='lightness frequencies',
-                            method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                            value=histograms["l"]["hist"], label=percent_values)
-    outputs.add_observation(variable='green-magenta_frequencies', trait='green-magenta frequencies',
-                            method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                            value=histograms["m"]["hist"], label=diverging_values)
-    outputs.add_observation(variable='blue-yellow_frequencies', trait='blue-yellow frequencies',
-                            method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                            value=histograms["y"]["hist"], label=diverging_values)
-    outputs.add_observation(variable='hue_frequencies', trait='hue frequencies',
-                            method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                            value=histograms["h"]["hist"][0:180], label=hue_values)
-    outputs.add_observation(variable='saturation_frequencies', trait='saturation frequencies',
-                            method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                            value=histograms["s"]["hist"], label=percent_values)
-    outputs.add_observation(variable='value_frequencies', trait='value frequencies',
-                            method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                            value=histograms["v"]["hist"], label=percent_values)
+
+    if hist_plot_type.upper() == 'RGB':
+        outputs.add_observation(variable='blue_frequencies', trait='blue frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["b"]["hist"], label=rgb_values)
+        outputs.add_observation(variable='green_frequencies', trait='green frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["g"]["hist"], label=rgb_values)
+        outputs.add_observation(variable='red_frequencies', trait='red frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["r"]["hist"], label=rgb_values)
+
+    elif hist_plot_type.upper() == 'LAB':
+        outputs.add_observation(variable='lightness_frequencies', trait='lightness frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["l"]["hist"], label=percent_values)
+        outputs.add_observation(variable='green-magenta_frequencies', trait='green-magenta frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["m"]["hist"], label=diverging_values)
+        outputs.add_observation(variable='blue-yellow_frequencies', trait='blue-yellow frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["y"]["hist"], label=diverging_values)
+
+    elif hist_plot_type.upper() == 'HSV':
+        outputs.add_observation(variable='hue_frequencies', trait='hue frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["h"]["hist"][0:180], label=hue_values)
+        outputs.add_observation(variable='saturation_frequencies', trait='saturation frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["s"]["hist"], label=percent_values)
+        outputs.add_observation(variable='value_frequencies', trait='value frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["v"]["hist"], label=percent_values)
+
+    elif hist_plot_type.upper() == 'ALL':
+
+        outputs.add_observation(variable='blue_frequencies', trait='blue frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["b"]["hist"], label=rgb_values)
+        outputs.add_observation(variable='green_frequencies', trait='green frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["g"]["hist"], label=rgb_values)
+        outputs.add_observation(variable='red_frequencies', trait='red frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["r"]["hist"], label=rgb_values)
+        outputs.add_observation(variable='lightness_frequencies', trait='lightness frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["l"]["hist"], label=percent_values)
+        outputs.add_observation(variable='green-magenta_frequencies', trait='green-magenta frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["m"]["hist"], label=diverging_values)
+        outputs.add_observation(variable='blue-yellow_frequencies', trait='blue-yellow frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["y"]["hist"], label=diverging_values)
+        outputs.add_observation(variable='hue_frequencies', trait='hue frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["h"]["hist"][0:180], label=hue_values)
+        outputs.add_observation(variable='saturation_frequencies', trait='saturation frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["s"]["hist"], label=percent_values)
+        outputs.add_observation(variable='value_frequencies', trait='value frequencies',
+                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                value=histograms["v"]["hist"], label=percent_values)
+    # Always save hue stats
     outputs.add_observation(variable='hue_circular_mean', trait='hue circular mean',
                             method='plantcv.plantcv.analyze_color', scale='degrees', datatype=float,
                             value=hue_circular_mean, label='degrees')

--- a/plantcv/plantcv/analyze_color.py
+++ b/plantcv/plantcv/analyze_color.py
@@ -165,69 +165,69 @@ def analyze_color(rgb_img, mask, hist_plot_type=None):
     percent_values = [round((i / 255) * 100, 2) for i in range(0, 256)]
     # Diverging values on a -128 to 127 scale (green-magenta and blue-yellow)
     diverging_values = [i for i in range(-128, 128)]
+    if hist_plot_type is not None:
+        if hist_plot_type.upper() == 'RGB':
+            outputs.add_observation(variable='blue_frequencies', trait='blue frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["b"]["hist"], label=rgb_values)
+            outputs.add_observation(variable='green_frequencies', trait='green frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["g"]["hist"], label=rgb_values)
+            outputs.add_observation(variable='red_frequencies', trait='red frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["r"]["hist"], label=rgb_values)
 
-    if hist_plot_type.upper() == 'RGB':
-        outputs.add_observation(variable='blue_frequencies', trait='blue frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["b"]["hist"], label=rgb_values)
-        outputs.add_observation(variable='green_frequencies', trait='green frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["g"]["hist"], label=rgb_values)
-        outputs.add_observation(variable='red_frequencies', trait='red frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["r"]["hist"], label=rgb_values)
+        elif hist_plot_type.upper() == 'LAB':
+            outputs.add_observation(variable='lightness_frequencies', trait='lightness frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["l"]["hist"], label=percent_values)
+            outputs.add_observation(variable='green-magenta_frequencies', trait='green-magenta frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["m"]["hist"], label=diverging_values)
+            outputs.add_observation(variable='blue-yellow_frequencies', trait='blue-yellow frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["y"]["hist"], label=diverging_values)
 
-    elif hist_plot_type.upper() == 'LAB':
-        outputs.add_observation(variable='lightness_frequencies', trait='lightness frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["l"]["hist"], label=percent_values)
-        outputs.add_observation(variable='green-magenta_frequencies', trait='green-magenta frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["m"]["hist"], label=diverging_values)
-        outputs.add_observation(variable='blue-yellow_frequencies', trait='blue-yellow frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["y"]["hist"], label=diverging_values)
+        elif hist_plot_type.upper() == 'HSV':
+            outputs.add_observation(variable='hue_frequencies', trait='hue frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["h"]["hist"][0:180], label=hue_values)
+            outputs.add_observation(variable='saturation_frequencies', trait='saturation frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["s"]["hist"], label=percent_values)
+            outputs.add_observation(variable='value_frequencies', trait='value frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["v"]["hist"], label=percent_values)
 
-    elif hist_plot_type.upper() == 'HSV':
-        outputs.add_observation(variable='hue_frequencies', trait='hue frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["h"]["hist"][0:180], label=hue_values)
-        outputs.add_observation(variable='saturation_frequencies', trait='saturation frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["s"]["hist"], label=percent_values)
-        outputs.add_observation(variable='value_frequencies', trait='value frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["v"]["hist"], label=percent_values)
+        elif hist_plot_type.upper() == 'ALL':
 
-    elif hist_plot_type.upper() == 'ALL':
-
-        outputs.add_observation(variable='blue_frequencies', trait='blue frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["b"]["hist"], label=rgb_values)
-        outputs.add_observation(variable='green_frequencies', trait='green frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["g"]["hist"], label=rgb_values)
-        outputs.add_observation(variable='red_frequencies', trait='red frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["r"]["hist"], label=rgb_values)
-        outputs.add_observation(variable='lightness_frequencies', trait='lightness frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["l"]["hist"], label=percent_values)
-        outputs.add_observation(variable='green-magenta_frequencies', trait='green-magenta frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["m"]["hist"], label=diverging_values)
-        outputs.add_observation(variable='blue-yellow_frequencies', trait='blue-yellow frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["y"]["hist"], label=diverging_values)
-        outputs.add_observation(variable='hue_frequencies', trait='hue frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["h"]["hist"][0:180], label=hue_values)
-        outputs.add_observation(variable='saturation_frequencies', trait='saturation frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["s"]["hist"], label=percent_values)
-        outputs.add_observation(variable='value_frequencies', trait='value frequencies',
-                                method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                value=histograms["v"]["hist"], label=percent_values)
+            outputs.add_observation(variable='blue_frequencies', trait='blue frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["b"]["hist"], label=rgb_values)
+            outputs.add_observation(variable='green_frequencies', trait='green frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["g"]["hist"], label=rgb_values)
+            outputs.add_observation(variable='red_frequencies', trait='red frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["r"]["hist"], label=rgb_values)
+            outputs.add_observation(variable='lightness_frequencies', trait='lightness frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["l"]["hist"], label=percent_values)
+            outputs.add_observation(variable='green-magenta_frequencies', trait='green-magenta frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["m"]["hist"], label=diverging_values)
+            outputs.add_observation(variable='blue-yellow_frequencies', trait='blue-yellow frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["y"]["hist"], label=diverging_values)
+            outputs.add_observation(variable='hue_frequencies', trait='hue frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["h"]["hist"][0:180], label=hue_values)
+            outputs.add_observation(variable='saturation_frequencies', trait='saturation frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["s"]["hist"], label=percent_values)
+            outputs.add_observation(variable='value_frequencies', trait='value frequencies',
+                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
+                                    value=histograms["v"]["hist"], label=percent_values)
     # Always save hue stats
     outputs.add_observation(variable='hue_circular_mean', trait='hue circular mean',
                             method='plantcv.plantcv.analyze_color', scale='degrees', datatype=float,

--- a/plantcv/plantcv/analyze_color.py
+++ b/plantcv/plantcv/analyze_color.py
@@ -166,7 +166,7 @@ def analyze_color(rgb_img, mask, hist_plot_type=None):
     # Diverging values on a -128 to 127 scale (green-magenta and blue-yellow)
     diverging_values = [i for i in range(-128, 128)]
     if hist_plot_type is not None:
-        if hist_plot_type.upper() == 'RGB':
+        if hist_plot_type.upper() == 'RGB' or hist_plot_type.upper() == 'ALL':
             outputs.add_observation(variable='blue_frequencies', trait='blue frequencies',
                                     method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
                                     value=histograms["b"]["hist"], label=rgb_values)
@@ -177,7 +177,7 @@ def analyze_color(rgb_img, mask, hist_plot_type=None):
                                     method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
                                     value=histograms["r"]["hist"], label=rgb_values)
 
-        elif hist_plot_type.upper() == 'LAB':
+        elif hist_plot_type.upper() == 'LAB' or hist_plot_type.upper() == 'ALL':
             outputs.add_observation(variable='lightness_frequencies', trait='lightness frequencies',
                                     method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
                                     value=histograms["l"]["hist"], label=percent_values)
@@ -188,7 +188,7 @@ def analyze_color(rgb_img, mask, hist_plot_type=None):
                                     method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
                                     value=histograms["y"]["hist"], label=diverging_values)
 
-        elif hist_plot_type.upper() == 'HSV':
+        elif hist_plot_type.upper() == 'HSV' or hist_plot_type.upper() == 'ALL':
             outputs.add_observation(variable='hue_frequencies', trait='hue frequencies',
                                     method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
                                     value=histograms["h"]["hist"][0:180], label=hue_values)
@@ -199,35 +199,6 @@ def analyze_color(rgb_img, mask, hist_plot_type=None):
                                     method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
                                     value=histograms["v"]["hist"], label=percent_values)
 
-        elif hist_plot_type.upper() == 'ALL':
-
-            outputs.add_observation(variable='blue_frequencies', trait='blue frequencies',
-                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                    value=histograms["b"]["hist"], label=rgb_values)
-            outputs.add_observation(variable='green_frequencies', trait='green frequencies',
-                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                    value=histograms["g"]["hist"], label=rgb_values)
-            outputs.add_observation(variable='red_frequencies', trait='red frequencies',
-                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                    value=histograms["r"]["hist"], label=rgb_values)
-            outputs.add_observation(variable='lightness_frequencies', trait='lightness frequencies',
-                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                    value=histograms["l"]["hist"], label=percent_values)
-            outputs.add_observation(variable='green-magenta_frequencies', trait='green-magenta frequencies',
-                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                    value=histograms["m"]["hist"], label=diverging_values)
-            outputs.add_observation(variable='blue-yellow_frequencies', trait='blue-yellow frequencies',
-                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                    value=histograms["y"]["hist"], label=diverging_values)
-            outputs.add_observation(variable='hue_frequencies', trait='hue frequencies',
-                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                    value=histograms["h"]["hist"][0:180], label=hue_values)
-            outputs.add_observation(variable='saturation_frequencies', trait='saturation frequencies',
-                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                    value=histograms["s"]["hist"], label=percent_values)
-            outputs.add_observation(variable='value_frequencies', trait='value frequencies',
-                                    method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
-                                    value=histograms["v"]["hist"], label=percent_values)
     # Always save hue stats
     outputs.add_observation(variable='hue_circular_mean', trait='hue circular mean',
                             method='plantcv.plantcv.analyze_color', scale='degrees', datatype=float,

--- a/plantcv/plantcv/cluster_contours.py
+++ b/plantcv/plantcv/cluster_contours.py
@@ -65,15 +65,16 @@ def cluster_contours(img, roi_objects, roi_obj_hierarchy, nrow=1, ncol=1, show_g
         # if isinstance(step, int):
         #     i = step
         # else:
-        i = len(step)
-        for x in range(0, i):
+        num_bins = len(step)
+        for x in range(0, num_bins):
             if x == 0:
-                if a >= 0 and a < step[x + 1]:
-                    return x + 1
-            elif a >= step[x - 1] and a < step[x]:
-                return x
-            elif a > step[x - 1] and a > np.max(step):
-                return i
+                if a >= 0 and a < step[1]:
+                    return 1
+            else:
+                if a >= step[x - 1] and a < step[x]:
+                    return x
+                elif a >= np.max(step):
+                    return num_bins
 
     dtype = [('cx', int), ('cy', int), ('rowbin', int), ('colbin', int), ('index', int)]
     coord = []

--- a/plantcv/plantcv/cluster_contours.py
+++ b/plantcv/plantcv/cluster_contours.py
@@ -106,8 +106,9 @@ def cluster_contours(img, roi_objects, roi_obj_hierarchy, nrow=1, ncol=1, show_g
     coordgroups = []
 
     for i, y in enumerate(unigroup):
-        col = int(y[0])
-        row = int(y[2])
+        col_row = y.split(',')
+        col = int(col_row[0])
+        row = int(col_row[1])
         for a, b in enumerate(coord2):
             if b[2] == col and b[3] == row:
                 grp = i

--- a/plantcv/plantcv/roi_objects.py
+++ b/plantcv/plantcv/roi_objects.py
@@ -71,10 +71,6 @@ def roi_objects(img, roi_contour, roi_hierarchy, object_contour, obj_hierarchy, 
         kept_cnt, kept_hierarchy = cv2.findContours(np.copy(mask), cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
         obj_area = cv2.countNonZero(mask)
 
-        # If no objects were found partially within the ROI then fail
-        if obj_area == 0:
-            fatal_error("No objects found are within or overlap with the ROI")
-
         # Find the largest contour if roi_type is set to 'largest'
         if roi_type.upper() == 'LARGEST':
             # Print warning statement about this feature

--- a/plantcv/plantcv/roi_objects.py
+++ b/plantcv/plantcv/roi_objects.py
@@ -55,7 +55,7 @@ def roi_objects(img, roi_contour, roi_hierarchy, object_contour, obj_hierarchy, 
             keep = False
 
             # Test if the contours are within the ROI
-            pptest = [None]*(length+1)
+            pptest = np.zeros(length+1)
             for i in range(0, length):
                 pptest[i] = cv2.pointPolygonTest(roi_contour[0], (stack[i][0], stack[i][1]), False)
                 if any([int(i) != -1 for i in pptest]):

--- a/plantcv/plantcv/roi_objects.py
+++ b/plantcv/plantcv/roi_objects.py
@@ -55,10 +55,19 @@ def roi_objects(img, roi_contour, roi_hierarchy, object_contour, obj_hierarchy, 
             keep = False
 
             # Test if the contours are within the ROI
+            pptest = [None]*(length+1)
             for i in range(0, length):
-                pptest = cv2.pointPolygonTest(roi_contour[0], (stack[i][0], stack[i][1]), False)
-                if int(pptest) != -1:
+                pptest[i] = cv2.pointPolygonTest(roi_contour[0], (stack[i][0], stack[i][1]), False)
+                if any([int(i) != -1 for i in pptest]):
                     keep = True
+                elif all([int(i) == -1 for i in pptest]):
+                    M = cv2.moments(cnt)
+                    cX = int(M["m10"] / M["m00"])
+                    cY = int(M["m01"] / M["m00"])
+                    if int(cv2.pointPolygonTest(cnt, (cX,cY), False)) == 1:
+                        keep = True
+                    else:
+                        keep = False
             if keep:
                 # Color the "gap contours" black
                 if obj_hierarchy[0][c][3] > -1:

--- a/plantcv/plantcv/roi_objects.py
+++ b/plantcv/plantcv/roi_objects.py
@@ -1,6 +1,7 @@
 import cv2
 import numpy as np
 import os
+from plantcv.plantcv import logical_and
 from plantcv.plantcv import print_image
 from plantcv.plantcv import plot_image
 from plantcv.plantcv import fatal_error
@@ -35,10 +36,17 @@ def roi_objects(img, roi_contour, roi_hierarchy, object_contour, obj_hierarchy, 
     :return mask: numpy.ndarray
     :return obj_area: int
     """
+    # Store debug
+    debug = params.debug
+    params.debug = None
 
     params.device += 1
     # Create an empty grayscale (black) image the same dimensions as the input image
     mask = np.zeros(np.shape(img)[:2], dtype=np.uint8)
+    # Create a mask of the filled in ROI
+    roi_mask = np.zeros(np.shape(img)[:2], dtype=np.uint8)
+    roi_points = np.vstack(roi_contour[0])
+    cv2.fillPoly(roi_mask, [roi_points], (255))
 
     # Make a copy of the input image for plotting
     ori_img = np.copy(img)
@@ -50,25 +58,28 @@ def roi_objects(img, roi_contour, roi_hierarchy, object_contour, obj_hierarchy, 
     if roi_type.upper() == 'PARTIAL' or roi_type.upper() == 'LARGEST':
         # Filter contours outside of the region of interest
         for c, cnt in enumerate(object_contour):
-            length = (len(cnt) - 1)
-            stack = np.vstack(cnt)
-            keep = False
-
-            # Test if the contours are within the ROI
-            pptest = np.zeros(length+1)
-            for i in range(0, length):
-                pptest[i] = cv2.pointPolygonTest(roi_contour[0], (stack[i][0], stack[i][1]), False)
-                if any([int(i) != -1 for i in pptest]):
-                    keep = True
-                elif all([int(i) == -1 for i in pptest]):
-                    M = cv2.moments(cnt)
-                    cX = int(M["m10"] / M["m00"])
-                    cY = int(M["m01"] / M["m00"])
-                    if int(cv2.pointPolygonTest(cnt, (cX,cY), False)) == 1:
-                        keep = True
-                    else:
-                        keep = False
-            if keep:
+            filtering_mask = np.zeros(np.shape(img)[:2], dtype=np.uint8)
+            cv2.fillPoly(filtering_mask, [np.vstack(object_contour[c])], (255))
+            overlap_img = logical_and(filtering_mask, roi_mask)
+            # length = (len(cnt) - 1)
+            # stack = np.vstack(cnt)
+            # keep = False
+            #
+            # # Test if the contours are within the ROI
+            # pptest = np.zeros(length+1)
+            # for i in range(0, length):
+            #     pptest[i] = cv2.pointPolygonTest(roi_contour[0], (stack[i][0], stack[i][1]), False)
+            #     if any([int(i) != -1 for i in pptest]):
+            #         keep = True
+            #     elif all([int(i) == -1 for i in pptest]):
+            #         M = cv2.moments(cnt)
+            #         cX = int(M["m10"] / M["m00"])
+            #         cY = int(M["m01"] / M["m00"])
+            #         if int(cv2.pointPolygonTest(cnt, (cX,cY), False)) == 1:
+            #             keep = True
+            #         else:
+            #             keep = False
+            if np.sum(overlap_img) > 0:
                 # Color the "gap contours" black
                 if obj_hierarchy[0][c][3] > -1:
                     cv2.drawContours(mask, object_contour, c, (0), -1, lineType=8, hierarchy=obj_hierarchy)
@@ -152,6 +163,8 @@ def roi_objects(img, roi_contour, roi_hierarchy, object_contour, obj_hierarchy, 
     else:
         fatal_error('ROI Type ' + str(roi_type) + ' is not "cutto", "largest", or "partial"!')
 
+    # Reset debug mode
+    params.debug = debug
     if params.debug == 'print':
         print_image(ori_img, os.path.join(params.debug_outdir, str(params.device) + '_obj_on_img.png'))
         print_image(mask, os.path.join(params.debug_outdir, str(params.device) + '_roi_mask.png'))

--- a/plantcv/plantcv/roi_objects.py
+++ b/plantcv/plantcv/roi_objects.py
@@ -43,6 +43,8 @@ def roi_objects(img, roi_contour, roi_hierarchy, object_contour, obj_hierarchy, 
     params.device += 1
     # Create an empty grayscale (black) image the same dimensions as the input image
     mask = np.zeros(np.shape(img)[:2], dtype=np.uint8)
+    cv2.drawContours(mask, object_contour, -1, (255), -1, lineType=8, hierarchy=obj_hierarchy)
+
     # Create a mask of the filled in ROI
     roi_mask = np.zeros(np.shape(img)[:2], dtype=np.uint8)
     roi_points = np.vstack(roi_contour[0])
@@ -61,33 +63,8 @@ def roi_objects(img, roi_contour, roi_hierarchy, object_contour, obj_hierarchy, 
             filtering_mask = np.zeros(np.shape(img)[:2], dtype=np.uint8)
             cv2.fillPoly(filtering_mask, [np.vstack(object_contour[c])], (255))
             overlap_img = logical_and(filtering_mask, roi_mask)
-            # length = (len(cnt) - 1)
-            # stack = np.vstack(cnt)
-            # keep = False
-            #
-            # # Test if the contours are within the ROI
-            # pptest = np.zeros(length+1)
-            # for i in range(0, length):
-            #     pptest[i] = cv2.pointPolygonTest(roi_contour[0], (stack[i][0], stack[i][1]), False)
-            #     if any([int(i) != -1 for i in pptest]):
-            #         keep = True
-            #     elif all([int(i) == -1 for i in pptest]):
-            #         M = cv2.moments(cnt)
-            #         cX = int(M["m10"] / M["m00"])
-            #         cY = int(M["m01"] / M["m00"])
-            #         if int(cv2.pointPolygonTest(cnt, (cX,cY), False)) == 1:
-            #             keep = True
-            #         else:
-            #             keep = False
-            if np.sum(overlap_img) > 0:
-                # Color the "gap contours" black
-                if obj_hierarchy[0][c][3] > -1:
-                    cv2.drawContours(mask, object_contour, c, (0), -1, lineType=8, hierarchy=obj_hierarchy)
-                else:
-                    # Color the plant contour parts white
-                    cv2.drawContours(mask, object_contour, c, (255), -1, lineType=8, hierarchy=obj_hierarchy)
-            else:
-                # If the contour isn't overlapping with the ROI, color it black
+            # Delete contours that do not overlap at all with the ROI
+            if np.sum(overlap_img) == 0:
                 cv2.drawContours(mask, object_contour, c, (0), -1, lineType=8, hierarchy=obj_hierarchy)
 
         # Find the kept contours and area

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -9,6 +9,7 @@ from plantcv.plantcv import plot_image
 from plantcv.plantcv import fatal_error
 from plantcv.plantcv import params
 from plantcv.plantcv.roi import circle
+from plantcv.plantcv import params
 
 
 def get_color_matrix(rgb_img, mask):
@@ -406,7 +407,7 @@ def create_color_card_mask(rgb_img, radius, start_coord, spacing, nrows, ncols, 
         canvas = np.copy(rgb_img)
         # Draw chip ROIs on the canvas image
         for chip in chips:
-            cv2.drawContours(canvas, chip[0], -1, (255, 255, 0), 5)
+            cv2.drawContours(canvas, chip[0], -1, (255, 255, 0), params.line_thickness)
         if params.debug == "print":
             print_image(img=canvas, filename=os.path.join(params.debug_outdir,
                                                           str(params.device) + "_color_card_mask_rois.png"))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2637,20 +2637,6 @@ def test_plantcv_roi_objects_grayscale_input():
     assert len(kept_contours) == 1891
 
 
-def test_plantcv_roi_objects_no_objects():
-    # Read in test data
-    img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_COLOR), 0)
-    roi_npz = np.load(os.path.join(TEST_DATA, TEST_INPUT_ROI), encoding="latin1")
-    roi_contour = [np.array([[[750, 750]],[[750, 849]],[[799, 849]],[[799, 750]]])]
-    roi_hierarchy = roi_npz['arr_1']
-    contours_npz = np.load(os.path.join(TEST_DATA, TEST_INPUT_CONTOURS1), encoding="latin1")
-    object_contours = contours_npz['arr_0']
-    object_hierarchy = contours_npz['arr_1']
-    with pytest.raises(RuntimeError):
-        _ = pcv.roi_objects(img=img, roi_type="partial", roi_contour=roi_contour, roi_hierarchy=roi_hierarchy,
-                            object_contour=object_contours, obj_hierarchy=object_hierarchy)
-
-
 def test_plantcv_rotate():
     # Test cache directory
     cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_rotate_img")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2596,7 +2596,7 @@ def test_plantcv_roi_objects():
                                                                 object_contour=object_contours,
                                                                 obj_hierarchy=object_hierarchy, roi_type="partial")
     # Assert that the contours were filtered as expected
-    assert len(kept_contours) == 1046
+    assert len(kept_contours) == 1105
 
 
 def test_plantcv_roi_objects_bad_input():
@@ -2634,7 +2634,7 @@ def test_plantcv_roi_objects_grayscale_input():
                                                                 object_contour=object_contours,
                                                                 obj_hierarchy=object_hierarchy)
     # Assert that the contours were filtered as expected
-    assert len(kept_contours) == 1046
+    assert len(kept_contours) == 1105
 
 
 def test_plantcv_roi_objects_no_objects():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2596,7 +2596,7 @@ def test_plantcv_roi_objects():
                                                                 object_contour=object_contours,
                                                                 obj_hierarchy=object_hierarchy, roi_type="partial")
     # Assert that the contours were filtered as expected
-    assert len(kept_contours) == 1105
+    assert len(kept_contours) == 1891
 
 
 def test_plantcv_roi_objects_bad_input():
@@ -2634,7 +2634,7 @@ def test_plantcv_roi_objects_grayscale_input():
                                                                 object_contour=object_contours,
                                                                 obj_hierarchy=object_hierarchy)
     # Assert that the contours were filtered as expected
-    assert len(kept_contours) == 1105
+    assert len(kept_contours) == 1891
 
 
 def test_plantcv_roi_objects_no_objects():


### PR DESCRIPTION
<!---
Labels: Please select one or more relevant tags (menu on the right).
(This only shows up for administrators.)
--->

### Description
* Realized the limitations of the current method for filtering out objects that don't partially overlap with a region of interest (details discussed in #435 ) so updated the method to be more robust (and generally more efficient). 
* While comparing the results from `pcv.roi_objects` it became clear that there were small (10's of pixels) differences, usually in gaps, that we believe resulted from using `cv2.drawContours` despite trying to use the most exact parameters in `cv2.findContours`. Rather than re-plotting contours that get kept, we create a mask and only delete contours that are filtered out. 
* Update unit tests to reflect the more accurate method within the `pcv.roi_objects` function. 
* Closes #435 

* Update row and column parsing in `pcv.cluster_contours` to handle numbers greater than 9. 
* Allow user to limit the type of color data that gets saved to the `Outputs` class rather than just changing the histogram. Removes verbose output data.


### Checklist:

- [x] Relevant tests (and test data) have been added or updated and passed.
- [x] Relevant issues were updated or added.
