### PR TITLE
add timestamp format argument to plantcv-workflow

### DIFF
--- a/docs/pipeline_parallel.md
+++ b/docs/pipeline_parallel.md
@@ -24,6 +24,7 @@ We normally execute workflows in a shell script or in in a condor job file (or d
 * -j is the --json, json database name
 * -m is the --mask any image mask that you would like to provide
 * -T is the --cpu # of cpu processes you would like to use.
+* -s is the --timestampformat specify timestamp format for strptime C library. default is '%Y-%m-%d %H:%M:%S.%f' to parse '2010-10-10 10:10:10.123'. see [strptime docs](https://docs.python.org/3.7/library/datetime.html#strftime-and-strptime-behavior) for supported codes.
 * -w is the --writeimg option, if True will write output images. default= False
 * -c is the --create option to overwrite an json database if it exists, if you are creating a new database or appending to database, do NOT add the -c flag
 * -o is the --other_args option, used to pass non-standard options to the workflow script. Must take the form `--other_args="--option1 value1 --option2 value2"`
@@ -147,7 +148,7 @@ AABA002948_2014-03-14 03-29-45_Pilot-031014_VIS_TV_z3500.png
 
 Valid metadata that can be collected from filenames are `camera`, `imgtype`, `zoom`, `exposure`, `gain`, `frame`, `lifter`, `timestamp`, `id`, `plantbarcode`, `treatment`, `cartag`, `measurementlabel`, and `other`. 
 
-`timestamps` must be of a format readable by [dateutil.parser.parse()](https://dateutil.readthedocs.io/en/stable/parser.html). Separator between date and time should be one of the `JUMP` listed [here](https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.parserinfo.JUMP). The ISO standard is a `T`.
+For a flat direcotory of images (`--adaptor = filename`) you are required to specify the timestamp format (`--timestampformat`, `-s`) code for the [strptime C library](https://docs.python.org/3.7/library/datetime.html#strftime-and-strptime-behavior). For the example above you would use `--timestampformat "%Y-%m-%d %H-%M-%S"`.
 
 **Next, run images over a flat directory with images named as described above:**
 
@@ -163,6 +164,8 @@ We normally execute workflows as a shell script or as a condor jobfile (or dagma
 /home/mgehan/plantcv/plantcv-workflow.py \
 -d /shares/mgehan_share/raw_data/raw_image/2016-08_pat-edger/data/split-round1/split-cam1 \
 -a filename \
+-s %y-%m-%d-%H:%M
+-l _
 -p /home/mgehan/pat-edger/round1-python-pipelines/2016-08_pat-edger_brassica-cam1-splitimg.py \
 -j edger-round1-brassica.json \
 -i /shares/mgehan_share/raw_data/raw_image/2016-08_pat-edger/data/split-round1/split-cam1/output \
@@ -214,6 +217,7 @@ plantcv-workflow.py \
 --outdir output_directory \
 --meta camera,plantbarcode,timestamp \
 --delimiter '(.{3})_(.+)_(\d{4}-\d{2}-\d{2} \d{2}_\d{2}_\d{2})'
+--timestampformat "%Y-%m-%d %H_%M_%S"
 
 ```
 

--- a/plantcv-workflow.py
+++ b/plantcv-workflow.py
@@ -144,14 +144,15 @@ def options():
                         help='Coprocess the specified imgtype with the imgtype specified in --match '
                              '(e.g. coprocess NIR images with VIS).',
                         default=None)
+    parser.add_argument("-s", "--timestampformat", 
+                        help='a date format code compatible with strptime C library, '
+                             'e.g. "%Y-%m-%d %H_%M_%S", except "%" symbols must be escaped on Windows with "%" '
+                             'e.g. "%%Y-%%m-%%d %%H_%%M_%%S". Required if adaptor = filename.',
+                        required=False,
+                        default='%Y-%m-%d %H:%M:%S.%f')
     parser.add_argument("-w", "--writeimg", help='Include analysis images in output.', default=False,
                         action="store_true")
     parser.add_argument("-o", "--other_args", help='Other arguments to pass to the workflow script.', required=False)
-    parser.add_argument("-s", "--timestampformat", 
-                        help='a date format code compatible with strptime C library, '
-                             'e.g. "%%Y-%%m-%%d %%H_%%M_%%S", except "%" symbols must be escaped on Windows with "%" '
-                             '"%%Y-%%m-%%d %%H_%%M_%%S". Required if adaptor = filename.',
-                        required=False)
     args = parser.parse_args()
 
     if not os.path.exists(args.dir):
@@ -177,7 +178,6 @@ def options():
         os.makedirs(args.jobdir)
     except IOError as e:
         raise IOError("{0}: {1}".format(e.strerror, args.jobdir))
-
 
     if args.dates:
         dates = args.dates.split('_')

--- a/plantcv-workflow.py
+++ b/plantcv-workflow.py
@@ -147,18 +147,24 @@ def options():
     parser.add_argument("-w", "--writeimg", help='Include analysis images in output.', default=False,
                         action="store_true")
     parser.add_argument("-o", "--other_args", help='Other arguments to pass to the workflow script.', required=False)
+    parser.add_argument("-s", "--timestampformat", help='a date format code compatible with strptime C library. '%' symbols must be escaped on Windows with %. E.G. "%%Y-%%m-%%d %%H_%%M_%%S". required if adaptor = filename.', required=False)
     args = parser.parse_args()
 
     if not os.path.exists(args.dir):
         raise IOError("Directory does not exist: {0}".format(args.dir))
     if not os.path.exists(args.workflow):
         raise IOError("File does not exist: {0}".format(args.workflow))
+    if args.adaptor != 'phenofront' and args.adaptor != 'filename':
+        raise ValueError("Adaptor must be either phenofront or filename")
     if args.adaptor is 'phenofront':
         if not os.path.exists(os.path.join(args.dir, 'SnapshotInfo.csv')):
             raise IOError(
                 'The snapshot metadata file SnapshotInfo.csv does not exist in {0}. '
                 'Perhaps you meant to use a different adaptor?'.format(
                     args.dir))
+    elif args.adaptor == 'filename':
+        if not args.timestampformat:
+            raise RuntimeError('A timestamp format (--timestampformat) must be provided when --adaptor = filename')
     if not os.path.exists(args.outdir):
         raise IOError("Directory does not exist: {0}".format(args.outdir))
 
@@ -168,8 +174,6 @@ def options():
     except IOError as e:
         raise IOError("{0}: {1}".format(e.strerror, args.jobdir))
 
-    if args.adaptor != 'phenofront' and args.adaptor != 'filename':
-        raise ValueError("Adaptor must be either phenofront or filename")
 
     if args.dates:
         dates = args.dates.split('_')
@@ -266,7 +270,7 @@ def main():
     # Read image file names
     ###########################################
     jobcount, meta = pcvp.metadata_parser(data_dir=args.dir, meta_fields=args.fields, valid_meta=args.valid_meta,
-                                          meta_filters=args.imgtype, start_date=args.start_date, end_date=args.end_date,
+                                          meta_filters=args.imgtype, date_format=args.timestampformat, start_date=args.start_date, end_date=args.end_date,
                                           error_log=error_log, delimiter=args.delimiter, file_type=args.type,
                                           coprocess=args.coprocess)
     ###########################################

--- a/plantcv-workflow.py
+++ b/plantcv-workflow.py
@@ -147,7 +147,11 @@ def options():
     parser.add_argument("-w", "--writeimg", help='Include analysis images in output.', default=False,
                         action="store_true")
     parser.add_argument("-o", "--other_args", help='Other arguments to pass to the workflow script.', required=False)
-    parser.add_argument("-s", "--timestampformat", help='a date format code compatible with strptime C library. '%' symbols must be escaped on Windows with %. E.G. "%%Y-%%m-%%d %%H_%%M_%%S". required if adaptor = filename.', required=False)
+    parser.add_argument("-s", "--timestampformat", 
+                        help='a date format code compatible with strptime C library, '
+                             'e.g. "%%Y-%%m-%%d %%H_%%M_%%S", except "%" symbols must be escaped on Windows with "%" '
+                             '"%%Y-%%m-%%d %%H_%%M_%%S". Required if adaptor = filename.',
+                        required=False)
     args = parser.parse_args()
 
     if not os.path.exists(args.dir):
@@ -156,7 +160,7 @@ def options():
         raise IOError("File does not exist: {0}".format(args.workflow))
     if args.adaptor != 'phenofront' and args.adaptor != 'filename':
         raise ValueError("Adaptor must be either phenofront or filename")
-    if args.adaptor is 'phenofront':
+    if args.adaptor == 'phenofront':
         if not os.path.exists(os.path.join(args.dir, 'SnapshotInfo.csv')):
             raise IOError(
                 'The snapshot metadata file SnapshotInfo.csv does not exist in {0}. '
@@ -164,7 +168,7 @@ def options():
                     args.dir))
     elif args.adaptor == 'filename':
         if not args.timestampformat:
-            raise RuntimeError('A timestamp format (--timestampformat) must be provided when --adaptor = filename')
+            raise ValueError('A timestamp format (--timestampformat) must be provided when --adaptor = filename')
     if not os.path.exists(args.outdir):
         raise IOError("Directory does not exist: {0}".format(args.outdir))
 

--- a/plantcv/parallel/__init__.py
+++ b/plantcv/parallel/__init__.py
@@ -1,6 +1,7 @@
-__all__ = ["metadata_parser", "job_builder", "process_results", "multiprocess"]
+__all__ = ["metadata_parser", "job_builder", "process_results", "multiprocess", "check_date_range"]
 
 from plantcv.parallel.parsers import metadata_parser
+from plantcv.parallel.parsers import check_date_range
 from plantcv.parallel.job_builder import job_builder
 from plantcv.parallel.process_results import process_results
 from plantcv.parallel.multiprocess import multiprocess

--- a/plantcv/parallel/parsers.py
+++ b/plantcv/parallel/parsers.py
@@ -6,8 +6,8 @@ from dateutil.parser import parse as dt_parser
 
 # Parse metadata from filenames in a directory
 ###########################################
-def metadata_parser(data_dir, meta_fields, valid_meta, meta_filters, date_format, start_date, end_date, error_log, delimiter="_",
-                    file_type="png", coprocess=None):
+def metadata_parser(data_dir, meta_fields, valid_meta, meta_filters, date_format, 
+                    start_date, end_date, error_log, delimiter="_", file_type="png", coprocess=None):
     """Reads metadata the input data directory.
 
     Args:

--- a/plantcv/parallel/parsers.py
+++ b/plantcv/parallel/parsers.py
@@ -119,7 +119,7 @@ def metadata_parser(data_dir, meta_fields, valid_meta, meta_filters, date_format
                                 img_meta[field] = valid_meta[field]["value"]
 
                         if start_date and end_date and img_meta['timestamp'] is not None:
-                            in_date_range = _check_date_range(start_date, end_date, img_meta['timestamp'], date_format)
+                            in_date_range = check_date_range(start_date, end_date, img_meta['timestamp'], date_format)
                             if in_date_range is False:
                                 img_pass = 0
 
@@ -199,7 +199,7 @@ def metadata_parser(data_dir, meta_fields, valid_meta, meta_filters, date_format
                                 img_meta[field] = valid_meta[field]["value"]
 
                         if start_date and end_date and img_meta['timestamp'] is not None:
-                            in_date_range = _check_date_range(start_date, end_date, img_meta['timestamp'], date_format)
+                            in_date_range = check_date_range(start_date, end_date, img_meta['timestamp'], date_format)
                             if in_date_range is False:
                                 img_pass = 0
 
@@ -214,7 +214,7 @@ def metadata_parser(data_dir, meta_fields, valid_meta, meta_filters, date_format
 
 # Check to see if the image was taken between a specified date range
 ###########################################
-def _check_date_range(start_date, end_date, img_time, date_format):
+def check_date_range(start_date, end_date, img_time, date_format):
     """Check image time versus included date range.
 
     Args:
@@ -230,10 +230,14 @@ def _check_date_range(start_date, end_date, img_time, date_format):
     :return: bool
     """
 
-    if date_format is None:
-        date_format = '%Y-%m-%d %H-%M-%S'
     # Convert image datetime to unix time
-    timestamp = datetime.datetime.strptime(img_time, date_format)
+    try:
+        timestamp = datetime.datetime.strptime(img_time, date_format)
+    except ValueError as e:
+        print(e)
+        print('Please specify the correct --timestampformat')
+        quit()
+    
     time_delta = timestamp - datetime.datetime(1970, 1, 1)
     unix_time = (time_delta.days * 24 * 3600) + time_delta.seconds
     # Does the image date-time fall outside or inside the included range

--- a/plantcv/parallel/parsers.py
+++ b/plantcv/parallel/parsers.py
@@ -119,7 +119,7 @@ def metadata_parser(data_dir, meta_fields, valid_meta, meta_filters, date_format
                                 img_meta[field] = valid_meta[field]["value"]
 
                         if start_date and end_date and img_meta['timestamp'] is not None:
-                            in_date_range = _check_date_range(start_date, end_date, img_meta['timestamp'])
+                            in_date_range = _check_date_range(start_date, end_date, img_meta['timestamp'], date_format)
                             if in_date_range is False:
                                 img_pass = 0
 
@@ -214,7 +214,7 @@ def metadata_parser(data_dir, meta_fields, valid_meta, meta_filters, date_format
 
 # Check to see if the image was taken between a specified date range
 ###########################################
-def _check_date_range(start_date, end_date, img_time, date_format='%Y-%m-%d %H-%M-%S'):
+def _check_date_range(start_date, end_date, img_time, date_format):
     """Check image time versus included date range.
 
     Args:
@@ -230,6 +230,8 @@ def _check_date_range(start_date, end_date, img_time, date_format='%Y-%m-%d %H-%
     :return: bool
     """
 
+    if date_format is None:
+        date_format = '%Y-%m-%d %H-%M-%S'
     # Convert image datetime to unix time
     timestamp = datetime.datetime.strptime(img_time, date_format)
     time_delta = timestamp - datetime.datetime(1970, 1, 1)

--- a/plantcv/parallel/parsers.py
+++ b/plantcv/parallel/parsers.py
@@ -3,7 +3,6 @@ import re
 import datetime
 from dateutil.parser import parse as dt_parser
 
-
 # Parse metadata from filenames in a directory
 ###########################################
 def metadata_parser(data_dir, meta_fields, valid_meta, meta_filters, date_format, 
@@ -234,9 +233,7 @@ def check_date_range(start_date, end_date, img_time, date_format):
     try:
         timestamp = datetime.datetime.strptime(img_time, date_format)
     except ValueError as e:
-        print(e)
-        print('Please specify the correct --timestampformat')
-        quit()
+        raise SystemExit(str(e) + '\n  --> Please specify the correct --timestampformat argument <--\n')
     
     time_delta = timestamp - datetime.datetime(1970, 1, 1)
     unix_time = (time_delta.days * 24 * 3600) + time_delta.seconds

--- a/plantcv/utils/converters.py
+++ b/plantcv/utils/converters.py
@@ -18,9 +18,10 @@ def json2csv(json_file, csv_file):
         for key, var in data["variables"].items():
             if var["category"] == "metadata":
                 meta_vars.append(key)
-            elif var["datatype"] in ["<class 'bool'>", "<class 'int'>", "<class 'float'>", "<class 'str'>"]:
+            elif var["datatype"] in ["<class 'bool'>", "<class 'int'>", "<class 'float'>", "<class 'str'>",
+                                     "<type 'bool'>", "<type 'int'>", "<type 'float'>", "<type 'str'>"]:
                 scalar_vars.append(key)
-            elif var["datatype"] in ["<class 'list'>"]:
+            elif var["datatype"] in ["<class 'list'>", "<type 'list'>"]:
                 multi_vars.append(key)
 
         # Create a CSV file of single-value traits

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -194,9 +194,10 @@ def test_plantcv_parallel_metadata_parser_snapshots():
     meta_filters = {"imgtype": "VIS"}
     start_date = 1413936000
     end_date = 1414022400
+    date_format = '%Y-%m-%d %H:%M:%S.%f'
     error_log = open(os.path.join(TEST_TMPDIR, "error.log"), 'w')
     jobcount, meta = plantcv.parallel.metadata_parser(data_dir=data_dir, meta_fields=META_FIELDS,
-                                                      valid_meta=VALID_META, meta_filters=meta_filters,
+                                                      valid_meta=VALID_META, meta_filters=meta_filters, date_format=date_format,
                                                       start_date=start_date, end_date=end_date, error_log=error_log,
                                                       delimiter="_", file_type="jpg", coprocess="NIR")
     assert meta == METADATA_COPROCESS
@@ -207,9 +208,10 @@ def test_plantcv_parallel_metadata_parser_snapshots_coimg():
     meta_filters = {"imgtype": "VIS"}
     start_date = 1413936000
     end_date = 1414022400
+    date_format = '%Y-%m-%d %H:%M:%S.%f'
     error_log = open(os.path.join(TEST_TMPDIR, "error.log"), 'w')
     jobcount, meta = plantcv.parallel.metadata_parser(data_dir=data_dir, meta_fields=META_FIELDS,
-                                                      valid_meta=VALID_META, meta_filters=meta_filters,
+                                                      valid_meta=VALID_META, meta_filters=meta_filters, date_format=date_format,
                                                       start_date=start_date, end_date=end_date, error_log=error_log,
                                                       delimiter="_", file_type="jpg", coprocess="FAKE")
     assert meta == METADATA_VIS_ONLY
@@ -220,9 +222,10 @@ def test_plantcv_parallel_metadata_parser_images():
     meta_filters = {"imgtype": "VIS"}
     start_date = 1413936000
     end_date = 1414022400
+    date_format = '%Y' # no date in filename so it skips check date range and date_format doesn't matter
     error_log = open(os.path.join(TEST_TMPDIR, "error.log"), 'w')
     jobcount, meta = plantcv.parallel.metadata_parser(data_dir=data_dir, meta_fields=META_FIELDS,
-                                                      valid_meta=VALID_META, meta_filters=meta_filters,
+                                                      valid_meta=VALID_META, meta_filters=meta_filters,date_format=date_format,
                                                       start_date=start_date, end_date=end_date, error_log=error_log,
                                                       delimiter="_", file_type="jpg", coprocess=None)
     expected = {
@@ -251,9 +254,10 @@ def test_plantcv_parallel_metadata_parser_regex():
     meta_filters = {"imgtype": "VIS"}
     start_date = 1413936000
     end_date = 1414022400
+    date_format = '%Y-%m-%d %H:%M:%S.%f'
     error_log = open(os.path.join(TEST_TMPDIR, "error.log"), 'w')
     jobcount, meta = plantcv.parallel.metadata_parser(data_dir=data_dir, meta_fields=META_FIELDS,
-                                                      valid_meta=VALID_META, meta_filters=meta_filters,
+                                                      valid_meta=VALID_META, meta_filters=meta_filters,date_format=date_format,
                                                       start_date=start_date, end_date=end_date, error_log=error_log,
                                                       delimiter='(VIS)_(SV)_(\d+)_(z1)_(h1)_(g0)_(e82)_(\d+)',
                                                       file_type="jpg", coprocess=None)
@@ -280,17 +284,30 @@ def test_plantcv_parallel_metadata_parser_regex():
 
 def test_plantcv_parallel_metadata_parser_images_outside_daterange():
     data_dir = os.path.join(PARALLEL_TEST_DATA, TEST_IMG_DIR2)
-    meta_filters = {"imgtype": "VIS"}
+    meta_filters = {"imgtype": "NIR"}
     start_date = 10
     end_date = 10
+    date_format = "%Y-%m-%d %H_%M_%S"
     meta_fields = {"imgtype": 0, "camera": 1, "frame": 2, "zoom": 3, "lifter": 4, "gain": 5, "exposure": 6,
                    "timestamp": 7}
     error_log = open(os.path.join(TEST_TMPDIR, "error.log"), 'w')
     jobcount, meta = plantcv.parallel.metadata_parser(data_dir=data_dir, meta_fields=meta_fields,
-                                                      valid_meta=VALID_META, meta_filters=meta_filters,
+                                                      valid_meta=VALID_META, meta_filters=meta_filters, date_format=date_format,
                                                       start_date=start_date, end_date=end_date, error_log=error_log,
-                                                      delimiter="_", file_type="jpg", coprocess=None)
+                                                      delimiter="(NIR)_(SV)_(\d)_(z1)_(h1)_(g0)_(e65)_(\d{4}-\d{2}-\d{2} \d{2}_\d{2}_\d{2})", 
+                                                      file_type="jpg", coprocess=None)
     assert meta == {}
+
+
+def test_plantcv_parallel_check_date_range_wrongdateformat():
+    start_date = 10
+    end_date = 10
+    img_time = '2010-10-10'
+
+    with pytest.raises(ValueError, match = r'does not match format'):
+        date_format = '%Y%m%d'
+        _ = plantcv.parallel.check_date_range(
+            start_date, end_date, img_time, date_format)
 
 
 def test_plantcv_parallel_metadata_parser_snapshot_outside_daterange():
@@ -298,9 +315,10 @@ def test_plantcv_parallel_metadata_parser_snapshot_outside_daterange():
     meta_filters = {"imgtype": "VIS"}
     start_date = 10
     end_date = 10
+    date_format = '%Y-%m-%d %H:%M:%S.%f'
     error_log = open(os.path.join(TEST_TMPDIR, "error.log"), 'w')
     jobcount, meta = plantcv.parallel.metadata_parser(data_dir=data_dir, meta_fields=META_FIELDS,
-                                                      valid_meta=VALID_META, meta_filters=meta_filters,
+                                                      valid_meta=VALID_META, meta_filters=meta_filters,date_format=date_format,
                                                       start_date=start_date, end_date=end_date, error_log=error_log,
                                                       delimiter="_", file_type="jpg", coprocess=None)
 
@@ -312,9 +330,10 @@ def test_plantcv_parallel_metadata_parser_fail_images():
     meta_filters = {"cartag": "VIS"}
     start_date = 10
     end_date = 10
+    date_format = '%Y-%m-%d %H:%M:%S.%f'
     error_log = open(os.path.join(TEST_TMPDIR, "error.log"), 'w')
     jobcount, meta = plantcv.parallel.metadata_parser(data_dir=data_dir, meta_fields=META_FIELDS,
-                                                      valid_meta=VALID_META, meta_filters=meta_filters,
+                                                      valid_meta=VALID_META, meta_filters=meta_filters,date_format=date_format,
                                                       start_date=start_date, end_date=end_date, error_log=error_log,
                                                       delimiter="_", file_type="jpg", coprocess="NIR")
 
@@ -327,9 +346,10 @@ def test_plantcv_parallel_metadata_parser_images_no_frame():
     meta_filters = {"imgtype": "VIS"}
     start_date = 1413936000
     end_date = 1414022400
+    date_format = '%Y-%m-%d %H:%M:%S.%f'
     error_log = open(os.path.join(TEST_TMPDIR, "error.log"), 'w')
     jobcount, meta = plantcv.parallel.metadata_parser(data_dir=data_dir, meta_fields=meta_fields,
-                                                      valid_meta=VALID_META, meta_filters=meta_filters,
+                                                      valid_meta=VALID_META, meta_filters=meta_filters,date_format=date_format,
                                                       start_date=start_date, end_date=end_date, error_log=error_log,
                                                       delimiter="_", file_type="jpg", coprocess="NIR")
     assert meta == {
@@ -377,9 +397,10 @@ def test_plantcv_parallel_metadata_parser_images_no_camera():
     meta_filters = {"imgtype": "VIS"}
     start_date = 1413936000
     end_date = 1414022400
+    date_format = '%Y-%m-%d %H:%M:%S.%f'
     error_log = open(os.path.join(TEST_TMPDIR, "error.log"), 'w')
     jobcount, meta = plantcv.parallel.metadata_parser(data_dir=data_dir, meta_fields=meta_fields,
-                                                      valid_meta=VALID_META, meta_filters=meta_filters,
+                                                      valid_meta=VALID_META, meta_filters=meta_filters,date_format=date_format,
                                                       start_date=start_date, end_date=end_date, error_log=error_log,
                                                       delimiter="_", file_type="jpg", coprocess="NIR")
     assert meta == {

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -304,7 +304,7 @@ def test_plantcv_parallel_check_date_range_wrongdateformat():
     end_date = 10
     img_time = '2010-10-10'
 
-    with pytest.raises(ValueError, match = r'does not match format'):
+    with pytest.raises(SystemExit, match = r'does not match format'):
         date_format = '%Y%m%d'
         _ = plantcv.parallel.check_date_range(
             start_date, end_date, img_time, date_format)


### PR DESCRIPTION
**Describe your changes**
Added a new argument to plantcv-workflow so the user can specify the timestamp format with --timestampformat or -s
I made the argument  mandatory with adaptor=filename and optional with phenofront. the Default value is %Y-%m-%d %H:%M%S.%f which I am guessing is the preexisting standard at the Danforth when using phenofront format.

**Type of update**
This both a bugfix #473  and new feature to complement regex metadata parsing feature #454 . 

**Associated issues**
Closes #473 

**Additional context**
I also fixed test for checking date_range since it was passing for the wrong reasons. I exported check_date_range to namespace so I could write a direct test. going through metadata_parser seemed heavy handed.   
We could potentially rewrite the other check_date_range tests to directly use the function now.