### PR TITLE
Apply mask to hyperspectral array

### DIFF
--- a/plantcv/plantcv/apply_mask.py
+++ b/plantcv/plantcv/apply_mask.py
@@ -2,6 +2,7 @@
 
 import os
 import cv2
+import numpy as np
 from plantcv.plantcv import print_image
 from plantcv.plantcv import plot_image
 from plantcv.plantcv import fatal_error

--- a/plantcv/plantcv/hyperspectral/apply_mask_spectral.py
+++ b/plantcv/plantcv/hyperspectral/apply_mask_spectral.py
@@ -35,7 +35,7 @@ def apply_mask_spectral(array, mask):
     med_band = int(num_bands / 2)
     pseudo_rgb = cv2.merge((array_data[:, :, [0]],
                             array_data[:, :, [med_band]],
-                            array_data[:, :, [num_bands]]))
+                            array_data[:, :, [num_bands-1]]))
 
         # Gamma correct pseudo_rgb image
     pseudo_rgb = pseudo_rgb ** (1 / 2.2)

--- a/plantcv/plantcv/hyperspectral/apply_mask_spectral.py
+++ b/plantcv/plantcv/hyperspectral/apply_mask_spectral.py
@@ -1,0 +1,28 @@
+# Apply White or Black Background Mask
+
+import os
+import cv2
+import numpy as np
+from plantcv.plantcv import print_image
+from plantcv.plantcv import plot_image
+from plantcv.plantcv import fatal_error
+from plantcv.plantcv import params
+
+
+def apply_mask_spectral(array, mask):
+    """Apply mask to hyperspectral datacube with numpy.where
+
+    Inputs:
+    array      = Array data
+    mask       = Binary mask image data
+
+    Returns:
+    masked_array = masked array data
+
+    :param array: numpy.ndarray
+    :param mask: numpy.ndarray
+    :return masked_array: numpy.ndarray
+    """
+    params.device += 1
+
+    rescaled_array[np.where(kept_mask == 0)] = 0

--- a/plantcv/plantcv/hyperspectral/apply_mask_spectral.py
+++ b/plantcv/plantcv/hyperspectral/apply_mask_spectral.py
@@ -25,4 +25,25 @@ def apply_mask_spectral(array, mask):
     """
     params.device += 1
 
-    rescaled_array[np.where(kept_mask == 0)] = 0
+    # Make a copy since we will directly mask the array
+    array_data = array.copy()
+    # Mask the array
+    array_data[np.where(mask == 0)] = 0
+
+    # Take 3 wavelengths, first, middle and last available wavelength
+    num_bands = np.shape(array)[2]
+    med_band = int(num_bands / 2)
+    pseudo_rgb = cv2.merge((array_data[:, :, [0]],
+                            array_data[:, :, [med_band]],
+                            array_data[:, :, [num_bands]]))
+
+        # Gamma correct pseudo_rgb image
+    pseudo_rgb = pseudo_rgb ** (1 / 2.2)
+
+    if params.debug == "plot":
+        # Gamma correct pseudo_rgb image
+        plot_image(pseudo_rgb)
+    elif params.debug == "print":
+        print_image(pseudo_rgb, os.path.join(params.debug_outdir, str(params.device) + "_masked_spectral.png"))
+
+    return array_data

--- a/plantcv/plantcv/hyperspectral/extract_index.py
+++ b/plantcv/plantcv/hyperspectral/extract_index.py
@@ -24,6 +24,8 @@ def extract_index(array, header_dict, index="NDVI", fudge_factor=20):
         :param index: str
         :return index_array: numpy.ndarray
         """
+    params.device += 1
+    
     # Min and max available wavelength will be used to determine if an index can be extracted
     max_wavelength = max([float(i.rstrip()) for i in header_dict['wavelength']])
     min_wavelength = min([float(i.rstrip()) for i in header_dict['wavelength']])
@@ -51,7 +53,7 @@ def extract_index(array, header_dict, index="NDVI", fudge_factor=20):
 
 
     elif index.upper() == "GDVI":
-        # "Green Difference Vegetation Index [Sripada et al. (2006)]"
+        # Green Difference Vegetation Index [Sripada et al. (2006)]
         if (max_wavelength + fudge_factor) >= 800 and (min_wavelength - fudge_factor) <= 680:
             nir_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
             red_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 680)
@@ -68,7 +70,7 @@ def extract_index(array, header_dict, index="NDVI", fudge_factor=20):
             fatal_error("Available wavelengths are not suitable for calculating GDVI. Try increasing fudge factor.")
 
     elif index.upper() == "SAVI":
-        # "Soil Adjusted Vegetation Index [Huete et al. (1988)]"
+        # Soil Adjusted Vegetation Index [Huete et al. (1988)]
         if (max_wavelength + fudge_factor) >= 800 and (min_wavelength - fudge_factor) <= 680:
             nir_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
             red_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 680)

--- a/plantcv/plantcv/hyperspectral/extract_index.py
+++ b/plantcv/plantcv/hyperspectral/extract_index.py
@@ -25,7 +25,7 @@ def extract_index(array, header_dict, index="NDVI", fudge_factor=20):
         :return index_array: numpy.ndarray
         """
     params.device += 1
-    
+
     # Min and max available wavelength will be used to determine if an index can be extracted
     max_wavelength = max([float(i.rstrip()) for i in header_dict['wavelength']])
     min_wavelength = min([float(i.rstrip()) for i in header_dict['wavelength']])


### PR DESCRIPTION
**Describe your changes**
Add a new function that will apply a mask to an entire array of hyperspectral data. 

**Type of update**
* New feature or feature enhancement

**Associated issues**
* #203  
* Closes #452  

**Additional context**
* Update the method for the existing `pcv.apply_mask` function? The inputs can be the exact same so with updates to the existing function it should be able to handle more types of arrays, including hyperspectral data. Currently the OpenCV functions that are utilized do not work depending on the `dtype` and the number of channels of the array. 
* When hyperspectral functions get added into PlantCV master then we can go back and add the method for plotting a pseudo-rgb in order to confirm mask has been applied to the datacube. 
* Add unit testing to cover the case where the array being masked has more layers than 3 (like in the case of a hyperspectral datacube) 
* Fix bug with `pcv.morphology.segement_insertion_angle` since sorting was affected by enhancements to the pruning function. (Tested on tutorial for Eveland lab and with morphology interactive tutorial. Works as intended now) 