### PR TITLE
Restrict max NumPy version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ name: test-environment
 dependencies:
   - python=3.7
   - matplotlib>=1.5
-  - numpy>=1.11
+  - numpy>=1.11, <1.17
   - pandas
   - python-dateutil
   - scipy < 1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib>=1.5
-numpy>=1.11
+numpy>=1.11, <1.17
 pandas
 python-dateutil
 scipy < 1.3


### PR DESCRIPTION
Prevent using NumPy 1.17+

**Describe your changes**
From initial testing it looks like NumPy 1.17 changes the way NumPy data saved to files (NPY or NPZ files) are read for security reasons. We have a fair amount of NPZ files in our test dataset, so this causes the tests that use these data to fail. This pull request pins NumPy to versions < 1.17 for now until we address #447.

**Type of update**
Is this a modification to our dependency list.

**Associated issues**
Issue #447 tracks what we need to do to use NumPy 1.17+.
