### PR TITLE
Hyperspectral helpers

### DIFF
--- a/plantcv/plantcv/hyperspectral/__init__.py
+++ b/plantcv/plantcv/hyperspectral/__init__.py
@@ -6,7 +6,8 @@ from plantcv.plantcv.hyperspectral.extract_index import extract_index
 from plantcv.plantcv.hyperspectral.analyze_index import analyze_index
 from plantcv.plantcv.hyperspectral.analyze_spectral import analyze_spectral
 from plantcv.plantcv.hyperspectral.calibrate import calibrate
+from plantcv.plantcv.hyperspectral._avg_reflectance import _avg_reflectance
 
 # add new functions to end of lists
 __all__ = ["read_data", "_find_closest", "extract_index", "analyze_spectral", "analyze_index", "calibrate",
-           "_make_pseudo_rgb", "extract_wavelength"]
+           "_make_pseudo_rgb", "extract_wavelength", "_avg_reflectance"]

--- a/plantcv/plantcv/hyperspectral/__init__.py
+++ b/plantcv/plantcv/hyperspectral/__init__.py
@@ -7,7 +7,8 @@ from plantcv.plantcv.hyperspectral.analyze_index import analyze_index
 from plantcv.plantcv.hyperspectral.analyze_spectral import analyze_spectral
 from plantcv.plantcv.hyperspectral.calibrate import calibrate
 from plantcv.plantcv.hyperspectral._avg_reflectance import _avg_reflectance
+from plantcv.plantcv.hyperspectral._inverse_covariance import _inverse_covariance
 
 # add new functions to end of lists
 __all__ = ["read_data", "_find_closest", "extract_index", "analyze_spectral", "analyze_index", "calibrate",
-           "_make_pseudo_rgb", "extract_wavelength", "_avg_reflectance"]
+           "_make_pseudo_rgb", "extract_wavelength", "_avg_reflectance", "_inverse_covariance"]

--- a/plantcv/plantcv/hyperspectral/_avg_reflectance.py
+++ b/plantcv/plantcv/hyperspectral/_avg_reflectance.py
@@ -1,0 +1,20 @@
+# Calculate masked average background reflectance
+
+import numpy as np
+
+
+def _avg_reflectance(spectral_data, mask):
+
+    avg_r = []
+    n_bands = len(spectral_data.wavelength_dict)
+    n_lines = spectral_data.lines
+    n_samples = spectral_data.samples
+    for i in range(0, len(spectral_data.wavelength_dict)):
+        band = spectral_data.array_data[:, :, [i]]
+        band_reshape = np.transpose(np.transpose(band)[0])
+        masked_band = band_reshape[np.where(mask > 0)]
+        band_avg = np.average(masked_band)
+        avg_r.append(band_avg)
+    avg_r = np.asarray(avg_r)
+
+    return avg_r

--- a/plantcv/plantcv/hyperspectral/_avg_reflectance.py
+++ b/plantcv/plantcv/hyperspectral/_avg_reflectance.py
@@ -4,17 +4,33 @@ import numpy as np
 
 
 def _avg_reflectance(spectral_data, mask):
+    """ Find average reflectance of masked hyperspectral data instance. This is useful for calculating a target
+        signature (n_band x 1 - column array) which is required in various GatorSense hyperspectral tools
+        (https://github.com/GatorSense/hsi_toolkit_py)
 
+        Inputs:
+            spectral_array = Hyperspectral data instance
+            mask           = Target wavelength value
+
+        Returns:
+            idx            = Index
+
+        :param spectral_array: __main__.Spectral_data
+        :param mask: numpy array
+        :return spectral_array: __main__.Spectral_data
+        """
+    # Initialize list of average reflectance values
     avg_r = []
-    n_bands = len(spectral_data.wavelength_dict)
-    n_lines = spectral_data.lines
-    n_samples = spectral_data.samples
+
+    # For each band in a hyperspectral datacube mask and take the average
     for i in range(0, len(spectral_data.wavelength_dict)):
         band = spectral_data.array_data[:, :, [i]]
         band_reshape = np.transpose(np.transpose(band)[0])
         masked_band = band_reshape[np.where(mask > 0)]
         band_avg = np.average(masked_band)
         avg_r.append(band_avg)
+
+    # Convert into array object rather than list
     avg_r = np.asarray(avg_r)
 
     return avg_r

--- a/plantcv/plantcv/hyperspectral/_inverse_covariance.py
+++ b/plantcv/plantcv/hyperspectral/_inverse_covariance.py
@@ -18,6 +18,11 @@ def _inverse_covariance(spectral_array):
             :return inverse_covariance: numpy array
             """
 
-    hsi_data = spectral_array.array_data
+    hsi_img = spectral_array.array_data
+
+    n_lines, n_samples, n_band = hsi_img.shape
+    n_pixels = n_lines * n_samples
+    hsi_data = np.reshape(hsi_img, (n_pixels, n_band), order='F').T
     inverse_covariance = np.linalg.pinv(np.cov(hsi_data.T, rowvar=False))
+
     return inverse_covariance

--- a/plantcv/plantcv/hyperspectral/_inverse_covariance.py
+++ b/plantcv/plantcv/hyperspectral/_inverse_covariance.py
@@ -1,12 +1,12 @@
-#
+# Calculate the inverse covariance matrix of a hyperspectral datacube
 
 import numpy as np
 
 
 
 def _inverse_covariance(spectral_array):
-    """ which is used in various GatorSense hyperspectral tools
-            (https://github.com/GatorSense/hsi_toolkit_py)
+    """ Calculate the inverse covariance matrix of a hyperspectral datacube, which is used in various
+        GatorSense hyperspectral tools (https://github.com/GatorSense/hsi_toolkit_py)
 
             Inputs:
                 spectral_array      = Hyperspectral data instance

--- a/plantcv/plantcv/hyperspectral/_inverse_covariance.py
+++ b/plantcv/plantcv/hyperspectral/_inverse_covariance.py
@@ -1,0 +1,23 @@
+#
+
+import numpy as np
+
+
+
+def _inverse_covariance(spectral_array):
+    """ which is used in various GatorSense hyperspectral tools
+            (https://github.com/GatorSense/hsi_toolkit_py)
+
+            Inputs:
+                spectral_array      = Hyperspectral data instance
+
+            Returns:
+                inverse_covariance  = Inverse covariance matrix of a hyperspectral datacube
+
+            :param spectral_array: __main__.Spectral_data
+            :return inverse_covariance: numpy array
+            """
+
+    hsi_data = spectral_array.array_data
+    inverse_covariance = np.linalg.pinv(np.cov(hsi_data.T, rowvar=False))
+    return inverse_covariance

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3788,6 +3788,14 @@ def test_plantcv_hyperspectral_avg_reflectance():
     avg_reflect = pcv.hyperspectral._avg_reflectance(spectral, mask=mask_img)
     assert len(avg_reflect) == 978
 
+
+def test_plantcv_hyperspectral_inverse_covariance():
+    spectral = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    spectral = pcv.hyperspectral.read_data(filename=spectral)
+    inv_cov = pcv.hyperspectral._inverse_covariance(spectral)
+    assert np.shape(inv_cov) == (978, 978)
+
+
 # ##############################
 # Tests for the roi subpackage
 # ##############################

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3780,6 +3780,14 @@ def test_plantcv_hyperspectral_extract_wavelength():
     new = pcv.hyperspectral.extract_wavelength(spectral_data=spectral, wavelength=500)
     assert np.shape(new.array_data) == (1, 1600)
 
+
+def test_plantcv_hyperspectral_avg_reflectance():
+    spectral = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    mask_img = cv2.imread(os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_MASK), -1)
+    spectral = pcv.hyperspectral.read_data(filename=spectral)
+    avg_reflect = pcv.hyperspectral._avg_reflectance(spectral, mask=mask_img)
+    assert len(avg_reflect) == 978
+
 # ##############################
 # Tests for the roi subpackage
 # ##############################


### PR DESCRIPTION
**Describe your changes**
Add helper functions that can allow users to use data read in with PlantCV and then go on to use GatorSense functions. Specifically, this PR includes the addition of two function. The `_inverse_covariance` will calculate an inverse covariance matrix given a hyperspectral data instance. The `_avg_reflectance` function finds the average masked reflectance given a hyperspectral data instance and a binary mask. 

**Type of update**
Is this a:
* New feature 

**Associated issues**
* closes #494 
* closes #495 
* #203 

**Additional context**
These functions are included in the `init` file and have testing coverage but I have not written any documentation since these functions are not expected to get used by the average PlantCV user. 