### PR TITLE
Consistent debugging img filetype

### DIFF
--- a/plantcv/plantcv/analyze_bound_horizontal.py
+++ b/plantcv/plantcv/analyze_bound_horizontal.py
@@ -138,8 +138,8 @@ def analyze_bound_horizontal(img, obj, mask, line_position):
                 cv2.line(wback, (int(cmx), y_coor - 2), (int(cmx), y_coor + height_below_bound), (0, 255, 0),
                          params.line_thickness)
         if params.debug == 'print':
-            print_image(wback, os.path.join(params.debug_outdir, str(params.device) + '_boundary_on_white.jpg'))
-            print_image(ori_img, os.path.join(params.debug_outdir, str(params.device) + '_boundary_on_img.jpg'))
+            print_image(wback, os.path.join(params.debug_outdir, str(params.device) + '_boundary_on_white.png'))
+            print_image(ori_img, os.path.join(params.debug_outdir, str(params.device) + '_boundary_on_img.png'))
         if params.debug == 'plot':
             plot_image(wback)
             plot_image(ori_img)

--- a/plantcv/plantcv/analyze_bound_vertical.py
+++ b/plantcv/plantcv/analyze_bound_vertical.py
@@ -138,8 +138,8 @@ def analyze_bound_vertical(img, obj, mask, line_position):
                 cv2.line(wback, (x_coor + 2, int(cmy)), (x_coor - width_right_bound, int(cmy)), (0, 255, 0),
                          params.line_thickness)
         if params.debug == 'print':
-            print_image(wback, os.path.join(params.debug_outdir, str(params.device) + '_boundary_on_white.jpg'))
-            print_image(ori_img, os.path.join(params.debug_outdir, str(params.device) + '_boundary_on_img.jpg'))
+            print_image(wback, os.path.join(params.debug_outdir, str(params.device) + '_boundary_on_white.png'))
+            print_image(ori_img, os.path.join(params.debug_outdir, str(params.device) + '_boundary_on_img.png'))
         if params.debug == 'plot':
             plot_image(wback)
             plot_image(ori_img)

--- a/plantcv/plantcv/analyze_nir_intensity.py
+++ b/plantcv/plantcv/analyze_nir_intensity.py
@@ -63,7 +63,7 @@ def analyze_nir_intensity(gray_img, mask, bins=256, histplot=False):
     if params.debug is not None:
         params.device += 1
         if params.debug == "print":
-            print_image(masked1, os.path.join(params.debug_outdir, str(params.device) + "_masked_nir_plant.jpg"))
+            print_image(masked1, os.path.join(params.debug_outdir, str(params.device) + "_masked_nir_plant.png"))
         if params.debug == "plot":
             plot_image(masked1)
 

--- a/plantcv/plantcv/analyze_object.py
+++ b/plantcv/plantcv/analyze_object.py
@@ -212,7 +212,7 @@ def analyze_object(img, obj, mask):
         cv2.line(ori_img, (tuple(caliper_transpose[caliper_length - 1])), (tuple(caliper_transpose[0])), (255, 0, 255),
                  params.line_thickness)
         if params.debug == 'print':
-            print_image(ori_img, os.path.join(params.debug_outdir, str(params.device) + '_shapes.jpg'))
+            print_image(ori_img, os.path.join(params.debug_outdir, str(params.device) + '_shapes.png'))
         elif params.debug == 'plot':
             if len(np.shape(img)) == 3:
                 plot_image(ori_img)

--- a/plantcv/plantcv/cluster_contour_splitimg.py
+++ b/plantcv/plantcv/cluster_contour_splitimg.py
@@ -103,8 +103,8 @@ def cluster_contour_splitimg(rgb_img, grouped_contour_indexes, contours, hierarc
     group_names = []
     group_names1 = []
     for i, x in enumerate(namelist):
-        plantname = str(filebase) + '_' + str(x) + '_p' + str(i) + '.jpg'
-        maskname = str(filebase) + '_' + str(x) + '_p' + str(i) + '_mask.jpg'
+        plantname = str(filebase) + '_' + str(x) + '_p' + str(i) + '.png'
+        maskname = str(filebase) + '_' + str(x) + '_p' + str(i) + '_mask.png'
         group_names.append(plantname)
         group_names1.append(maskname)
 

--- a/plantcv/plantcv/naive_bayes_classifier.py
+++ b/plantcv/plantcv/naive_bayes_classifier.py
@@ -85,7 +85,7 @@ def naive_bayes_classifier(rgb_img, pdf_file):
     if params.debug == "print":
         for class_name, mask in masks.items():
             print_image(mask, os.path.join(params.debug_outdir,
-                                           str(params.device) + "_naive_bayes_" + class_name + "_mask.jpg"))
+                                           str(params.device) + "_naive_bayes_" + class_name + "_mask.png"))
     elif params.debug == "plot":
         for class_name, mask in masks.items():
             plot_image(mask, cmap="gray")

--- a/plantcv/plantcv/opening.py
+++ b/plantcv/plantcv/opening.py
@@ -34,7 +34,7 @@ def opening(gray_img, kernel=None):
         filtered_img = morphology.opening(gray_img, kernel)
 
     if params.debug == 'print':
-        print_image(filtered_img, os.path.join(params.debug_outdir, str(params.device) + '_opening' + '.png'))
+        print_image(filtered_img, os.path.join(params.debug_outdir, str(params.device) + '_opening.png'))
     elif params.debug == 'plot':
         plot_image(filtered_img, cmap='gray')
 

--- a/plantcv/plantcv/resize.py
+++ b/plantcv/plantcv/resize.py
@@ -33,7 +33,7 @@ def resize(img, resize_x, resize_y):
     reimg = cv2.resize(img, (0, 0), fx=resize_x, fy=resize_y)
 
     if params.debug == 'print':
-        print_image(reimg, os.path.join(params.debug_outdir, str(params.device) + "_resize1.png"))
+        print_image(reimg, os.path.join(params.debug_outdir, str(params.device) + "_resize.png"))
     elif params.debug == 'plot':
         plot_image(reimg)
 


### PR DESCRIPTION
**Describe your changes**
Noticed that a handful of PlantCV functions would save out debugging images as JPEGs rather than PNGs, which is what the majority of images saved out will be. Updated functions so that they filetype is consistent. 


