### PR TITLE
add defaults channel for dependencies when installing from source

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,5 @@ dependencies:
   - pip:
     - opencv-python<4, >=3.4
 channels:
+  - defaults
   - conda-forge


### PR DESCRIPTION
**Describe your changes**
Updated environment.yml to have defaults channel above conda-forge to be similar to resolution in #469 

the same problem (I think) as #469 just bit me when I was trying to install `add-regex-metadata-parser` branch into my `test-environment`