### PR TITLE
Remove hyphens in datetime

### DIFF
--- a/plantcv/parallel/parsers.py
+++ b/plantcv/parallel/parsers.py
@@ -221,7 +221,7 @@ def _check_date_range(start_date, end_date, img_time):
     """
 
     # Convert image datetime to unix time
-    timestamp = dt_parser(img_time)
+    timestamp = dt_parser(img_time.replace("-", ""))
     time_delta = timestamp - datetime.datetime(1970, 1, 1)
     unix_time = (time_delta.days * 24 * 3600) + time_delta.seconds
     # Does the image date-time fall outside or inside the included range

--- a/plantcv/plantcv/analyze_color.py
+++ b/plantcv/plantcv/analyze_color.py
@@ -177,7 +177,7 @@ def analyze_color(rgb_img, mask, hist_plot_type=None):
                                     method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
                                     value=histograms["r"]["hist"], label=rgb_values)
 
-        elif hist_plot_type.upper() == 'LAB' or hist_plot_type.upper() == 'ALL':
+        if hist_plot_type.upper() == 'LAB' or hist_plot_type.upper() == 'ALL':
             outputs.add_observation(variable='lightness_frequencies', trait='lightness frequencies',
                                     method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
                                     value=histograms["l"]["hist"], label=percent_values)
@@ -188,7 +188,7 @@ def analyze_color(rgb_img, mask, hist_plot_type=None):
                                     method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
                                     value=histograms["y"]["hist"], label=diverging_values)
 
-        elif hist_plot_type.upper() == 'HSV' or hist_plot_type.upper() == 'ALL':
+        if hist_plot_type.upper() == 'HSV' or hist_plot_type.upper() == 'ALL':
             outputs.add_observation(variable='hue_frequencies', trait='hue frequencies',
                                     method='plantcv.plantcv.analyze_color', scale='frequency', datatype=list,
                                     value=histograms["h"]["hist"][0:180], label=hue_values)


### PR DESCRIPTION
**Describe your changes**
Python dateutil does not like parsing datetimes in the format Y-M-D H-M-S. But removing the hyphens to either YMD HMS or YMDHMS works. This pull request updates the datetime parser in the parallel subpackage to remove "-" characters from datetime strings prior to parsing.

**Type of update**
Is this a bug fix

**Associated issues**
Possibly fixes #444 and somewhat addresses #423
