### PR TITLE
Update process_results to bypass missing metadata bug

### DIFF
--- a/plantcv/parallel/process_results.py
+++ b/plantcv/parallel/process_results.py
@@ -40,10 +40,10 @@ def process_results(job_dir, json_file):
                     obs = json.load(results)
                     data["entities"].append(obs)
                     # Keep track of all metadata variables stored
-                    for vars in obs["metadata"].keys():
+                    for vars in obs["metadata"]:
                         data["variables"][vars] = {"category": "metadata", "datatype": "<class 'str'>"}
                     # Keep track of all observations variables stored
-                    for othervars in obs["observations"].keys():
+                    for othervars in obs["observations"]:
                         data["variables"][othervars] = {"category": "observations",
                                                         "datatype": obs["observations"][othervars]["datatype"]}
 


### PR DESCRIPTION
**Describe your changes**
This pull request updates the `plantcv.parallel.process_results` method to remove the use of the `keys` method that was used to iterate over the keys of two dictionaries. `keys` will return an error if the dictionary is undefined, which occurs when the metadata dictionary is missing in some instances as described in #466. Instead `process_results` is updated to use a for loop on the dictionary without `keys`, which functions in the same way but does not require the dictionary to be defined and just skips the loop if it is not.

**Type of update**
Is this a bug fix

**Associated issues**
Should fix #466
