### PR TITLE
Add Dockerfile

### DIFF
--- a/vice/Dockerfile
+++ b/vice/Dockerfile
@@ -1,0 +1,23 @@
+FROM discoenv/jupyter-lab:beta
+
+MAINTAINER PlantCV <ddpsc.plantcv@gmail.com>
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y libx264-dev \
+    && apt-get clean \
+    && rm -rf /usr/lib/apt/lists/* \
+    && fix-permissions $CONDA_DIR
+
+USER jovyan
+
+# install plantcv
+RUN conda update -n base conda \
+    && conda install jupyterlab=0.35.4 nb_conda \
+    && conda create -n plantcv -c bioconda plantcv nb_conda \
+    && conda clean -tipsy \
+    && fix-permissions $CONDA_DIR
+
+ENTRYPOINT ["jupyter"]
+CMD ["lab", "--no-browser"]


### PR DESCRIPTION
**Describe your changes**
Adds a second Dockerfile for building a container for use in the CyVerse VICE interface (https://learning.cyverse.org/projects/vice/en/latest/developer_guide/adding.html). After the Dockerfile is in place, we will set up a second automatic Docker build in DockerHub.

**Type of update**
Is this a: New feature or feature enhancement

**Additional context**
Once the container is available we will try creating a CyVerse app in the Discovery Environment that can use VICE so a user can use PlantCV in Jupyter within CyVerse.
