### PR TITLE
Extract spectral indices

### DIFF
--- a/plantcv/plantcv/hyperspectral/__init__.py
+++ b/plantcv/plantcv/hyperspectral/__init__.py
@@ -24,7 +24,8 @@
 #         self.text_thickness = text_thickness
 
 from plantcv.plantcv.hyperspectral.read_data import read_data
+from plantcv.plantcv.hyperspectral.read_data import _find_closest
 
 # add new functions to end of lists
-__all__ = ["read_data"]
+__all__ = ["read_data", "_find_closest"]
 

--- a/plantcv/plantcv/hyperspectral/__init__.py
+++ b/plantcv/plantcv/hyperspectral/__init__.py
@@ -25,7 +25,8 @@
 
 from plantcv.plantcv.hyperspectral.read_data import read_data
 from plantcv.plantcv.hyperspectral.read_data import _find_closest
+from plantcv.plantcv.hyperspectral.extract_index import extract_index
 
 # add new functions to end of lists
-__all__ = ["read_data", "_find_closest"]
+__all__ = ["read_data", "_find_closest", "extract_index"]
 

--- a/plantcv/plantcv/hyperspectral/extract_index.py
+++ b/plantcv/plantcv/hyperspectral/extract_index.py
@@ -1,0 +1,52 @@
+import os
+import numpy as np
+from plantcv.plantcv import params
+from plantcv.plantcv import plot_image
+from plantcv.plantcv import print_image
+from plantcv.plantcv import fatal_error
+from plantcv.plantcv.hyperspectral import _find_closest
+
+
+
+def extract_index(array, header_dict, index="NDVI", fudge_factor=20):
+    """Pull out indices of interest from a hyperspectral datacube.
+
+        Inputs:
+        array = hyperspectral data array
+        header_dict = dictionary with header information
+        index = index of interest
+
+        Returns:
+        index_array    = image object as numpy array
+
+        :param array: numpy.ndarray
+        :param header_dict: dict
+        :param index: str
+        :return index_array: numpy.ndarray
+        """
+    # Min and max available wavelength will be used to determine if an index can be extracted
+    max_wavelength = float(max(header_dict['wavelength']))
+    min_wavelength = float(min(header_dict['wavelength']))
+
+    # Dictionary of wavelength and it's index in the list
+    wavelength_dict = {}
+    for j, wavelength in enumerate(header_dict["wavelength"]):
+        wavelength_dict.update({wavelength: j})
+
+
+    if index.upper() == "NDVI":
+        if (max_wavelength + fudge_factor) >= 800 and (min_wavelength - fudge_factor) <= 670:
+            nir = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
+            red = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 670)
+            index_array = (nir - red) / (nir + red)
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating NDVI. Try increasing fudge factor.")
+
+
+    if params.debug == "plot":
+        # Gamma correct pseudo_rgb image
+        plot_image(index_array)
+    elif params.debug == "print":
+        print_image(index_array, os.path.join(params.debug_outdir, str(params.device) + index + "_index.png"))
+
+    return index_array

--- a/plantcv/plantcv/hyperspectral/extract_index.py
+++ b/plantcv/plantcv/hyperspectral/extract_index.py
@@ -25,9 +25,8 @@ def extract_index(array, header_dict, index="NDVI", fudge_factor=20):
         :return index_array: numpy.ndarray
         """
     # Min and max available wavelength will be used to determine if an index can be extracted
-    max_wavelength = float(max(header_dict['wavelength']))
-    min_wavelength = float(min(header_dict['wavelength']))
-
+    max_wavelength = max([float(i.rstrip()) for i in header_dict['wavelength']])
+    min_wavelength = min([float(i.rstrip()) for i in header_dict['wavelength']])
     # Dictionary of wavelength and it's index in the list
     wavelength_dict = {}
     for j, wavelength in enumerate(header_dict["wavelength"]):
@@ -48,7 +47,8 @@ def extract_index(array, header_dict, index="NDVI", fudge_factor=20):
             datandvi = all_positive.astype(np.float64) / 2  # normalize the data to 0 - 1
             index_array = (255 * datandvi).astype(np.uint8)  # scale to 255
         else:
-            fatal_error("Available wavelengths are not suitable for calculating NDVI. Try increasing fudge factor.")
+            fatal_error("Available wavelengths are not suitable for calculating NDVI. Try increasing fudge factor." )
+
 
     elif index.upper() == "GDVI":
         # "Green Difference Vegetation Index [Sripada et al. (2006)]"

--- a/plantcv/plantcv/hyperspectral/extract_index.py
+++ b/plantcv/plantcv/hyperspectral/extract_index.py
@@ -37,8 +37,8 @@ def extract_index(array, header_dict, index="NDVI", fudge_factor=20):
             # Obtain index that best represents NIR and red bands
             nir_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
             red_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 670)
-            nir = array[:, :, [nir_index]]
-            red = array[:, :, [red_index]]
+            nir = (array[:, :, [nir_index]] + array[:, :, [nir_index + 4]] + array[:, :, [nir_index - 4]]) / 3
+            red = (array[:, :, [red_index]] + array[:, :, [red_index + 4]] + array[:, :, [red_index - 4]]) / 3
             ndvi = (nir - red) / (nir + red)
             index_array_raw = np.transpose(np.transpose(ndvi)[0])
 

--- a/plantcv/plantcv/hyperspectral/extract_index.py
+++ b/plantcv/plantcv/hyperspectral/extract_index.py
@@ -36,9 +36,12 @@ def extract_index(array, header_dict, index="NDVI", fudge_factor=20):
 
     if index.upper() == "NDVI":
         if (max_wavelength + fudge_factor) >= 800 and (min_wavelength - fudge_factor) <= 670:
-            nir = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
-            red = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 670)
-            index_array = (nir - red) / (nir + red)
+            nir_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
+            red_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 670)
+            nir = array[:, :, [nir_index]]
+            red = array[:, :, [red_index]]
+            ndvi = (nir - red) / (nir + red)
+            index_array = np.transpose(np.transpose(ndvi)[0])
         else:
             fatal_error("Available wavelengths are not suitable for calculating NDVI. Try increasing fudge factor.")
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3520,7 +3520,7 @@ def test_plantcv_hyperspectral_extract_index_ndvi():
     _ = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="NDVI")
     pcv.params.debug = "print"
     index_array = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="NDVI")
-    assert np.shape(index_array) == (1,800) and np.max(index_array) == 167
+    assert np.shape(index_array) == (1,800) and np.max(index_array) == 153
 
 
 def test_plantcv_hyperspectral_extract_index_gdvi():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3534,6 +3534,17 @@ def test_plantcv_hyperspectral_extract_index_gdvi():
     assert np.shape(index_array) == (1,800) and np.max(index_array) == 127
 
 
+def test_plantcv_hyperspectral_extract_index_savi():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_savi")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data, header_dict = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="SAVI")
+    assert np.shape(index_array) == (1,800) and np.max(index_array) == 127
+
+
 def test_plantcv_hyperspectral_extract_index_ndvi_bad_input():
     header_dict = HYPERSPECTRAL_HDR_SMALL_RANGE
     array_data = TEST_ACUTE_RESULT
@@ -3546,6 +3557,13 @@ def test_plantcv_hyperspectral_extract_index_gdvi_bad_input():
     array_data = TEST_ACUTE_RESULT
     with pytest.raises(RuntimeError):
         index_array = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="GDVI")
+
+
+def test_plantcv_hyperspectral_extract_index_savi_bad_input():
+    header_dict = HYPERSPECTRAL_HDR_SMALL_RANGE
+    array_data = TEST_ACUTE_RESULT
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="SAVI")
 
 
 # ##############################

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -502,6 +502,11 @@ HYPERSPECTRAL_DATA_NO_DEFAULT = "darkReference2"
 HYPERSPECTRAL_HDR_NO_DEFAULT = "darkReference2.hdr"
 HYPERSPECTRAL_DATA_APPROX_PSEUDO = "darkReference3"
 HYPERSPECTRAL_HDR_APPROX_PSEUDO = "darkReference3.hdr"
+HYPERSPECTRAL_HDR_SMALL_RANGE = {'description': '{[HEADWALL Hyperspec III]}', 'samples': '800', 'lines': '1',
+                                 'bands': '978', 'header offset': '0',  'file type': 'ENVI Standard',
+                                 'interleave': 'bil', 'sensor type': 'Unknown', 'byte order': '0',
+                                 'default bands': '159,253,520', 'wavelength units': 'nm',
+                                 'wavelength': ['379.027', '379.663', '380.3', '380.936', '381.573', '382.209']}
 TEST_COLOR_DIM = (2056, 2454, 3)
 TEST_GRAY_DIM = (2056, 2454)
 TEST_BINARY_DIM = TEST_GRAY_DIM
@@ -3502,6 +3507,45 @@ def test_plantcv_hyperspectral_read_data_approx_pseudorgb():
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA,HYPERSPECTRAL_DATA_APPROX_PSEUDO)
     array_data, header_dict = pcv.hyperspectral.read_data(filename=spectral_filename)
     assert np.shape(array_data) == (1, 800, 978)
+
+
+def test_plantcv_hyperspectral_extract_index_ndvi():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_ndvi")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data, header_dict = pcv.hyperspectral.read_data(filename=spectral_filename)
+    pcv.params.debug = "plot"
+    _ = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="NDVI")
+    pcv.params.debug = "print"
+    index_array = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="NDVI")
+    assert np.shape(index_array) == (1,800) and np.max(index_array) == 167
+
+
+def test_plantcv_hyperspectral_extract_index_gdvi():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_gdvi")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data, header_dict = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="GDVI")
+    assert np.shape(index_array) == (1,800) and np.max(index_array) == 127
+
+
+def test_plantcv_hyperspectral_extract_index_ndvi_bad_input():
+    header_dict = HYPERSPECTRAL_HDR_SMALL_RANGE
+    array_data = TEST_ACUTE_RESULT
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="NDVI")
+
+
+def test_plantcv_hyperspectral_extract_index_gdvi_bad_input():
+    header_dict = HYPERSPECTRAL_HDR_SMALL_RANGE
+    array_data = TEST_ACUTE_RESULT
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="GDVI")
 
 
 # ##############################


### PR DESCRIPTION
**Describe your changes**
* Add a function to the hyperspectral package that will extra spectral indices from hyperspectral datacubes. The function allows for some wiggle room to allow for hyperspectral data that doesn't exactly match the wavelength needed to calculate an index since neighbor bands tend to be highly correlated with one another. The amount of wiggle room is flexible; it can be refined using the `fudge_factor` parameter (rename??). For now the user needs to input the specific index that is desired but we may later update so that a list of indices can get returned at the same time, or maybe all similar indices will be returned. 
* Includes unit testing for the new function. 

**Type of update**
* New feature 

**Associated issues**
#443 
#203 
