### PR TITLE
Sample images fix

### DIFF
--- a/plantcv-utils.py
+++ b/plantcv-utils.py
@@ -29,7 +29,7 @@ def options():
     sample_images_cmd.add_argument("-s", "--source", help="Source directory of images", required=True)
     sample_images_cmd.add_argument("-o", "--outdir", help="Output directory for the random sample to get saved",
                                    required=True)
-    sample_images_cmd.add_argument("-n", "--number", help="The number of images to sample", default=100)
+    sample_images_cmd.add_argument("-n", "--number", help="The number of images to sample", default=100, type = int)
     sample_images_cmd.set_defaults(func=run_sample_images)
 
 

--- a/plantcv/utils/sample_images.py
+++ b/plantcv/utils/sample_images.py
@@ -8,10 +8,8 @@ def sample_images(source_path, dest_path, num=100):
     if not os.path.exists(source_path):
         raise IOError("Directory does not exist: {0}".format(source_path))
 
-    if not os.path.exists(dest_path):
-        os.mkdir(dest_path)
+    os.makedirs(dest_path, exist_ok=True)#python >=3.2
 
-    num = int(num)
     img_element_array = []
     sample_array = []
     num_images = []
@@ -45,8 +43,7 @@ def sample_images(source_path, dest_path, num=100):
             out_file.write(','.join(element))
             snap_path = os.path.join(source_path, "snapshot" + element[1])
             folder_path = os.path.join(dest_path, "snapshot" + element[1])
-            if not os.path.exists(folder_path):
-                os.mkdir(folder_path)
+            os.makedirs(folder_path, exist_ok=True)
             for root, dirs, files in os.walk(snap_path):
                 for file in files:
                     shutil.copy(os.path.join(root, file), folder_path)

--- a/plantcv/utils/sample_images.py
+++ b/plantcv/utils/sample_images.py
@@ -8,8 +8,10 @@ def sample_images(source_path, dest_path, num=100):
     if not os.path.exists(source_path):
         raise IOError("Directory does not exist: {0}".format(source_path))
 
-    os.makedirs(dest_path, exist_ok=True)#python >=3.2
+    if not os.path.exists(dest_path):
+        os.mkdir(dest_path)
 
+    num = int(num)
     img_element_array = []
     sample_array = []
     num_images = []
@@ -43,7 +45,8 @@ def sample_images(source_path, dest_path, num=100):
             out_file.write(','.join(element))
             snap_path = os.path.join(source_path, "snapshot" + element[1])
             folder_path = os.path.join(dest_path, "snapshot" + element[1])
-            os.makedirs(folder_path, exist_ok=True)
+            if not os.path.exists(folder_path):
+                os.mkdir(folder_path)
             for root, dirs, files in os.walk(snap_path):
                 for file in files:
                     shutil.copy(os.path.join(root, file), folder_path)

--- a/plantcv/utils/sample_images.py
+++ b/plantcv/utils/sample_images.py
@@ -1,20 +1,21 @@
 import os
 import random
 import shutil
+import errno
 from plantcv.plantcv import fatal_error
-
 
 def sample_images(source_path, dest_path, num=100):
     if not os.path.exists(source_path):
         raise IOError("Directory does not exist: {0}".format(source_path))
-
+      
     if not os.path.exists(dest_path):
-        dirs = dest_path.split(os.path.sep)
-        for i, d in enumerate(dirs):
-            newpath = os.path.sep.join(dirs[0:i+2])
-            if not os.path.exists(newpath):
-                os.mkdir(newpath)   
-
+        try:
+            os.makedirs(dest_path) #exist_ok argument does not exist in python 2
+        except OSError as exception:
+            # in python 3 function docs say cannot rely on checking for EEXIST, since the operating system could give priority to other errors like EACCES or EROFS
+            if exception.errno != errno.EEXIST:
+                raise
+  
     img_element_array = []
     sample_array = []
     num_images = []

--- a/plantcv/utils/sample_images.py
+++ b/plantcv/utils/sample_images.py
@@ -11,7 +11,7 @@ def sample_images(source_path, dest_path, num=100):
     if not os.path.exists(dest_path):
         dirs = dest_path.split(os.path.sep)
         for i, d in enumerate(dirs):
-            newpath = os.path.sep.join(dirs[0:i+1])
+            newpath = os.path.sep.join(dirs[0:i+2])
             if not os.path.exists(newpath):
                 os.mkdir(newpath)   
 

--- a/plantcv/utils/sample_images.py
+++ b/plantcv/utils/sample_images.py
@@ -9,9 +9,9 @@ def sample_images(source_path, dest_path, num=100):
         raise IOError("Directory does not exist: {0}".format(source_path))
 
     if not os.path.exists(dest_path):
-        dirs = dest_path.split('/')
-        for i,d in enumerate(dirs):
-            newpath = os.path.sep.join(dirs[0:i+1])
+        dirs = dest_path.split(os.path.sep)
+        for i, d in enumerate(dirs):
+            newpath = os.path.join(dirs[0:i+1])
             if not os.path.exists(newpath):
                 os.mkdir(newpath)   
 
@@ -49,7 +49,7 @@ def sample_images(source_path, dest_path, num=100):
             snap_path = os.path.join(source_path, "snapshot" + element[1])
             folder_path = os.path.join(dest_path, "snapshot" + element[1])
             if not os.path.exists(folder_path):
-                os.mkdir(folder_path)#the beginning of folder_path (dest_path) already exists from above
+                os.mkdir(folder_path)  # the beginning of folder_path (dest_path) already exists from above
             for root, dirs, files in os.walk(snap_path):
                 for file in files:
                     shutil.copy(os.path.join(root, file), folder_path)

--- a/plantcv/utils/sample_images.py
+++ b/plantcv/utils/sample_images.py
@@ -11,7 +11,6 @@ def sample_images(source_path, dest_path, num=100):
     if not os.path.exists(dest_path):
         os.mkdir(dest_path)
 
-    num = int(num)
     img_element_array = []
     sample_array = []
     num_images = []

--- a/plantcv/utils/sample_images.py
+++ b/plantcv/utils/sample_images.py
@@ -11,6 +11,7 @@ def sample_images(source_path, dest_path, num=100):
     if not os.path.exists(dest_path):
         os.mkdir(dest_path)
 
+    num = int(num)
     img_element_array = []
     sample_array = []
     num_images = []

--- a/plantcv/utils/sample_images.py
+++ b/plantcv/utils/sample_images.py
@@ -11,7 +11,9 @@ def sample_images(source_path, dest_path, num=100):
     if not os.path.exists(dest_path):
         dirs = dest_path.split('/')
         for i,d in enumerate(dirs):
-            os.mkdir("/".join(dirs[0:i+1]))
+            newpath = os.path.sep.join(dirs[0:i+1])
+            if not os.path.exists(newpath):
+                os.mkdir(newpath)   
 
     img_element_array = []
     sample_array = []
@@ -47,9 +49,8 @@ def sample_images(source_path, dest_path, num=100):
             snap_path = os.path.join(source_path, "snapshot" + element[1])
             folder_path = os.path.join(dest_path, "snapshot" + element[1])
             if not os.path.exists(folder_path):
-                dirs = dest_path.split('/')
-                for i,d in enumerate(dirs):
-                    os.mkdir("/".join(dirs[0:i+1]))            for root, dirs, files in os.walk(snap_path):
+                os.mkdir(folder_path)#the beginning of folder_path (dest_path) already exists from above
+            for root, dirs, files in os.walk(snap_path):
                 for file in files:
                     shutil.copy(os.path.join(root, file), folder_path)
     else:

--- a/plantcv/utils/sample_images.py
+++ b/plantcv/utils/sample_images.py
@@ -11,7 +11,7 @@ def sample_images(source_path, dest_path, num=100):
     if not os.path.exists(dest_path):
         dirs = dest_path.split(os.path.sep)
         for i, d in enumerate(dirs):
-            newpath = os.path.join(dirs[0:i+1])
+            newpath = os.path.sep.join(dirs[0:i+1])
             if not os.path.exists(newpath):
                 os.mkdir(newpath)   
 

--- a/plantcv/utils/sample_images.py
+++ b/plantcv/utils/sample_images.py
@@ -9,7 +9,9 @@ def sample_images(source_path, dest_path, num=100):
         raise IOError("Directory does not exist: {0}".format(source_path))
 
     if not os.path.exists(dest_path):
-        os.mkdir(dest_path)
+        dirs = dest_path.split('/')
+        for i,d in enumerate(dirs):
+            os.mkdir("/".join(dirs[0:i+1]))
 
     img_element_array = []
     sample_array = []
@@ -45,8 +47,9 @@ def sample_images(source_path, dest_path, num=100):
             snap_path = os.path.join(source_path, "snapshot" + element[1])
             folder_path = os.path.join(dest_path, "snapshot" + element[1])
             if not os.path.exists(folder_path):
-                os.mkdir(folder_path)
-            for root, dirs, files in os.walk(snap_path):
+                dirs = dest_path.split('/')
+                for i,d in enumerate(dirs):
+                    os.mkdir("/".join(dirs[0:i+1]))            for root, dirs, files in os.walk(snap_path):
                 for file in files:
                     shutil.copy(os.path.join(root, file), folder_path)
     else:

--- a/plantcv/utils/sample_images.py
+++ b/plantcv/utils/sample_images.py
@@ -9,12 +9,7 @@ def sample_images(source_path, dest_path, num=100):
         raise IOError("Directory does not exist: {0}".format(source_path))
       
     if not os.path.exists(dest_path):
-        try:
-            os.makedirs(dest_path) #exist_ok argument does not exist in python 2
-        except OSError as exception:
-            # in python 3 function docs say cannot rely on checking for EEXIST, since the operating system could give priority to other errors like EACCES or EROFS
-            if exception.errno != errno.EEXIST:
-                raise
+        os.makedirs(dest_path) #exist_ok argument does not exist in python 2
   
     img_element_array = []
     sample_array = []


### PR DESCRIPTION
**Describe your changes**
Coerce 'num' argument in run_sample_images to integer to avoid `TypeError: '>' not supported between instances of 'str' and 'int'`

If i run sample_samples without an n argument it works fine. I could not figure out why or at what point num is getting converted to a str but that's what the error suggests. I tested the function with `num = int(num)` and it works for me.

```
(plantcv) C:\Users\dominikschneider\Documents\phenomics\GoldStandard2>python %CONDA_PREFIX%/Scripts/plantcv-utils.py sample_images -s data/raw_snapshots/vis -o data/testimages/vis -n 50
Traceback (most recent call last):
  File "C:\Users\dominikschneider\Miniconda3\envs\plantcv/Scripts/plantcv-utils.py", line 74, in <module>
    main()
  File "C:\Users\dominikschneider\Miniconda3\envs\plantcv/Scripts/plantcv-utils.py", line 69, in main
    options()
  File "C:\Users\dominikschneider\Miniconda3\envs\plantcv/Scripts/plantcv-utils.py", line 44, in options
    args.func(args)
  File "C:\Users\dominikschneider\Miniconda3\envs\plantcv/Scripts/plantcv-utils.py", line 58, in run_sample_images
    plantcv.utils.sample_images(source_path=args.source, dest_path=args.outdir, num=args.number)
  File "C:\Users\dominikschneider\Miniconda3\envs\plantcv\lib\site-packages\plantcv\utils\sample_images.py", line 61, in sample_images
    if num > len(img_element_array):
TypeError: '>' not supported between instances of 'str' and 'int'
```

**Type of update**
Is this a:
* Bug fix

**Additional context**
WIndows 10, bioconda plantcv v3.6