### PR TITLE
Add border width to within_frame

### DIFF
--- a/docs/updating.md
+++ b/docs/updating.md
@@ -785,6 +785,7 @@ pages for more details on the input and output variable types.
 
 * pre v3.3: NA
 * post v3.3: in_bounds = **plantcv.within_frame**(*mask*)
+* post v3.8: in_bounds = **plantcv.within_frame**(*mask, border_width=1*)
 
 #### plantcv.x_axis_pseudolandmarks
 

--- a/docs/within_frame.md
+++ b/docs/within_frame.md
@@ -1,18 +1,21 @@
 ## Check whether an object is completely within an image
 
-This function tests whether an object (defined as nonzero pixels in a mask) falls completely within the bounds of an image or if it touches the edge.
+This function tests whether an object (defined as nonzero pixels in a mask) falls completely within the bounds of an 
+image or if it touches the edge.
 
-**plantcv.within_frame**(*mask*)
+**plantcv.within_frame**(*mask, border_width=1*)
 
 **returns** in_bounds
 
 - **Parameters:**
     - mask = a single channel image (i.e. binary or greyscale)
+    - border_width = distance from border of image considered out of frame (default = 1)
 
 - **Context:**
     - This function could be used to test whether the plant has grown outside the field of view.
 - **Output data stored:** Data ('in_bounds') automatically gets stored to the [`Outputs` class](outputs.md) when this function is ran. 
-    These data can always get accessed during a workflow (example below). For more detail about data output see [Summary of Output Observations](output_measurements.md#summary-of-output-observations)
+    These data can always get accessed during a workflow (example below). For more detail about data output see 
+    [Summary of Output Observations](output_measurements.md#summary-of-output-observations)
 
 - **Example use:**
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,11 +3,11 @@ name: test-environment
 dependencies:
   - python=3.7
   - matplotlib>=1.5
-  - numpy>=1.11, <1.17
+  - numpy>=1.11
   - pandas
   - python-dateutil
-  - scipy < 1.3
-  - scikit-image==0.14.2
+  - scipy
+  - scikit-image
   - pytest
   - plotnine
   - coveralls

--- a/plantcv/plantcv/within_frame.py
+++ b/plantcv/plantcv/within_frame.py
@@ -5,18 +5,19 @@ from plantcv.plantcv import fatal_error
 from plantcv.plantcv import outputs
 
 
-def within_frame(mask):
+def within_frame(mask, border_width=1):
     """
     This function tests whether the plant touches the edge of the image, i.e. it is completely in the field of view.
     Input:
-    mask = a binary image of 0 and nonzero values
+    mask         = a binary image of 0 and nonzero values
+    border_width = distance from border of image considered out of frame (default = 1)
 
     Returns:
     in_bounds = a boolean (True or False) confirming that the object does not touch the edge of the image
 
     :param mask: numpy.ndarray
+    :param border_width: int
     :return in_bounds: bool
-
     """
 
     # Check if object is touching image boundaries (QC)
@@ -24,20 +25,20 @@ def within_frame(mask):
         fatal_error("Mask should be a binary image of 0 and nonzero values.")
 
     # First column
-    first_col = mask[:, 0]
+    first_col = mask[:, range(0, border_width)]
 
     # Last column
-    last_col = mask[:, -1]
+    last_col = mask[:, range(-border_width, 0)]
 
     # First row
-    first_row = mask[0, :]
+    first_row = mask[range(0, border_width), :]
 
     # Last row
-    last_row = mask[-1, :]
+    last_row = mask[range(-border_width, 0), :]
 
-    edges = np.concatenate([first_col, last_col, first_row, last_row])
+    border_pxs = np.concatenate([first_col.flatten(), last_col.flatten(), first_row.flatten(), last_row.flatten()])
 
-    out_of_bounds = bool(np.count_nonzero(edges))
+    out_of_bounds = bool(np.count_nonzero(border_pxs))
     in_bounds = not out_of_bounds
 
     outputs.add_observation(variable='in_bounds', trait='whether the plant goes out of bounds ',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2188,8 +2188,8 @@ def test_plantcv_within_frame():
     # Read in test data
     mask_ib = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_MASK), -1)
     mask_oob = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_MASK_OOB), -1)
-    in_bounds_ib = pcv.within_frame(mask = mask_ib)
-    in_bounds_oob = pcv.within_frame(mask = mask_oob)
+    in_bounds_ib = pcv.within_frame(mask=mask_ib, border_width=1)
+    in_bounds_oob = pcv.within_frame(mask=mask_oob, border_width=1)
     assert(in_bounds_ib is True and in_bounds_oob is False)
 
 


### PR DESCRIPTION
**Describe your changes**
In working on a dataset with @phloz we found that even though plants were growing out of frame, `in_bounds` was always `True`. In the particular workflow the single border pixels around the image were clear of plant pixels (due to an erosion I think). This pull request adds a `border_width` parameter to `plantcv.within_frame` that allows the user to specify how many pixels from the image edge they want to consider for detecting out-of-frame objects. The default is 1 px, which maintains the previous default behavior.

**Type of update**
Is this a:
* New feature or feature enhancement

**Additional context**
- [x] Function updated
- [x] Documentation updated
- [x] Tests updated
