### PR TITLE
Analyze index march2020 updates

### DIFF
--- a/docs/analyze_index.md
+++ b/docs/analyze_index.md
@@ -3,7 +3,7 @@
 This function calculates the hyperspectral index statistics and writes the values  as observations out to
        the [Outputs class](outputs.md).
        
-**plantcv.hyperspectral.analyze_index**(*index_array, mask, bins=100, min_bin=None, max_bin=None*)
+**plantcv.hyperspectral.analyze_index**(*index_array, mask, bins=100, min_bin=0, max_bin=1*)
 
 **returns** None
 
@@ -12,12 +12,13 @@ This function calculates the hyperspectral index statistics and writes the value
     - mask          - Binary mask made from selected contours
     - histplot      - If True plots histogram of intensity values
     - bins          - Optional, number of classes to divide spectrum into (default bins=100) 
-    - min_bin       - Optional, maximum bin label. If `None` then 0 will be used for the smallest bin label while calculating pixel frequency data.
-    - max_bin       - Optional, maximum bin label. If `None` then maximum pixel value detected in the image will be used for the largest bin label.
+    - min_bin       - Optional, maximum bin label. Default of 0 will be used for the smallest bin label while calculating pixel frequency data unless otherwise defined. 
+                      `min_bin="auto"` will set minimum bin to the smallest observed pixel value within the masked index provided.
+    - max_bin       - Optional, maximum bin label. Default of 1 will be used for the maximum  bin label. `max_bin="auto"` will set maximum bin to the largest observed pixel value within the masked index provided. 
 
 - **Context:**
     - Calculates data about mean, median, and standard deviation of an input index within a masked region. 
-    - If using an index that is expected to have negative values after masking (i.e. PRI) then default `min_bin` settings will cut off at 0 unless adjusted. 
+    - If using an index that is expected to have negative values after masking (i.e. PRI) the default `min_bin=0` will cut off pixel frequency data at 0 unless adjusted. 
 - **Example use:**
     - Below
 - **Output data stored:** Mean, median, and standard deviation of the index automatically gets stored to the 

--- a/docs/analyze_index.md
+++ b/docs/analyze_index.md
@@ -30,7 +30,7 @@ This function calculates the hyperspectral index statistics and writes the value
 
 from plantcv import plantcv as pcv
 
-pcv.hyperspectral.analyze_index(index_array=ndvi_index, mask=leaf_mask, histplot=True, bins=100)
+pcv.hyperspectral.analyze_index(index_array=ndvi_index, mask=leaf_mask, histplot=True, bins=100, min_bin=0, max_bin="auto")
 
 ```
 

--- a/docs/analyze_index.md
+++ b/docs/analyze_index.md
@@ -12,9 +12,9 @@ This function calculates the hyperspectral index statistics and writes the value
     - mask          - Binary mask made from selected contours
     - histplot      - If True plots histogram of intensity values
     - bins          - Optional, number of classes to divide spectrum into (default bins=100) 
-    - min_bin       - Optional, maximum bin label. Default of 0 will be used for the smallest bin label while calculating pixel frequency data unless otherwise defined. 
+    - min_bin       - Optional, minimum bin label. Default of 0 will be used for the smallest bin label while calculating pixel frequency data unless otherwise defined. 
                       `min_bin="auto"` will set minimum bin to the smallest observed pixel value within the masked index provided.
-    - max_bin       - Optional, maximum bin label. Default of 1 will be used for the maximum  bin label. `max_bin="auto"` will set maximum bin to the largest observed pixel value within the masked index provided. 
+    - max_bin       - Optional, maximum bin label. Default of 1 will be used for the maximum bin label unless otherwise defined. `max_bin="auto"` will set maximum bin to the largest observed pixel value within the masked index provided. 
 
 - **Context:**
     - Calculates data about mean, median, and standard deviation of an input index within a masked region. 

--- a/docs/analyze_index.md
+++ b/docs/analyze_index.md
@@ -12,7 +12,7 @@ This function calculates the hyperspectral index statistics and writes the value
     - mask          - Binary mask made from selected contours
     - histplot      - If True plots histogram of intensity values
     - bins          - Optional, number of classes to divide spectrum into (default bins=100) 
-    - min_bin       - Optional, maximum bin label. If `None` then 0 will be used for the smallest bin label.
+    - min_bin       - Optional, maximum bin label. If `None` then 0 will be used for the smallest bin label while calculating pixel frequency data.
     - max_bin       - Optional, maximum bin label. If `None` then maximum pixel value detected in the image will be used for the largest bin label.
 
 - **Context:**

--- a/docs/analyze_index.md
+++ b/docs/analyze_index.md
@@ -17,6 +17,7 @@ This function calculates the hyperspectral index statistics and writes the value
 
 - **Context:**
     - Calculates data about mean, median, and standard deviation of an input index within a masked region. 
+    - If using an index that is expected to have negative values after masking (i.e. PRI) then default `min_bin` settings will cut off at 0 unless adjusted. 
 - **Example use:**
     - Below
 - **Output data stored:** Mean, median, and standard deviation of the index automatically gets stored to the 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -346,7 +346,7 @@ pages for more details on the input and output variable types.
 
 * pre v3.7: NA
 * post v3.7: **plantcv.hyperspectral.analyze_index**(*index_array, mask*)
-* post v3.8: index_histogram = **plantcv.hyperspectral.analyze_index**(*index_array, mask, histplot=False, bins=100, max_bin=None, min_bin=None*)
+* post v3.8: index_histogram = **plantcv.hyperspectral.analyze_index**(*index_array, mask, histplot=False, bins=100, max_bin=0, min_bin=1*)
 
 #### plantcv.hyperspectral.analyze_spectral
 

--- a/plantcv/plantcv/hyperspectral/analyze_index.py
+++ b/plantcv/plantcv/hyperspectral/analyze_index.py
@@ -12,7 +12,7 @@ from plantcv.plantcv import fatal_error
 from plotnine import ggplot, aes, geom_line, scale_x_continuous
 
 
-def analyze_index(index_array, mask, histplot=False, bins=100, min_bin=None, max_bin=None):
+def analyze_index(index_array, mask, histplot=False, bins=100, min_bin=0, max_bin=1):
     """This extracts the hyperspectral index statistics and writes the values  as observations out to
        the Outputs class.
 
@@ -51,14 +51,15 @@ def analyze_index(index_array, mask, histplot=False, bins=100, min_bin=None, max
     index_median = np.median(masked_array)
     index_std = np.std(masked_array)
 
-    maxval = round(np.amax(masked_array), 8) # Auto bins will detect maxval to use for calculating centers
-    b = 0  # Auto bins will always start from 0
+    # Set starting point and max bin values
+    maxval = max_bin
+    b = min_bin
 
-
-    if not max_bin == None:
-        maxval = max_bin # If bin_max is defined then overwrite maxval variable
-    if not min_bin == None:
-        b = min_bin # If bin_min is defined then overwrite starting value
+    # Auto calculate max_bin if set
+    if type(max_bin) is str and (max_bin.upper() == "AUTO"):
+        maxval = round(np.nanmax(masked_array), 8)  # Auto bins will detect maxval to use for calculating labels/bins
+    if type(min_bin) is str and (min_bin.upper() == "AUTO"):
+        b = round(np.nanmin(masked_array), 8) # If bin_min is auto then overwrite starting value
 
     # Calculate histogram
     hist_val = [float(l[0]) for l in cv2.calcHist([masked_array.astype(np.float32)], [0], None, [bins], [b, maxval])]

--- a/plantcv/plantcv/hyperspectral/analyze_index.py
+++ b/plantcv/plantcv/hyperspectral/analyze_index.py
@@ -61,7 +61,7 @@ def analyze_index(index_array, mask, histplot=False, bins=100, min_bin=None, max
         b = min_bin # If bin_min is defined then overwrite starting value
 
     # Calculate histogram
-    hist_val = [float(l[0]) for l in cv2.calcHist([masked_array.astype(np.float32)], [0], None, [bins], [0, 1])]
+    hist_val = [float(l[0]) for l in cv2.calcHist([masked_array.astype(np.float32)], [0], None, [bins], [b, maxval])]
     bin_width = (maxval - b) / float(bins)
     bin_labels = [float(b)]
     plotting_labels = [float(b)]

--- a/plantcv/plantcv/hyperspectral/analyze_index.py
+++ b/plantcv/plantcv/hyperspectral/analyze_index.py
@@ -55,11 +55,21 @@ def analyze_index(index_array, mask, histplot=False, bins=100, min_bin=0, max_bi
     maxval = max_bin
     b = min_bin
 
+    # Calculate observed min and max pixel values of the masked array
+    observed_max = np.nanmax(masked_array)
+    observed_min = np.nanmin(masked_array)
+
     # Auto calculate max_bin if set
     if type(max_bin) is str and (max_bin.upper() == "AUTO"):
-        maxval = round(np.nanmax(masked_array), 8)  # Auto bins will detect maxval to use for calculating labels/bins
+        maxval = round(observed_max, 8)  # Auto bins will detect maxval to use for calculating labels/bins
     if type(min_bin) is str and (min_bin.upper() == "AUTO"):
-        b = round(np.nanmin(masked_array), 8) # If bin_min is auto then overwrite starting value
+        b = round(observed_min, 8) # If bin_min is auto then overwrite starting value
+
+    # Print a warning if observed min/max outside user defined range
+    if observed_max > maxval or observed_min < b:
+        print("WARNING!!! The observed range of pixel values in your masked index provided is [" + str(observed_min) +
+              ", " + str(observed_max) + "] but the user defined range of bins for pixel frequencies is [" + str(b) +
+              ", " + str(maxval) + "]. Adjust min_bin and max_bin in order to avoid cutting off data being collected.")
 
     # Calculate histogram
     hist_val = [float(l[0]) for l in cv2.calcHist([masked_array.astype(np.float32)], [0], None, [bins], [b, maxval])]

--- a/plantcv/plantcv/hyperspectral/extract_index.py
+++ b/plantcv/plantcv/hyperspectral/extract_index.py
@@ -109,7 +109,7 @@ def extract_index(array, index="NDVI", distance=20):
     obs_min_pixel = float(np.nanmin(index_array_raw))
 
     index_array = Spectral_data(array_data=index_array_raw, max_wavelength=0,
-                                min_wavelength=0, max_value=max_pixel, min_value=min_pixel, d_type=np.uint8,
+                                min_wavelength=0, max_value=obs_max_pixel, min_value=obs_min_pixel, d_type=np.uint8,
                                 wavelength_dict={}, samples=array.samples,
                                 lines=array.lines, interleave=array.interleave,
                                 wavelength_units=array.wavelength_units, array_type="index_" + index.lower(),

--- a/plantcv/plantcv/hyperspectral/extract_index.py
+++ b/plantcv/plantcv/hyperspectral/extract_index.py
@@ -105,8 +105,8 @@ def extract_index(array, index="NDVI", distance=20):
     scaled = rescale(all_positive)
 
     # Find array min and max values
-    max_pixel = float(np.amax(index_array_raw))
-    min_pixel = float(np.amin(index_array_raw))
+    max_pixel = float(np.nanmax(index_array_raw))
+    min_pixel = float(np.nanmin(index_array_raw))
 
     index_array = Spectral_data(array_data=index_array_raw, max_wavelength=0,
                                 min_wavelength=0, max_value=max_pixel, min_value=min_pixel, d_type=np.uint8,

--- a/plantcv/plantcv/hyperspectral/extract_index.py
+++ b/plantcv/plantcv/hyperspectral/extract_index.py
@@ -105,8 +105,8 @@ def extract_index(array, index="NDVI", distance=20):
     scaled = rescale(all_positive)
 
     # Find array min and max values
-    max_pixel = float(np.nanmax(index_array_raw))
-    min_pixel = float(np.nanmin(index_array_raw))
+    obs_max_pixel = float(np.nanmax(index_array_raw))
+    obs_min_pixel = float(np.nanmin(index_array_raw))
 
     index_array = Spectral_data(array_data=index_array_raw, max_wavelength=0,
                                 min_wavelength=0, max_value=max_pixel, min_value=min_pixel, d_type=np.uint8,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3762,7 +3762,7 @@ def test_plantcv_hyperspectral_analyze_index():
 
 
 def test_plantcv_hyperspectral_analyze_index_set_range():
-    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_analyze_index")
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_analyze_index_set_range")
     os.mkdir(cache_dir)
     pcv.params.debug_outdir = cache_dir
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
@@ -3770,6 +3770,18 @@ def test_plantcv_hyperspectral_analyze_index_set_range():
     index_array = pcv.hyperspectral.extract_index(array=array_data, index="savi", distance=801)
     mask_img = np.ones(np.shape(index_array.array_data), dtype=np.uint8) * 255
     pcv.hyperspectral.analyze_index(index_array=index_array, mask=mask_img, histplot=True, min_bin=0, max_bin=1)
+    assert pcv.outputs.observations['mean_index_savi']['value'] > 0
+
+
+def test_plantcv_hyperspectral_analyze_index_auto_range():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_analyze_index_auto_range")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="savi", distance=801)
+    mask_img = np.ones(np.shape(index_array.array_data), dtype=np.uint8) * 255
+    pcv.hyperspectral.analyze_index(index_array=index_array, mask=mask_img, min_bin="auto", max_bin="auto")
     assert pcv.outputs.observations['mean_index_savi']['value'] > 0
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3785,6 +3785,24 @@ def test_plantcv_hyperspectral_analyze_index_auto_range():
     assert pcv.outputs.observations['mean_index_savi']['value'] > 0
 
 
+def test_plantcv_hyperspectral_analyze_index_outside_range_warning():
+    import io
+    from contextlib import redirect_stdout
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_analyze_index_auto_range")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="savi", distance=801)
+    mask_img = np.ones(np.shape(index_array.array_data), dtype=np.uint8) * 255
+    f = io.StringIO()
+    with redirect_stdout(f):
+        pcv.hyperspectral.analyze_index(index_array=index_array, mask=mask_img, min_bin=.5, max_bin=.55)
+    out = f.getvalue()
+    #assert os.listdir(cache_dir) is 0
+    assert out[0:10] == 'WARNING!!!'
+
+
 def test_plantcv_hyperspectral_analyze_index_bad_input_mask():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)


### PR DESCRIPTION
**Describe your changes**
Minimum and maximum bin parameters now control range of histogram values. There was a plotting mismatch between histogram plotting and calculation since the range for frequency values used to be independent of `min_bin` and `max_bin`. 

**Type of update**
Is this a:
* Bug fix
* Feature enhancement

**Associated issues**
#203 
#526 


