### PR TITLE
Stop scaling calculated indices

### DIFF
--- a/plantcv/plantcv/hyperspectral/extract_wavelength.py
+++ b/plantcv/plantcv/hyperspectral/extract_wavelength.py
@@ -36,14 +36,15 @@ def extract_wavelength(spectral_data, wavelength):
 
     # Reshape
     index_array_raw = spectral_data.array_data[:, :, [band_index]]
-    index_array_reshape = np.transpose(np.transpose(index_array_raw)[0])
+    index_array_raw = np.transpose(np.transpose(index_array_raw)[0])
 
     # Resulting array is float 32 from -1 to 1, transform into uint8 for plotting
-    all_positive = np.add(index_array_reshape, np.ones(np.shape(index_array_reshape)))
+    all_positive = np.add(index_array_raw, np.ones(np.shape(index_array_raw)))
     normalized = all_positive.astype(np.float64) / 2  # normalize the data to 0 - 1
     index_array = (255 * normalized).astype(np.uint8)  # scale to 255
 
     # Plot out grayscale image
+
     if params.debug == "plot":
         plot_image(index_array)
     elif params.debug == "print":
@@ -51,7 +52,7 @@ def extract_wavelength(spectral_data, wavelength):
                     os.path.join(params.debug_outdir, str(params.device) + str(wavelength) + "_index.png"))
 
     # Make a spectral data instance
-    index_array = Spectral_data(array_data=index_array, max_wavelength=wavelength,
+    index_array = Spectral_data(array_data=index_array_raw, max_wavelength=wavelength,
                                 min_wavelength=wavelength, d_type=np.uint8,
                                 wavelength_dict={}, samples=spectral_data.samples,
                                 lines=spectral_data.lines, interleave=spectral_data.interleave,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3719,7 +3719,7 @@ def test_plantcv_hyperspectral_analyze_index():
     pcv.hyperspectral.analyze_index(index_array=index_array, mask=mask_img)
     pcv.params.debug = "plot"
     pcv.hyperspectral.analyze_index(index_array=index_array, mask=mask_img)
-    assert pcv.outputs.observations['mean_index_savi']['value'] == 141.0
+    assert pcv.outputs.observations['mean_index_savi']['value'] == -0.11320754716981132
 
 def test_plantcv_hyperspectral_analyze_index_bad_input_mask():
     pcv.params.debug = None

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3719,7 +3719,7 @@ def test_plantcv_hyperspectral_analyze_index():
     pcv.hyperspectral.analyze_index(index_array=index_array, mask=mask_img)
     pcv.params.debug = "plot"
     pcv.hyperspectral.analyze_index(index_array=index_array, mask=mask_img)
-    assert pcv.outputs.observations['mean_index_savi']['value'] < 0
+    assert pcv.outputs.observations['mean_index_savi']['value'] > 0
 
 def test_plantcv_hyperspectral_analyze_index_bad_input_mask():
     pcv.params.debug = None

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3631,7 +3631,7 @@ def test_plantcv_hyperspectral_extract_index_gdvi():
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
     index_array = pcv.hyperspectral.extract_index(array=array_data, index="GDVI", distance=801)
-    assert np.shape(index_array.array_data) == (1,1600) and np.max(index_array.array_data) == 255
+    assert np.shape(index_array.array_data) == (1,1600) and np.max(index_array.pseudo_rgb) == 255
 
 
 def test_plantcv_hyperspectral_extract_index_ndvi():
@@ -3642,7 +3642,7 @@ def test_plantcv_hyperspectral_extract_index_ndvi():
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
     index_array = pcv.hyperspectral.extract_index(array=array_data, index="ndvi", distance=801)
-    assert np.shape(index_array.array_data) == (1,1600) and np.max(index_array.array_data) == 255
+    assert np.shape(index_array.array_data) == (1,1600) and np.max(index_array.pseudo_rgb) == 255
 
 
 def test_plantcv_hyperspectral_extract_index_savi():
@@ -3653,7 +3653,7 @@ def test_plantcv_hyperspectral_extract_index_savi():
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
     index_array = pcv.hyperspectral.extract_index(array=array_data, index="SAVI", distance=801)
-    assert np.shape(index_array.array_data) == (1,1600) and np.max(index_array.array_data) == 253
+    assert np.shape(index_array.array_data) == (1,1600) and np.max(index_array.pseudo_rgb) == 255
 
 
 def test_plantcv_hyperspectral_extract_index_ndvi_bad_input():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3719,7 +3719,7 @@ def test_plantcv_hyperspectral_analyze_index():
     pcv.hyperspectral.analyze_index(index_array=index_array, mask=mask_img)
     pcv.params.debug = "plot"
     pcv.hyperspectral.analyze_index(index_array=index_array, mask=mask_img)
-    assert pcv.outputs.observations['mean_index_savi']['value'] == -0.11320754716981132
+    assert pcv.outputs.observations['mean_index_savi']['value'] < 0
 
 def test_plantcv_hyperspectral_analyze_index_bad_input_mask():
     pcv.params.debug = None


### PR DESCRIPTION
**Describe your changes**
The function `plantcv.plantcv.hyperspectral.extract_index` had been scaling the raw calculated array into a numpy uint8 array for plotting. Instead, after these updates the function will return the raw array that is calculated based on the index selected and instead there is a scaled image stored in the `pseudo_rgb` method of the `Spectral_data` object that is created. 

**Type of update**
* feature enhancement

**Associated issues**
#203 

**Additional context**
Add any other context about the problem here.
