### PR TITLE
Add Spectral_data class  

### DIFF
--- a/plantcv/plantcv/__init__.py
+++ b/plantcv/plantcv/__init__.py
@@ -96,6 +96,35 @@ params = Params()
 outputs = Outputs()
 
 
+class Spectral_data:
+    # PlantCV Hyperspectral data class
+    def __init__(self, array_data, max_wavelength, min_wavelength, d_type, wavelength_dict, samples, lines, interleave,
+                 wavelength_units, array_type, filename):
+        # The actual array/datacube
+        self.array_data = array_data
+        self.max_wavelength = max_wavelength
+        self.min_wavelength = min_wavelength
+        # Datatype
+        self.d_type = d_type
+        # Contains all available wavelengths where keys are wavelength and value are indices
+        self.wavelength_dict = wavelength_dict
+        # Resolution of a single band of spectral data is (samples, lines) rather than (x,y) with other arrays
+        self.samples = samples
+        self.lines = lines
+        # Interleave type
+        self.interleave = interleave
+        self.wavelength_units = wavelength_units
+        # The type of array data (entire datacube, specific index, first derivative, etc)
+        self.array_type = array_type
+        # The filename where the data originated from
+        self.filename = filename
+
+# Example
+# spectral_array = Spectral_data(max_wavelength=1000.95, min_wavelength=379.027, d_type=numpy.float32,
+#                           wavelength_dict=dictionary, samples=1600, lines=1704, interleave='bil',
+#                           wavelength_units='nm', array_type="datacube", filename=filename)
+
+
 from plantcv.plantcv.fatal_error import fatal_error
 from plantcv.plantcv.print_image import print_image
 from plantcv.plantcv.plot_image import plot_image

--- a/plantcv/plantcv/hyperspectral/analyze_spectral.py
+++ b/plantcv/plantcv/hyperspectral/analyze_spectral.py
@@ -51,6 +51,7 @@ def analyze_spectral(array, header_dict, mask, histplot=True):
         new_wavelengths.append(float(wavelength))
         new_freq.append(str(wavelength_freq[i]))
 
+    # Calculate reflectance statistics
     max_reflectance = np.amax(wavelength_data)
     min_reflectance = np.amin(wavelength_data)
     avg_reflectance = np.average(wavelength_data)

--- a/plantcv/plantcv/hyperspectral/analyze_spectral.py
+++ b/plantcv/plantcv/hyperspectral/analyze_spectral.py
@@ -38,10 +38,12 @@ def analyze_spectral(array, header_dict, mask, histplot=True):
     wavelength_data = array[np.where(mask > 0)]
     wavelength_freq = wavelength_data.mean(axis=0)
 
-    #
+    # Identify smallest and largest wavelengths available to scale the x-axis
     min_wavelength = int(np.ceil(float(header_dict["wavelength"][0])))
     max_wavelength = int(np.ceil(float(header_dict["wavelength"][-1])))
 
+    # Create lists with wavelengths in float format rather than as strings
+    # and make a list of the frequencies since they are in an array
     new_wavelengths = []
     new_freq = []
 
@@ -53,7 +55,6 @@ def analyze_spectral(array, header_dict, mask, histplot=True):
     minreflectance = np.amin(wavelength_data)
     avgreflectance = np.average(wavelength_data)
     medianreflectance = np.median(wavelength_data)
-    print("max")
 
     # Store data into outputs class
     outputs.add_observation(variable='max_reflectance', trait='maximum reflectance',

--- a/plantcv/plantcv/hyperspectral/analyze_spectral.py
+++ b/plantcv/plantcv/hyperspectral/analyze_spectral.py
@@ -51,24 +51,24 @@ def analyze_spectral(array, header_dict, mask, histplot=True):
         new_wavelengths.append(float(wavelength))
         new_freq.append(str(wavelength_freq[i]))
 
-    maxreflectance = np.amax(wavelength_data)
-    minreflectance = np.amin(wavelength_data)
-    avgreflectance = np.average(wavelength_data)
-    medianreflectance = np.median(wavelength_data)
+    max_reflectance = np.amax(wavelength_data)
+    min_reflectance = np.amin(wavelength_data)
+    avg_reflectance = np.average(wavelength_data)
+    median_reflectance = np.median(wavelength_data)
 
     # Store data into outputs class
     outputs.add_observation(variable='max_reflectance', trait='maximum reflectance',
                             method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='degrees', datatype=float,
-                            value=float(maxreflectance), label='reflectance')
+                            value=float(max_reflectance), label='reflectance')
     outputs.add_observation(variable='min_reflectance', trait='minimum reflectance',
                             method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='degrees', datatype=float,
-                            value=float(minreflectance), label='reflectance')
+                            value=float(min_reflectance), label='reflectance')
     outputs.add_observation(variable='mean_reflectance', trait='mean_reflectance',
                             method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='degrees', datatype=float,
-                            value=float(avgreflectance), label='reflectance')
+                            value=float(avg_reflectance), label='reflectance')
     outputs.add_observation(variable='median_reflectance', trait='median_reflectance',
                             method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='degrees', datatype=float,
-                            value=float(medianreflectance), label='reflectance')
+                            value=float(median_reflectance), label='reflectance')
     outputs.add_observation(variable='spectral_frequencies', trait='thermal spectral_frequencies',
                             method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='frequency', datatype=list,
                             value=new_freq, label=header_dict["wavelength"])
@@ -77,10 +77,10 @@ def analyze_spectral(array, header_dict, mask, histplot=True):
     analysis_img = None
 
     if histplot is True:
-        dataset = pd.DataFrame({'Wavelength': new_wavelengths,
+        dataset = pd.DataFrame({'Wavelength (nm)': new_wavelengths,
                                 'Reflectance': wavelength_freq})
         fig_hist = (ggplot(data=dataset,
-                           mapping=aes(x='Wavelength',
+                           mapping=aes(x='Wavelength (nm)',
                                        y='Reflectance'))
                     + geom_line(color='purple')
                     + scale_x_continuous(breaks=list(range(min_wavelength, max_wavelength, 50)))
@@ -89,7 +89,7 @@ def analyze_spectral(array, header_dict, mask, histplot=True):
         analysis_img = fig_hist
 
         if params.debug == "print":
-            fig_hist.save(os.path.join(params.debug_outdir, str(params.device) + '_therm_histogram.png'))
+            fig_hist.save(os.path.join(params.debug_outdir, str(params.device) + '_spectral_histogram.png'))
         elif params.debug == "plot":
             print(fig_hist)
 

--- a/plantcv/plantcv/hyperspectral/extract_index.py
+++ b/plantcv/plantcv/hyperspectral/extract_index.py
@@ -89,9 +89,9 @@ def extract_index(array, index="NDVI", fudge_factor=20):
         else:
             fatal_error("Available wavelengths are not suitable for calculating SAVI. Try increasing fudge factor.")
 
-    index_array = Spectral_data(array_data=index_array, max_wavelength=None,
-                                min_wavelength=None, d_type=np.uint8,
-                                wavelength_dict=None, samples=array.samples,
+    index_array = Spectral_data(array_data=index_array, max_wavelength=0,
+                                min_wavelength=0, d_type=np.uint8,
+                                wavelength_dict={}, samples=array.samples,
                                 lines=array.lines, interleave=array.interleave,
                                 wavelength_units=array.wavelength_units, array_type="index_" + index.lower(),
                                 filename=array.filename)

--- a/plantcv/plantcv/hyperspectral/extract_index.py
+++ b/plantcv/plantcv/hyperspectral/extract_index.py
@@ -5,6 +5,7 @@ from plantcv.plantcv import plot_image
 from plantcv.plantcv import print_image
 from plantcv.plantcv import fatal_error
 from plantcv.plantcv import Spectral_data
+from plantcv.plantcv.hyperspectral import _find_closest
 
 
 

--- a/plantcv/plantcv/hyperspectral/extract_index.py
+++ b/plantcv/plantcv/hyperspectral/extract_index.py
@@ -4,16 +4,15 @@ from plantcv.plantcv import params
 from plantcv.plantcv import plot_image
 from plantcv.plantcv import print_image
 from plantcv.plantcv import fatal_error
-from plantcv.plantcv.hyperspectral import _find_closest
+from plantcv.plantcv import Spectral_data
 
 
 
-def extract_index(array, header_dict, index="NDVI", fudge_factor=20):
+def extract_index(array, index="NDVI", fudge_factor=20):
     """Pull out indices of interest from a hyperspectral datacube.
 
         Inputs:
         array = hyperspectral data array
-        header_dict = dictionary with header information
         index = index of interest
 
         Returns:
@@ -27,20 +26,21 @@ def extract_index(array, header_dict, index="NDVI", fudge_factor=20):
     params.device += 1
 
     # Min and max available wavelength will be used to determine if an index can be extracted
-    max_wavelength = max([float(i.rstrip()) for i in header_dict['wavelength']])
-    min_wavelength = min([float(i.rstrip()) for i in header_dict['wavelength']])
+    max_wavelength = array.max_wavelength
+    min_wavelength = array.min_wavelength
     # Dictionary of wavelength and it's index in the list
-    wavelength_dict = {}
-    for j, wavelength in enumerate(header_dict["wavelength"]):
-        wavelength_dict.update({wavelength: j})
+    wavelength_dict = array.wavelength_dict.copy()
+    array_data = array.array_data.copy()
 
     if index.upper() == "NDVI":
         if (max_wavelength + fudge_factor) >= 800 and (min_wavelength - fudge_factor) <= 670:
             # Obtain index that best represents NIR and red bands
             nir_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
             red_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 670)
-            nir = (array[:, :, [nir_index]] + array[:, :, [nir_index + 4]] + array[:, :, [nir_index - 4]]) / 3
-            red = (array[:, :, [red_index]] + array[:, :, [red_index + 4]] + array[:, :, [red_index - 4]]) / 3
+            nir = (array_data[:, :, [nir_index]] + array_data[:, :, [nir_index + 4]] + array_data[:, :,
+                                                                                       [nir_index - 4]]) / 3
+            red = (array_data[:, :, [red_index]] + array_data[:, :, [red_index + 4]] + array_data[:, :,
+                                                                                       [red_index - 4]]) / 3
             ndvi = (nir - red) / (nir + red)
             index_array_raw = np.transpose(np.transpose(ndvi)[0])
 
@@ -49,7 +49,7 @@ def extract_index(array, header_dict, index="NDVI", fudge_factor=20):
             datandvi = all_positive.astype(np.float64) / 2  # normalize the data to 0 - 1
             index_array = (255 * datandvi).astype(np.uint8)  # scale to 255
         else:
-            fatal_error("Available wavelengths are not suitable for calculating NDVI. Try increasing fudge factor." )
+            fatal_error("Available wavelengths are not suitable for calculating NDVI. Try increasing fudge factor.")
 
 
     elif index.upper() == "GDVI":
@@ -57,8 +57,10 @@ def extract_index(array, header_dict, index="NDVI", fudge_factor=20):
         if (max_wavelength + fudge_factor) >= 800 and (min_wavelength - fudge_factor) <= 680:
             nir_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
             red_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 680)
-            nir = (array[:, :, [nir_index]] + array[:, :, [nir_index + 4]] + array[:, :, [nir_index - 4]]) / 3
-            red = (array[:, :, [red_index]] + array[:, :, [red_index + 4]] + array[:, :, [red_index - 4]]) / 3
+            nir = (array_data[:, :, [nir_index]] + array_data[:, :, [nir_index + 4]] + array_data[:, :,
+                                                                                       [nir_index - 4]]) / 3
+            red = (array_data[:, :, [red_index]] + array_data[:, :, [red_index + 4]] + array_data[:, :,
+                                                                                       [red_index - 4]]) / 3
             gdvi = nir - red
             index_array_raw = np.transpose(np.transpose(gdvi)[0])
 
@@ -74,8 +76,8 @@ def extract_index(array, header_dict, index="NDVI", fudge_factor=20):
         if (max_wavelength + fudge_factor) >= 800 and (min_wavelength - fudge_factor) <= 680:
             nir_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
             red_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 680)
-            nir = (array[:, :, [nir_index]])
-            red = (array[:, :, [red_index]])
+            nir = (array_data[:, :, [nir_index]])
+            red = (array_data[:, :, [red_index]])
             savi = (1.5 * (nir - red)) / (red + nir + 0.5)
             index_array_raw = np.transpose(np.transpose(savi)[0])
 
@@ -86,10 +88,18 @@ def extract_index(array, header_dict, index="NDVI", fudge_factor=20):
         else:
             fatal_error("Available wavelengths are not suitable for calculating SAVI. Try increasing fudge factor.")
 
+    index_array = Spectral_data(array_data=index_array, max_wavelength=None,
+                                min_wavelength=None, d_type=np.uint8,
+                                wavelength_dict=None, samples=array.samples,
+                                lines=array.lines, interleave=array.interleave,
+                                wavelength_units=array.wavelength_units, array_type="index_" + index.lower(),
+                                filename=array.filename)
+
     if params.debug == "plot":
         # Gamma correct pseudo_rgb image
-        plot_image(index_array)
+        plot_image(index_array.array_data)
     elif params.debug == "print":
-        print_image(index_array, os.path.join(params.debug_outdir, str(params.device) + index + "_index.png"))
+        print_image(index_array.array_data,
+                    os.path.join(params.debug_outdir, str(params.device) + index + "_index.png"))
 
     return index_array

--- a/plantcv/plantcv/hyperspectral/read_data.py
+++ b/plantcv/plantcv/hyperspectral/read_data.py
@@ -6,6 +6,7 @@ import numpy as np
 from plantcv.plantcv import params
 from plantcv.plantcv import plot_image
 from plantcv.plantcv import print_image
+from plantcv.plantcv import Spectral_data
 
 
 def _find_closest(A, target):

--- a/plantcv/plantcv/hyperspectral/read_data.py
+++ b/plantcv/plantcv/hyperspectral/read_data.py
@@ -116,8 +116,8 @@ def read_data(filename):
     pseudo_rgb = pseudo_rgb ** (1 / 2.2)
 
     # Create an instance of the spectral_data class
-    spectral_array = Spectral_data(array_data=array_data, max_wavelength=header_dict["wavelength"][-1],
-                                   min_wavelength=header_dict["wavelength"][0], d_type=header_dict["data type"],
+    spectral_array = Spectral_data(array_data=array_data, max_wavelength=float(header_dict["wavelength"][-1]),
+                                   min_wavelength=float(header_dict["wavelength"][0]), d_type=header_dict["data type"],
                                    wavelength_dict=wavelength_dict, samples=int(header_dict["samples"]),
                                    lines=int(header_dict["lines"]), interleave=header_dict["interleave"],
                                    wavelength_units=header_dict["wavelength units"], array_type="datacube",

--- a/plantcv/plantcv/readimage.py
+++ b/plantcv/plantcv/readimage.py
@@ -40,7 +40,7 @@ def readimage(filename, mode="native"):
         img = inputarray.values
     elif mode.upper() == "ENVI":
         array_data, header_dict = read_data(filename)
-        return array_data, header_dict
+        return array_data
     else:
         img = cv2.imread(filename, -1)
 

--- a/tests/hyperspectral_data/darkReference2.hdr
+++ b/tests/hyperspectral_data/darkReference2.hdr
@@ -11,7 +11,7 @@ sensor type = Unknown
 byte order = 0
 wavelength units = nm
 wavelength = {
-513.342p
+513.342
 ,513.342
 ,513.342
 ,513.342

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3578,15 +3578,21 @@ def test_plantcv_hyperspectral_extract_index_ndvi_bad_input():
 
 
 def test_plantcv_hyperspectral_extract_index_gdvi_bad_input():
-    array_data = TEST_ACUTE_RESULT
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug = None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="SAVI")
     with pytest.raises(RuntimeError):
-        index_array = pcv.hyperspectral.extract_index(array=array_data, index="GDVI")
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="GDVI")
 
 
 def test_plantcv_hyperspectral_extract_index_savi_bad_input():
-    array_data = TEST_ACUTE_RESULT
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug = None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="SAVI")
     with pytest.raises(RuntimeError):
-        index_array = pcv.hyperspectral.extract_index(array=array_data, index="SAVI")
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="SAVI")
 
 
 def test_plantcv_hyperspectral_analyze_spectral():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1075,7 +1075,7 @@ def test_plantcv_apply_mask_hyperspectral():
     pcv.params.debug_outdir = cache_dir
     # Read in test data
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
-    hyper_array, dict = pcv.hyperspectral.read_data(filename=spectral_filename)
+    hyper_array = pcv.hyperspectral.read_data(filename=spectral_filename)
 
     mask = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_BINARY), -1)
     img = np.ones((2056, 2454))
@@ -1086,7 +1086,7 @@ def test_plantcv_apply_mask_hyperspectral():
     _ = pcv.apply_mask(rgb_img=img_stacked, mask=img, mask_color="black")
     # Test with debug = "plot"
     pcv.params.debug = "plot"
-    masked_array = pcv.apply_mask(rgb_img=hyper_array, mask=img, mask_color="black")
+    masked_array = pcv.apply_mask(rgb_img=hyper_array.array_data, mask=img, mask_color="black")
     assert np.mean(masked_array) < np.mean(img_stacked)
 
 
@@ -3521,15 +3521,15 @@ def test_plantcv_hyperspectral_read_data_default():
 def test_plantcv_hyperspectral_read_data_no_default_bands():
     pcv.params.debug = "plot"
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA,HYPERSPECTRAL_DATA_NO_DEFAULT)
-    array_data, header_dict = pcv.hyperspectral.read_data(filename=spectral_filename)
-    assert np.shape(array_data) == (1, 800, 978)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    assert np.shape(array_data.array_data) == (1, 800, 978)
 
 
 def test_plantcv_hyperspectral_read_data_approx_pseudorgb():
     pcv.params.debug = "plot"
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA,HYPERSPECTRAL_DATA_APPROX_PSEUDO)
-    array_data, header_dict = pcv.hyperspectral.read_data(filename=spectral_filename)
-    assert np.shape(array_data) == (1, 800, 978)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    assert np.shape(array_data.array_data) == (1, 800, 978)
 
 
 def test_plantcv_hyperspectral_extract_index_ndvi():
@@ -3538,12 +3538,12 @@ def test_plantcv_hyperspectral_extract_index_ndvi():
     pcv.params.debug_outdir = cache_dir
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
-    array_data, header_dict = pcv.hyperspectral.read_data(filename=spectral_filename)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
     pcv.params.debug = "plot"
-    _ = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="NDVI")
+    _ = pcv.hyperspectral.extract_index(array=array_data, index="NDVI")
     pcv.params.debug = "print"
-    index_array = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="NDVI")
-    assert np.shape(index_array) == (1,800)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="NDVI")
+    assert np.shape(index_array.array_data) == (1,800)
 
 
 def test_plantcv_hyperspectral_extract_index_gdvi():
@@ -3552,9 +3552,9 @@ def test_plantcv_hyperspectral_extract_index_gdvi():
     pcv.params.debug_outdir = cache_dir
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
-    array_data, header_dict = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="GDVI")
-    assert np.shape(index_array) == (1,800) and np.max(index_array) == 127
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="GDVI")
+    assert np.shape(index_array.array_data) == (1,800) and np.max(index_array.array_data) == 127
 
 
 def test_plantcv_hyperspectral_extract_index_savi():
@@ -3563,23 +3563,23 @@ def test_plantcv_hyperspectral_extract_index_savi():
     pcv.params.debug_outdir = cache_dir
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
-    array_data, header_dict = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="SAVI")
-    assert np.shape(index_array) == (1,800) and np.max(index_array) == 127
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="SAVI")
+    assert np.shape(index_array.array_data) == (1,800) and np.max(index_array.array_data) == 127
 
 
 def test_plantcv_hyperspectral_extract_index_ndvi_bad_input():
     header_dict = HYPERSPECTRAL_HDR_SMALL_RANGE
     array_data = TEST_ACUTE_RESULT
     with pytest.raises(RuntimeError):
-        index_array = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="NDVI")
+        index_array = pcv.hyperspectral.extract_index(array=array_data, index="NDVI")
 
 
 def test_plantcv_hyperspectral_extract_index_gdvi_bad_input():
     header_dict = HYPERSPECTRAL_HDR_SMALL_RANGE
     array_data = TEST_ACUTE_RESULT
     with pytest.raises(RuntimeError):
-        index_array = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="GDVI")
+        index_array = pcv.hyperspectral.extract_index(array=array_data, index="GDVI")
 
 
 def test_plantcv_hyperspectral_extract_index_savi_bad_input():
@@ -3596,12 +3596,11 @@ def test_plantcv_hyperspectral_analyze_spectral():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     mask = cv2.imread(os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_MASK), -1)
-    array_data, header_dict = pcv.hyperspectral.read_data(filename=spectral_filename)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
     pcv.params.debug = "plot"
-    _ = pcv.hyperspectral.analyze_spectral(array=array_data, header_dict=header_dict, mask=mask,
-                                                      histplot=True)
+    _ = pcv.hyperspectral.analyze_spectral(array=array_data, mask=mask, histplot=True)
     pcv.params.debug = "print"
-    analysis_img = pcv.hyperspectral.analyze_spectral(array=array_data, header_dict=header_dict, mask=mask, histplot=True)
+    analysis_img = pcv.hyperspectral.analyze_spectral(array=array_data, mask=mask, histplot=True)
     assert len(pcv.outputs.observations['spectral_frequencies']['value']) == 978
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3569,24 +3569,24 @@ def test_plantcv_hyperspectral_extract_index_savi():
 
 
 def test_plantcv_hyperspectral_extract_index_ndvi_bad_input():
-    header_dict = HYPERSPECTRAL_HDR_SMALL_RANGE
-    array_data = TEST_ACUTE_RESULT
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="SAVI")
     with pytest.raises(RuntimeError):
-        index_array = pcv.hyperspectral.extract_index(array=array_data, index="NDVI")
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="NDVI")
 
 
 def test_plantcv_hyperspectral_extract_index_gdvi_bad_input():
-    header_dict = HYPERSPECTRAL_HDR_SMALL_RANGE
     array_data = TEST_ACUTE_RESULT
     with pytest.raises(RuntimeError):
         index_array = pcv.hyperspectral.extract_index(array=array_data, index="GDVI")
 
 
 def test_plantcv_hyperspectral_extract_index_savi_bad_input():
-    header_dict = HYPERSPECTRAL_HDR_SMALL_RANGE
     array_data = TEST_ACUTE_RESULT
     with pytest.raises(RuntimeError):
-        index_array = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="SAVI")
+        index_array = pcv.hyperspectral.extract_index(array=array_data, index="SAVI")
 
 
 def test_plantcv_hyperspectral_analyze_spectral():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3543,7 +3543,7 @@ def test_plantcv_hyperspectral_extract_index_ndvi():
     _ = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="NDVI")
     pcv.params.debug = "print"
     index_array = pcv.hyperspectral.extract_index(array=array_data, header_dict=header_dict, index="NDVI")
-    assert np.shape(index_array) == (1,800) 
+    assert np.shape(index_array) == (1,800)
 
 
 def test_plantcv_hyperspectral_extract_index_gdvi():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2265,8 +2265,8 @@ def test_plantcv_readimage_csv():
 
 def test_plantcv_readimage_envi():
     pcv.params.debug = None
-    array_data, header_dict = pcv.readimage(filename=os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA), mode="envi")
-    assert header_dict["bands"] == '978'
+    array_data = pcv.readimage(filename=os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA), mode="envi")
+    assert len(array_data.wavelength_dict) == '978'
 
 
 def test_plantcv_readimage_bad_file():
@@ -3512,10 +3512,10 @@ def test_plantcv_hyperspectral_read_data_default():
     pcv.params.debug_outdir = cache_dir
     pcv.params.debug = "plot"
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA,HYPERSPECTRAL_DATA)
-    _, _ = pcv.hyperspectral.read_data(filename=spectral_filename)
+    _ = pcv.hyperspectral.read_data(filename=spectral_filename)
     pcv.params.debug = "print"
-    array_data, header_dict = pcv.hyperspectral.read_data(filename=spectral_filename)
-    assert np.shape(array_data) == (1, 800, 978)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    assert np.shape(array_data.array_data) == (1, 800, 978)
 
 
 def test_plantcv_hyperspectral_read_data_no_default_bands():


### PR DESCRIPTION
**Describe your changes**
Added a `Spectral_data` class to the hyperspectral sub-package in order to streamline inputs to functions. Attach all the important metadata from the header dictionary that is created while reading in ENVI data as properties of the spectral data object as the image is read in. 

**Type of update**
* Enhancement


**Associated issues**
#203 

**Additional context**
The instances of this class have a lot of properties since there is a lot of metadata about a hyperspectral datacube that is important to analysis functions used on it. We plan to do a similar transition to the rest of the PlantCV functions. This should remove the need for repetitive inputs (e.g. contours and hierarchies) since we can make them attributes for objects of an image array data class. 