### PR TITLE
analyze_spectral bugfix w print_results

### DIFF
--- a/plantcv/plantcv/hyperspectral/analyze_spectral.py
+++ b/plantcv/plantcv/hyperspectral/analyze_spectral.py
@@ -75,7 +75,7 @@ def analyze_spectral(array, mask, histplot=True):
                             value=float(median_reflectance), label='reflectance')
     outputs.add_observation(variable='spectral_std', trait='pixel-wise standard deviation ',
                             method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='None', datatype=float,
-                            value=std_reflectance, label='reflectance')
+                            value=float(std_reflectance), label='reflectance')
     outputs.add_observation(variable='spectral_frequencies', trait='spectral frequencies',
                             method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='frequency', datatype=list,
                             value=new_freq, label=wavelength_labels)


### PR DESCRIPTION
**Describe your changes**
While running `pcv.print_results` after collecting data from the updated `pcv.hyperspectral.analyze_spectral` function (which was updated since v3.7 and now includes std) there was an error printing out data since json files cannot handle float32. 

**Type of update**
Is this a:
* Bug fix
