### PR TITLE
Sort excluded color chips

### DIFF
--- a/docs/transform_correct_color.md
+++ b/docs/transform_correct_color.md
@@ -117,7 +117,7 @@ Creates a uniquely labeled mask for each color chip based on user-defined positi
     - spacing        = Two-element tuple of the horizontal and vertical spacing between chip masks.
     - nrows          = Number of chip rows.
     - ncols          = Number of chip columns.
-    - exclude        = Optional list of chips to exclude. List in largest to smallest index (e.g. [20, 0])
+    - exclude        = Optional list of chips to exclude.
 - **Returns**
     - mask           = Labeled mask of chips. The first chip is labeled with the value 0, then 10, 20, and so on.
     

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -355,7 +355,7 @@ def create_color_card_mask(rgb_img, radius, start_coord, spacing, nrows, ncols, 
     spacing        = Two-element tuple of the horizontal and vertical spacing between chip masks.
     nrows          = Number of chip rows.
     ncols          = Number of chip columns.
-    exclude        = Optional list of chips to exclude. List in largest to smallest index (e.g. [20, 0])
+    exclude        = Optional list of chips to exclude.
 
     Returns:
     mask           = Labeled mask of chips
@@ -389,6 +389,8 @@ def create_color_card_mask(rgb_img, radius, start_coord, spacing, nrows, ncols, 
             x = start_coord[0] + j * spacing[0]
             # Create a chip ROI
             chips.append(circle(img=rgb_img, x=x, y=y, r=radius))
+    # Sort excluded chips from largest to smallest
+    exclude.sort(reverse=True)
     # Remove any excluded chips
     for chip in exclude:
         del chips[chip]


### PR DESCRIPTION
**Describe your changes**
In `plantcv.transform.create_color_card_mask()` the exclude input option required users to input excluded color chip IDs in descending numerical order. Based on #389 this pull request automatically sorts the user input chip IDs.

**Type of update**
Is this a feature enhancement.

**Associated issues**
Closes #389

**Additional context**
No changes to tests were needed. The docstring and documentation were updated to remove reference to the need to provide sorted inputs.
