### PR TITLE
Add links to source code throughout documentation pages 

### DIFF
--- a/docs/HistEqualization.md
+++ b/docs/HistEqualization.md
@@ -32,3 +32,5 @@ he_img = pcv.hist_equalization(gray_img)
 **Normalized image**
 
 ![Screenshot](img/documentation_images/HistEqualization/normalized_image.jpg)  
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/hist_equalization.py)

--- a/docs/Spectral_data.md
+++ b/docs/Spectral_data.md
@@ -76,3 +76,5 @@ print(str(spectral_data_instance.max_wavelength) + spectral_data_instance.wavele
 ```python
 > 1000.95nm
 ```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/__init__.py)

--- a/docs/acute_vertex.md
+++ b/docs/acute_vertex.md
@@ -42,3 +42,5 @@ vertices = pcv.outputs.observations['tip_coordinates']['value']
 **Image of points selected**
 
 ![Screenshot](img/documentation_images/acute_vertex/av_output.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/acute_vertex.py)

--- a/docs/analyze_NIR_intensity.md
+++ b/docs/analyze_NIR_intensity.md
@@ -47,3 +47,5 @@ nir_frequencies = pcv.outputs.observations['nir_frequencies']['value']
 
 **Note:** The grayscale input image and object mask can be used with the [pcv.visualize.pseudocolor](visualize_pseudocolor.md) function
 which allows the user to pick a colormap for plotting.
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/analyze_nir_intensity.py)

--- a/docs/analyze_bound_horizontal.md
+++ b/docs/analyze_bound_horizontal.md
@@ -50,3 +50,5 @@ green is area above boundary line.
 
 Boundary line set at 520, purple is boundary line, blue line is extent y above boundary line, 
 green line is extent y below boundary line, green is area above boundary line and red is area below boundary line.
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/analyze_bound_horizontal.py)

--- a/docs/analyze_bound_vertical.md
+++ b/docs/analyze_bound_vertical.md
@@ -52,3 +52,5 @@ of the boundary line.
 Boundary line set at 1100, purple is boundary line, blue line is extent x right of the boundary line, 
 green is area right of boundary line. Green line is extent x left of the boundary line and red is area left
 of the boundary line.
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/analyze_bound_vertical.py)

--- a/docs/analyze_color.md
+++ b/docs/analyze_color.md
@@ -52,3 +52,5 @@ hue_circular_mean = pcv.outputs.observations['hue_circular_mean']['value']
 which allows the user to pick a colormap for plotting.
 
 ![Screenshot](img/documentation_images/analyze_color/pseudocolored_value_image.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/analyze_color.py)

--- a/docs/analyze_index.md
+++ b/docs/analyze_index.md
@@ -40,3 +40,5 @@ pcv.hyperspectral.analyze_index(index_array=ndvi_index, mask=leaf_mask, histplot
 *Masked Index Histogram*
 
 ![Screenshot](img/documentation_images/analyze_index/index_ndvi_hist.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/hyperspectral/analyze_index.py)

--- a/docs/analyze_shape.md
+++ b/docs/analyze_shape.md
@@ -55,3 +55,5 @@ plant_solidity = pcv.outputs.observations['solidity']['value']
 **Image with shape characteristics**
 
 ![Screenshot](img/documentation_images/analyze_shape/shapes_on_image.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/analyze_object.py)

--- a/docs/analyze_spectral.md
+++ b/docs/analyze_spectral.md
@@ -37,3 +37,5 @@ reflectance_range = max(pcv.outputs.observations['max_reflectance']['value']) - 
 **Spectral Reflectance Intensity Histogram**
 
 ![Screenshot](img/tutorial_images/hyperspectral/spectral_histogram.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/hyperspectral/analyze_spectral.py)

--- a/docs/analyze_thermal_values.md
+++ b/docs/analyze_thermal_values.md
@@ -56,3 +56,5 @@ pseudocolor_img  = pcv.visualize.pseudocolor(thermal_img, min_value=31, max_valu
 ```
 
 ![Screenshot](img/documentation_images/analyze_thermal_values/thermal_pseudocolored.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/analyze_thermal_values.py)

--- a/docs/apply_mask.md
+++ b/docs/apply_mask.md
@@ -61,3 +61,5 @@ masked_image = pcv.apply_mask(img=img, mask=mask, mask_color='black')
 **Black-masked image**
 
 ![Screenshot](img/documentation_images/apply_mask/black_masked_image.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/apply_mask.py)

--- a/docs/auto_crop.md
+++ b/docs/auto_crop.md
@@ -43,3 +43,4 @@ crop_img2 = pcv.auto_crop(rgb_img, id_objects[0], 20, 20, 'image')
 
 ![Screenshot](img/documentation_images/auto_crop/155_auto_image.jpg)
 
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/auto_crop.py)

--- a/docs/background_subtraction.md
+++ b/docs/background_subtraction.md
@@ -48,3 +48,5 @@ fgmask = pcv.background_subtraction(foreground_image, background_image)
 **Foreground Mask**
 
 ![Screenshot](img/documentation_images/background_subtraction/1_background_subtraction.png)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/background_subtraction.py)

--- a/docs/binary_threshold.md
+++ b/docs/binary_threshold.md
@@ -65,3 +65,5 @@ threshold_dark = pcv.threshold.binary(gray_img, 36, 255, 'dark')
 **Thresholded image (inverse)**
 
 ![Screenshot](img/documentation_images/binary_threshold/thresholded_inverse_image.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/threshold/threshold_methods.py)

--- a/docs/calibrate.md
+++ b/docs/calibrate.md
@@ -34,3 +34,4 @@ dark_reference = pcv.readimage(filename=dark_reference_filename)
 calibrated_data = pcv.hyperspectral.calibrate(raw_data=raw, white_reference=white_reference, dark_reference=dark_reference)
 ```
 
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/hyperspectral/calibrate.py)

--- a/docs/canny_edge_detect.md
+++ b/docs/canny_edge_detect.md
@@ -66,3 +66,5 @@ edges3 = pcv.canny_edge_detect(img=img, mask=bin_img, mask_color='black')
 ![Screenshot](img/documentation_images/canny_edge_detect/mask_canny.jpg)
 
 ![Screenshot](img/documentation_images/canny_edge_detect/masked_img_canny.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/canny_edge_detect.py)

--- a/docs/check_cycles.md
+++ b/docs/check_cycles.md
@@ -37,3 +37,5 @@ num_cycles = pcv.outputs.observations['num_cycles']['value']
 ```
 
 ![Screenshot](img/documentation_images/check_cycles/plot_cycles.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/morphology/check_cycles.py)

--- a/docs/closing.md
+++ b/docs/closing.md
@@ -49,3 +49,5 @@ pcv.params.debug = "print"
 filtered_img = pcv.closing(gray_img=gray_img, kernel=np.array([[1, 0, 1], [0, 1, 0], [1, 0, 1]]))
 
 ```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/closing.py)

--- a/docs/cluster_contours.md
+++ b/docs/cluster_contours.md
@@ -48,3 +48,5 @@ clusters_i, contours, hierarchy = pcv.cluster_contours(img, roi_objects,
 **Cluster Contour Image with Grid**
 
 ![Screenshot](img/documentation_images/cluster_contour/show_grid.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/cluster_contours.py)

--- a/docs/cluster_contours_splitimg.md
+++ b/docs/cluster_contours_splitimg.md
@@ -52,3 +52,5 @@ output_path, imgs, masks = pcv.cluster_contour_splitimg(rgb_img, clusters_i, con
 ![Screenshot](img/documentation_images/cluster_contour_splitimg/16_clusters.jpg)
 
 ![Screenshot](img/documentation_images/cluster_contour_splitimg/17_clusters.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/cluster_contour_splitimg.py)

--- a/docs/color_palette.md
+++ b/docs/color_palette.md
@@ -27,3 +27,5 @@ print(colors)
 [(0, 0, 255), (0, 255, 205), (100, 255, 0), (255, 106, 0), (255, 0, 199)]
 
 ```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/color_palette.py)

--- a/docs/crop.md
+++ b/docs/crop.md
@@ -38,3 +38,5 @@ crop_img = pcv.crop(img=img, x=800, y=400, h=1200, w=900)
 **Cropped Image**
 
 ![Screenshot](img/documentation_images/crop/cropped_img.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/crop.py)

--- a/docs/crop_position_mask.md
+++ b/docs/crop_position_mask.md
@@ -63,3 +63,5 @@ cropped1 = pcv.crop_position_mask(img, mask, 40, 3, "top", "right")
 ****
 
 ![Screenshot](img/documentation_images/crop_position_mask/19_mask_overlay.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/crop_position_mask.py)

--- a/docs/custom_range_threshold.md
+++ b/docs/custom_range_threshold.md
@@ -138,3 +138,5 @@ mask, masked_img = pcv.threshold.custom_range(rgb_img=gray_img, lower_thresh=[39
 **Mask (Grayscale Color-space)**
 
 ![Screenshot](img/documentation_images/custom_range_threshold/gray_mask.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/threshold/threshold_methods.py)

--- a/docs/dilate.md
+++ b/docs/dilate.md
@@ -37,3 +37,5 @@ dilate_img = pcv.dilate(gray_img=gray_img, ksize=9, i=1)
 **Image after dilation**
 
 ![Screenshot](img/documentation_images/dilate/dilate.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/dilate.py)

--- a/docs/distance_transform.md
+++ b/docs/distance_transform.md
@@ -36,3 +36,5 @@ distance_transform_img = pcv.distance_transform(mask, 1, 3)
 **Image after distance transform**
 
 ![Screenshot](img/documentation_images/distance_transform/distance_transform_img.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/distance_transform.py)

--- a/docs/erode.md
+++ b/docs/erode.md
@@ -38,3 +38,5 @@ er_img = pcv.erode(gray_img, ksize, 1)
 **Image after erosion**
 
 ![Screenshot](img/documentation_images/erode/erosion.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/erode.py)

--- a/docs/extract_index.md
+++ b/docs/extract_index.md
@@ -45,3 +45,5 @@ ndvi_array  = pcv.hyperspectral.extract_index(array=spectral_data, index="NDVI",
 **SAVI array image**
 
 ![Screenshot](img/tutorial_images/hyperspectral/savi_index.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/hyperspectral/extract_index.py)

--- a/docs/extract_wavelength.md
+++ b/docs/extract_wavelength.md
@@ -50,3 +50,5 @@ blue_array_obj.array_type
 > 'index_430'
 
 ```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/hyperspectral/extract_wavelength.py)

--- a/docs/fill.md
+++ b/docs/fill.md
@@ -39,3 +39,5 @@ fill_image = pcv.fill(binary_img, 200)
 **Binary image with median blur and fill (200 pixels)**
 
 ![Screenshot](img/documentation_images/fill/fill_200.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/fill.py)

--- a/docs/fill_holes.md
+++ b/docs/fill_holes.md
@@ -34,3 +34,5 @@ fill_image = pcv.fill_holes(binary_img, 200)
 **Binary image with holes filled**
 
 ![Screenshot](img/documentation_images/fill_holes/filled_holes.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/fill_holes.py)

--- a/docs/find_branch_pts.md
+++ b/docs/find_branch_pts.md
@@ -47,3 +47,5 @@ branch_points_img = pcv.morphology.find_branch_pts(skel_img=skeleton, mask=plant
 *Debug Image with Mask*
 
 ![Screenshot](img/documentation_images/find_branch_pts/branch_pts_debug_mask.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/morphology/find_branch_pts.py)

--- a/docs/find_objects.md
+++ b/docs/find_objects.md
@@ -40,3 +40,5 @@ id_objects, obj_hierarchy = pcv.find_objects(img, mask)
 **Image with contours highlighted**
 
 ![Screenshot](img/documentation_images/find_objects/contours.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/find_objects.py)

--- a/docs/find_tips.md
+++ b/docs/find_tips.md
@@ -46,3 +46,5 @@ tips_img = pcv.morphology.find_tips(skel_img=skeleton, mask=plant_mask)
 *Debug Image with Mask*
 
 ![Screenshot](img/documentation_images/find_tips/tips_debug_mask.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/morphology/find_tips.py)

--- a/docs/flip.md
+++ b/docs/flip.md
@@ -51,3 +51,5 @@ flipped= pcv.flip(img, 'vertical')
 **Flipped Image**
 
 ![Screenshot](img/documentation_images/flip/flipped1.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/flip.py)

--- a/docs/fluor_fvfm.md
+++ b/docs/fluor_fvfm.md
@@ -65,3 +65,5 @@ pseudo_img = pcv.pseudocolor(gray_img=fv_img, mask=kept_mask)
 
 The grayscale Fv/Fm image (returned to analysis_image) can be used with the [pcv.visualize.pseudocolor](visualize_pseudocolor.md) function
 which allows the user to pick a colormap for plotting.
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/fluor_fvfm.py)

--- a/docs/gaussian_blur.md
+++ b/docs/gaussian_blur.md
@@ -51,3 +51,5 @@ gaussian_img = pcv.gaussian_blur(img=img1, ksize=(101, 101), sigma_x=0, sigma_y=
 **Gaussian blur (ksize = (101,101))**
 
 ![Screenshot](img/documentation_images/gaussian_blur/gaussian_blur101.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/gaussian_blur.py)

--- a/docs/gaussian_threshold.md
+++ b/docs/gaussian_threshold.md
@@ -36,3 +36,5 @@ threshold_gaussian = pcv.threshold.gaussian(gray_img, 255, 'dark')
 **Auto-Thresholded image (gaussian)**
 
 ![Screenshot](img/documentation_images/auto_threshold/gaussian_threshold.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/threshold/threshold_methods.py)

--- a/docs/get_kernel.md
+++ b/docs/get_kernel.md
@@ -46,3 +46,5 @@ print(cross_kernel)
 
 ```
 
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/get_kernel.py)
+

--- a/docs/get_nir.md
+++ b/docs/get_nir.md
@@ -30,3 +30,4 @@ nir_path = pcv.get_nir("/home/images/sorghum/snapshot1",
 
 ```
 
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/get_nir.py)

--- a/docs/image_add.md
+++ b/docs/image_add.md
@@ -40,3 +40,5 @@ sum_img = pcv.image_add(img1, img2)
 **Sum of images 1 and 2**
 
 ![Screenshot](img/documentation_images/image_add/added_image.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/image_add.py)

--- a/docs/image_subtract.md
+++ b/docs/image_subtract.md
@@ -39,3 +39,5 @@ subtracted_img = pcv.image_subtract(gray_img1, gray_img2)
 **Result**
 
 ![Screenshot](img/documentation_images/image_subtract/result.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/image_subtract.py)

--- a/docs/invert.md
+++ b/docs/invert.md
@@ -33,3 +33,5 @@ inverted_img = pcv.invert(gray_img)
 **Inverted image**
 
 ![Screenshot](img/documentation_images/invert/inverted_image.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/invert.py)

--- a/docs/job_builder.md
+++ b/docs/job_builder.md
@@ -19,3 +19,4 @@ The job builder step in [PlantCV Workflow Parallelization](pipeline_parallel.md)
     - This step is built into the [PlantCV Workflow Parallelization](pipeline_parallel.md) feature. It builds a list of image processing 
     jobs which is the input for the [multiprocess](multiprocess.md) step in workflow parallelization. 
 
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/parallel/job_builder.py)

--- a/docs/landmark_reference_pt_dist.md
+++ b/docs/landmark_reference_pt_dist.md
@@ -41,3 +41,5 @@ avg_vert_distance = pcv.outputs.observations['vert_ave_c']['value']
 **Representation of many data points collected in two treatment blocks throughout time**
 
 ![Screenshot](img/documentation_images/landmark_reference_pt_dist/lrpd_output.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/landmark_reference_pt_dist.py)

--- a/docs/laplace_filter.md
+++ b/docs/laplace_filter.md
@@ -36,3 +36,5 @@ lp_img = pcv.laplace_filter(gray_img, 1, 1)
 **Image after Laplace filter**
 
 ![Screenshot](img/documentation_images/laplace_filter/lp_filtered.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/laplace_filter.py)

--- a/docs/logical_and.md
+++ b/docs/logical_and.md
@@ -41,3 +41,5 @@ and_image = pcv.logical_and(s_threshold, b_threshold)
 **Combined image**
 
 ![Screenshot](img/documentation_images/logical_and/joined.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/logical_and.py)

--- a/docs/logical_or.md
+++ b/docs/logical_or.md
@@ -42,3 +42,5 @@ ab = pcv.logical_or(maskeda_thresh, maskedb_thresh)
 **Combined image**
 
 ![Screenshot](img/documentation_images/logical_or/joined.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/logical_or.py)

--- a/docs/logical_xor.md
+++ b/docs/logical_xor.md
@@ -41,3 +41,5 @@ xor_image = pcv.logical_xor(s_threshold, b_threshold)
 **Combined image**
 
 ![Screenshot](img/documentation_images/logical_xor/21_xor_joined.png)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/logical_xor.py)

--- a/docs/mean_threshold.md
+++ b/docs/mean_threshold.md
@@ -35,3 +35,5 @@ threshold_mean = pcv.threshold.mean(gray_img, 255, 'dark')
 **Auto-Thresholded image (mean)**
 
 ![Screenshot](img/documentation_images/auto_threshold/mean_threshold.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/threshold/threshold_methods.py)

--- a/docs/median_blur.md
+++ b/docs/median_blur.md
@@ -52,3 +52,5 @@ blur_11 = pcv.median_blur(gray_img, (11, 11))
 **Median blur (ksize = (11,11))**
 
 ![Screenshot](img/documentation_images/median_blur/median_blur11.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/median_blur.py)

--- a/docs/metadata_parser.md
+++ b/docs/metadata_parser.md
@@ -22,3 +22,5 @@ Reads metadata the from the input data directory.
 - **Context:**
     - This is one of the first steps built into the [PlantCV Workflow Parallelization](pipeline_parallel.md) feature. 
     It reads metadata the from the input data directory and uses the outputs in the [job builder](job_builder.md) step. 
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/parallel/parsers.py)

--- a/docs/multiprocess.md
+++ b/docs/multiprocess.md
@@ -12,3 +12,5 @@ Runs as many jobs as possible with the specified number of CPUs.
 - **Context:**
     - This is one of the last steps built into the [PlantCV Workflow Parallelization](pipeline_parallel.md) feature. 
     It executes jobs from a list created by the [job builder](job_builder.md) step. 
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/parallel/multiprocess.py)

--- a/docs/naive_bayes.md
+++ b/docs/naive_bayes.md
@@ -26,3 +26,5 @@ to the output file and can be used with the [naive Bayes classifier](naive_bayes
     - Used to help differentiate plant and background
 - **Example use:**
     - [Use In Machine Learning Tutorial](machine_learning_tutorial.md)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/learn/naive_bayes.py)

--- a/docs/naive_bayes_classifier.md
+++ b/docs/naive_bayes_classifier.md
@@ -43,3 +43,5 @@ The output mask is a dictionary with the keys being the class names and the valu
 **Binary mask image**
 
 ![Screenshot](img/documentation_images/naive_bayes_classifier/mask_image.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/learn/naive_bayes.py)

--- a/docs/naive_bayes_multiclass.md
+++ b/docs/naive_bayes_multiclass.md
@@ -28,3 +28,5 @@ be created with [pcv.visualize.colorize_masks](visualize_colorize_masks.md).
     - Used to help differentiate two or more feature classes
 - **Example use:**
     - [Use In Machine Learning Tutorial](machine_learning_tutorial.md)
+
+**Source Code:** [Here]https://github.com/danforthcenter/plantcv/blob/master/plantcv/learn/naive_bayes.py)

--- a/docs/nonuniform_illumination.md
+++ b/docs/nonuniform_illumination.md
@@ -35,3 +35,5 @@ corrected_img = pcv.transform.nonuniform_illumination(img=img, ksize=31)
 **Image after correction**
 
 ![Screenshot](img/documentation_images/nonuniform_illumination/corrected_img.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/transform/nonuniform_illumination.py)

--- a/docs/object_composition.md
+++ b/docs/object_composition.md
@@ -41,3 +41,5 @@ obj, mask = pcv.object_composition(img, roi_objects, hierarchy)
 **Combined contours**
 
 ![Screenshot](img/documentation_images/object_composition/combined.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/object_composition.py)

--- a/docs/opening.md
+++ b/docs/opening.md
@@ -48,3 +48,5 @@ pcv.params.debug = "print"
 filtered_img = pcv.opening(gray_img=gray_img, kernel=np.array([[1, 0, 1], [0, 1, 0], [1, 0, 1]]))
 
 ```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/opening.py)

--- a/docs/otsu_threshold.md
+++ b/docs/otsu_threshold.md
@@ -57,3 +57,5 @@ threshold_dark = pcv.threshold.otsu(gray_img, 255, 'light')
 **Thresholded image (inverse)**
 
 ![Screenshot](img/documentation_images/otsu_threshold/thresholded_light.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/threshold/threshold_methods.py)

--- a/docs/output_mask.md
+++ b/docs/output_mask.md
@@ -28,3 +28,5 @@ maskpath, analysis_images = pcv.output_mask(img, mask, 'test.png',
                                             '/home/user/images', mask_only=True)
 
 ```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/output_mask_ori_img.py)

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -105,3 +105,5 @@ pcv.outputs.add_observation(variable='percent_diseased', trait='percent of plant
 pcv.print_results(filename=args.result)
 
 ```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/__init__.py)

--- a/docs/params.md
+++ b/docs/params.md
@@ -68,3 +68,5 @@ roi_contour, roi_hierarchy = pcv.roi.rectangle(x=100, y=100, h=200, w=200, img=i
 *pcv.params.line_thickness = 3*
 
 ![Screenshot](img/documentation_images/params/thickness3.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/__init__.py)

--- a/docs/pipeline_parallel.md
+++ b/docs/pipeline_parallel.md
@@ -235,3 +235,5 @@ plantcv-utils.py json2csv -j output.json -c result-table
 This can be added as an additional line in the shell script that runs the workflow too.
 
 See [Accessory Tools](tools.md) for more information.
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv-workflow.py)

--- a/docs/plot_image.md
+++ b/docs/plot_image.md
@@ -21,3 +21,5 @@ from plantcv import plantcv as pcv
 pcv.plot_image(img)
 
 ```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/plot_image.py)

--- a/docs/print_image.md
+++ b/docs/print_image.md
@@ -26,3 +26,5 @@ from plantcv import plantcv as pcv
 pcv.print_image(img, "home/user/images/test-image.png")
 
 ```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/print_image.py)

--- a/docs/print_results.md
+++ b/docs/print_results.md
@@ -51,3 +51,5 @@ img, path, img_filename = pcv.readimage("home/user/images/test-image.png")
 pcv.print_results(filename='test_workflow_results.txt')
 
 ```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/print_results.py)

--- a/docs/process_results.md
+++ b/docs/process_results.md
@@ -25,3 +25,5 @@ parallel.process_results(job_dir="home/user/parallel_results", json_file="combin
 
 
 ```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/parallel/process_results.py)

--- a/docs/prune.md
+++ b/docs/prune.md
@@ -74,3 +74,5 @@ pruned_skeleton, segmented_img, segment_objects = pcv.morphology.prune(skel_img=
 *Segmented Skeleton with Mask (image getting returned)*
 
 ![Screenshot](img/documentation_images/prune/pruned_segmented_img_mask.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/morphology/prune.py)

--- a/docs/read_bayer.md
+++ b/docs/read_bayer.md
@@ -27,3 +27,5 @@ pcv.params.debug = "print"
 img, path, img_filename = pcv.readbayer("home/user/images/test-image.tiff")
 
 ```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/readbayer.py)

--- a/docs/read_image.md
+++ b/docs/read_image.md
@@ -38,3 +38,5 @@ pcv.params.debug = "print"
 img, path, img_filename = pcv.readimage(filename="home/user/images/test-image.png", mode="native")
 
 ```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/readimage.py)

--- a/docs/rectangle_mask.md
+++ b/docs/rectangle_mask.md
@@ -41,3 +41,5 @@ masked, binary, contours, hierarchy = pcv.rectangle_mask(img=img, p1=(0,0), p2=(
 **Masked image**
 
 ![Screenshot](img/documentation_images/rectangle_mask/masked.jpg) 
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/rectangle_mask.py)

--- a/docs/report_size_marker.md
+++ b/docs/report_size_marker.md
@@ -54,3 +54,5 @@ marker_area = pcv.outputs.observations['marker_area']['value']
 **Object (green) that is identified as size marker**
 
 ![Screenshot](img/documentation_images/report_size_marker/21_marker_shape.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/report_size_marker_area.py)

--- a/docs/resize.md
+++ b/docs/resize.md
@@ -36,3 +36,5 @@ resize_img = pcv.resize(img, 0.1154905775, 0.1154905775)
 **Image after resizing**
 
 ![Screenshot](img/documentation_images/resize/19_resize1.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/resize.py)

--- a/docs/rgb2gray.md
+++ b/docs/rgb2gray.md
@@ -32,3 +32,5 @@ gray = pcv.rgb2gray(rgb_img=img)
 **Gray-scale Image**
 
 ![Screenshot](img/documentation_images/rgb2gray/gray.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/rgb2gray.py)

--- a/docs/rgb2hsv.md
+++ b/docs/rgb2hsv.md
@@ -73,3 +73,5 @@ v_channel = pcv.rgb2gray_hsv(rgb_img, 'v')
 **Value channel image**
 
 ![Screenshot](img/documentation_images/rgb2hsv/hsv_value.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/rgb2gray_hsv.py)

--- a/docs/rgb2lab.md
+++ b/docs/rgb2lab.md
@@ -72,3 +72,5 @@ b_channel = pcv.rgb2gray_lab(rgb_img, 'b')
 **Blue-Yellow channel image**
 
 ![Screenshot](img/documentation_images/rgb2lab/lab_blue-yellow.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/rgb2gray_lab.py)

--- a/docs/roi2mask.md
+++ b/docs/roi2mask.md
@@ -41,3 +41,5 @@ mask = pcv.roi.roi2mask(img=img, contour=roi_contour)
 **Binary Mask**
 
 ![Screenshot](img/documentation_images/roi2mask/custom_mask.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/roi/roi2mask.py)

--- a/docs/roi_circle.md
+++ b/docs/roi_circle.md
@@ -29,3 +29,5 @@ roi_contour, roi_hierarchy = pcv.roi.circle(img=rgb_img, x=200, y=225, r=75)
 ```
 
 ![Screenshot](img/documentation_images/circle/image_with_roi.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/roi/roi_methods.py)

--- a/docs/roi_custom.md
+++ b/docs/roi_custom.md
@@ -38,3 +38,4 @@ roi_contour, roi_hierarchy = pcv.roi.custom(img=img,
 
 ![Screenshot](img/documentation_images/roi_custom/custom_roi.jpg)
 
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/roi/roi_methods.py)

--- a/docs/roi_ellipse.md
+++ b/docs/roi_ellipse.md
@@ -32,3 +32,5 @@ roi_contour, roi_hierarchy = pcv.roi.ellipse(img=rgb_img, x=200, y=200,
 ```
 
 ![Screenshot](img/documentation_images/ellipse/image_with_roi.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/roi/roi_methods.py)

--- a/docs/roi_from_binary_image.md
+++ b/docs/roi_from_binary_image.md
@@ -26,3 +26,5 @@ roi_contour, roi_hierarchy = pcv.roi.from_binary_image(img=rgb_img, bin_img=bin_
 ```
 
 ![Screenshot](img/documentation_images/from_binary_image/image_with_roi.png)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/roi/roi_methods.py)

--- a/docs/roi_multi.md
+++ b/docs/roi_multi.md
@@ -116,3 +116,4 @@ Many intermediate outputs later...
 
 ![Screenshot](img/documentation_images/multi/multi_plants_shape.jpg)
 
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/roi/roi_methods.py)

--- a/docs/roi_objects.md
+++ b/docs/roi_objects.md
@@ -76,3 +76,5 @@ roi_objects, hierarchy, kept_mask, obj_area = pcv.roi_objects(img, roi, roi_hier
 **Kept objects**
 
 ![Screenshot](img/documentation_images/roi_objects/kept_objects2.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/roi_objects.py)

--- a/docs/roi_rectangle.md
+++ b/docs/roi_rectangle.md
@@ -30,3 +30,5 @@ roi_contour, roi_hierarchy = pcv.roi.rectangle(img=rgb_img, x=100, y=100, h=200,
 ```
 
 ![Screenshot](img/documentation_images/rectangle/image_with_roi.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/roi/roi_methods.py)

--- a/docs/rotate2.md
+++ b/docs/rotate2.md
@@ -52,3 +52,5 @@ rotate_img = pcv.rotate(img, -10, False)
 **Image after rotating -10 degrees**
 
 ![Screenshot](img/documentation_images/rotate2/8_rotated_img.png)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/rotate.py)

--- a/docs/saturation_threshold.md
+++ b/docs/saturation_threshold.md
@@ -40,3 +40,5 @@ sat_thresh = pcv.threshold.saturation(rgb_img=rgb_img, threshold=250, channel="a
 We can see that part of the table was masked out due to being fully saturated. 
 
 ![Screenshot](img/documentation_images/saturation_threshold/saturation_threshold.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/threshold/threshold_methods.py)

--- a/docs/scale_features.md
+++ b/docs/scale_features.md
@@ -37,3 +37,5 @@ points_rescaled, centroid_rescaled, base_rescaled = pcv.scale_features(obj, mask
 **Image of rescaled points in white, centroid is in gold and centroid at pot base is in blue**
 
 ![Screenshot](img/documentation_images/scale_features/sf_output.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/scale_features.py)

--- a/docs/scharr_filter.md
+++ b/docs/scharr_filter.md
@@ -45,3 +45,5 @@ sr_y_img = pcv.scharr_filter(gray_img, 0, 1, 1)
 **Scharr filtered (y-axis)**
 
 ![Screenshot](img/documentation_images/scharr_filter/scharr-y.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/scharr_filter.py)

--- a/docs/segment_angle.md
+++ b/docs/segment_angle.md
@@ -40,3 +40,5 @@ segment_angles = pcv.outputs.observations['segment_angle']['value']
 *Labeled Image*
 
 ![Screenshot](img/documentation_images/segment_angle/labeled_angles.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/morphology/segment_angle.py)

--- a/docs/segment_combine.md
+++ b/docs/segment_combine.md
@@ -66,3 +66,5 @@ labeled_img2, new_objects = pcv.morphology.segment_combine([7,6], new_objects, m
 *Other Leaf Combined*
 
 ![Screenshot](img/documentation_images/combine_segments/combined2_img.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/morphology/segment_combine.py)

--- a/docs/segment_curvature.md
+++ b/docs/segment_curvature.md
@@ -46,3 +46,5 @@ segment_curvatures = pcv.outputs.observations['segment_curvature']['value']
 *Labeled Image (only leaves)*
 
 ![Screenshot](img/documentation_images/segment_curvature/labeled_leaf_curvature.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/morphology/segment_curvature.py)

--- a/docs/segment_euclidean_length.md
+++ b/docs/segment_euclidean_length.md
@@ -42,3 +42,5 @@ euclidean_lengths = pcv.outputs.observations['segment_eu_length']['value']
 *Labeled Image*
 
 ![Screenshot](img/documentation_images/segment_euclidean_length/labeled_eu_lengths.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/morphology/segment_euclidean_length.py)

--- a/docs/segment_id.md
+++ b/docs/segment_id.md
@@ -58,3 +58,5 @@ segmented_img, leaves_labeled = pcv.morphology.segment_id(skel_img=skeleton,
 *Labeled Image, Leaves Only with Mask*
 
 ![Screenshot](img/documentation_images/segment_id/labeled_leaves_mask.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/morphology/segment_id.py)

--- a/docs/segment_insertion_angle.md
+++ b/docs/segment_insertion_angle.md
@@ -51,3 +51,5 @@ segment_insertion_angles = pcv.outputs.observations['segment_insertion_angle']['
 *Labeled Image*
 
 ![Screenshot](img/documentation_images/segment_insertion_angle/insertion_angle_img.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/morphology/segment_insertion_angle.py)

--- a/docs/segment_pathlength.md
+++ b/docs/segment_pathlength.md
@@ -42,3 +42,5 @@ path_lengths = pcv.outputs.observations['segment_path_length']['value']
 *Labeled Image*
 
 ![Screenshot](img/documentation_images/segment_path_length/labeled_path_lengths.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/morphology/segment_path_length.py)

--- a/docs/segment_skeleton.md
+++ b/docs/segment_skeleton.md
@@ -47,3 +47,5 @@ segmented_img2, obj = pcv.morphology.segment_skeleton(skel_img=skeleton,
 *Segmented Image with Mask*
 
 ![Screenshot](img/documentation_images/segment_skeleton/segmented_img_mask.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/morphology/segment_skeleton.py)

--- a/docs/segment_sort.md
+++ b/docs/segment_sort.md
@@ -50,3 +50,5 @@ leaf_obj, other_obj = pcv.morphology.segment_sort(skel_img=skeleton,
 *Segmented Image with Mask*
 
 ![Screenshot](img/documentation_images/segment_sort/sorted_segments_mask.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/morphology/segment_sort.py)

--- a/docs/segment_tangent_angle.md
+++ b/docs/segment_tangent_angle.md
@@ -49,3 +49,5 @@ leaf_tangent_angles = pcv.outputs.observations['segment_tangent_angle']['value']
 *Labeled Image*
 
 ![Screenshot](img/documentation_images/segment_tangent_angle/tangent_angle_img.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/morphology/segment_tangent_angle.py)

--- a/docs/shift.md
+++ b/docs/shift.md
@@ -35,3 +35,5 @@ shifted_img = pcv.shift_img(img, 300, "top")
 **Image after shift**
 
 ![Screenshot](img/documentation_images/shift/37_shifted.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/shift_img.py)

--- a/docs/skeletonize.md
+++ b/docs/skeletonize.md
@@ -28,3 +28,5 @@ skeleton = pcv.morphology.skeletonize(mask=plant_mask)
 ```
 
 ![Screenshot](img/documentation_images/skeletonize/skeleton_image.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/morphology/skeletonize.py)

--- a/docs/sobel_filter.md
+++ b/docs/sobel_filter.md
@@ -44,3 +44,5 @@ sb_y_img = pcv.sobel_filter(gray_img, 0, 1, 1)
 **Sobel filtered (y-axis)**
 
 ![Screenshot](img/documentation_images/sobel_filter/sobel-y.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/sobel_filter.py)

--- a/docs/texture_threshold.md
+++ b/docs/texture_threshold.md
@@ -49,3 +49,5 @@ texture_img = pcv.threshold.texture(gray_img, ksize=6, threshold=7, offset=3,
 **Thresholded image**
 
 ![Screenshot](img/documentation_images/texture_threshold/texture_thresholded.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/threshold/threshold_methods.py)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -39,6 +39,9 @@ Subcommands:
 
 `plantcv-utils.py` is a command-line tool for running various utilities.
 
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv-utils.py)
+
+
 #### Convert output JSON data files to CSV tables
 
 `plantcv-utils.py json2csv` is a command-line tool for converting the output JSON files from `plantcv-workflow.py` to
@@ -63,6 +66,9 @@ is a table of observations with single values (e.g. area, convex hull area, etc.
 per image. `prefix-multi-value-traits.csv` is a table of observations with multiple values (e.g. frequency distribution
 of hue or other color channel/properties). The format of this table is one row per value/label. 
 
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/utils/converters.py)
+
+
 #### Collect a random sample of images for testing workflows
 
 `plantcv-utils.py sample_images` is a command-line tool for gathering a random set of images for
@@ -85,6 +91,9 @@ identify 'problem images' before running a workflow in parallel over a large set
 tool can handle LemnaTec structured output in addition to a flat file directory. Currently supported image types include 
 .png, .jpg, .jpeg, .tif, .tiff, and .gif. A source directory will be created if it does not already exist. The number of 
 random images requested must be less than or equal to the number of images in the source directory. 
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/utils/sample_images.py)
+
 
 ### Parallel workflow processing
 
@@ -161,3 +170,6 @@ optional arguments:
                         (default: None)
 
 ```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv-workflow.py)
+

--- a/docs/transform_color_correction_tutorial.md
+++ b/docs/transform_color_correction_tutorial.md
@@ -617,3 +617,5 @@ if __name__ == '__main__':
     main()
     
 ```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/transform/color_correction.py)

--- a/docs/transform_correct_color.md
+++ b/docs/transform_correct_color.md
@@ -370,3 +370,5 @@ from plotnine import *
 pcv.transform.quick_color_check(source_matrix = s_matrix, target_matrix = t_matrix, num_chips = 24)
 
 ```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/transform/color_correction.py)

--- a/docs/transform_rescale.md
+++ b/docs/transform_rescale.md
@@ -36,3 +36,5 @@ scaled_img = pcv.transform.rescale(thermal_data, 0, 255)
 **Image after resizing**
 
 ![Screenshot](img/tutorial_images/thermal/rescaled_image.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/transform/rescale.py)

--- a/docs/triangle_threshold.md
+++ b/docs/triangle_threshold.md
@@ -59,3 +59,5 @@ thresholded = pcv.threshold.triangle(gray_img, 255, 'light', xstep=1)
 ![Screenshot](img/documentation_images/triangle_threshold/11_triangle_thresh_hist_3.0.jpg)
 
 ![Screenshot](img/documentation_images/triangle_threshold/11_triangle_thresh_img_3.0.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/threshold/threshold_methods.py)

--- a/docs/visualize_clustered_contours.md
+++ b/docs/visualize_clustered_contours.md
@@ -52,3 +52,5 @@ clustered_image = pcv.visualize.clustered_contours(img=img, grouped_contour_indi
 **Clustered Image with Grid:** 
 
 ![Screenshot](img/documentation_images/visualize_clustered_contours/contour_cluster_img_grid.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/visualize/clustered_contours.py)

--- a/docs/visualize_colorize_masks.md
+++ b/docs/visualize_colorize_masks.md
@@ -50,3 +50,5 @@ plotted = pcv.visualize.colorize_masks(masks=[mask['plant'], mask['pustule'], ma
 **Plot with Colored Masks**
 
 ![Screenshot](img/documentation_images/colorize_masks/colored_classes.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/visualize/colorize_masks.py)

--- a/docs/visualize_colorspace.md
+++ b/docs/visualize_colorspace.md
@@ -30,3 +30,4 @@ colorspace_img = pcv.visualize.colorspaces(rgb_img=img)
 
 ![Screenshot](img/documentation_images/visualize_colorspaces/all_colorspaces.jpg)
 
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/visualize/colorspaces.py)

--- a/docs/visualize_histogram.md
+++ b/docs/visualize_histogram.md
@@ -40,3 +40,5 @@ hist_figure = pcv.visualize.histogram(gray_img, mask=mask, bins=256, color='red'
 **Histogram of signal intensity**
 
 ![Screenshot](img/documentation_images/histogram/hist.jpg) 
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/visualize/histogram.py)

--- a/docs/visualize_pseudocolor.md
+++ b/docs/visualize_pseudocolor.md
@@ -96,3 +96,5 @@ simple_pseudo_img = pcv.visualize.pseudocolor(gray_img=img, obj=None, mask=mask,
 **Pseudocolored, Plotted on Input Image (no axes or colorbar)**
 
 ![Screenshot](img/documentation_images/pseudocolor/pseudo_onimage_simple.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/visualize/pseudocolor.py)

--- a/docs/watershed.md
+++ b/docs/watershed.md
@@ -41,3 +41,5 @@ analysis_image = pcv.watershed_segmentation(crop_img, thresh, 10)
 **Watershed Segmentation**
 
 ![Screenshot](img/documentation_images/watershed/watershed.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/watershed.py)

--- a/docs/white_balance.md
+++ b/docs/white_balance.md
@@ -37,3 +37,5 @@ corrected_img = pcv.white_balance(img, mode='hist', roi=(5, 5, 80, 80))
 **Corrected image**
 
 ![Screenshot](img/documentation_images/white_balance/corrected_image.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/white_balance.py)

--- a/docs/within_frame.md
+++ b/docs/within_frame.md
@@ -25,3 +25,5 @@ mask = pcv.threshold.binary(gray_img, 36, 255, 'light')
 in_bounds = pcv.within_frame(mask)  #True or False?
 
 ```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/within_frame.py)

--- a/docs/x_axis_pseudolandmarks.md
+++ b/docs/x_axis_pseudolandmarks.md
@@ -38,3 +38,5 @@ bottom_landmarks = pcv.outputs.observations['bottom_lmk']['value']
 **Image of points selected**
 
 ![Screenshot](img/documentation_images/x_axis_pseudolandmarks/xap_output.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/x_axis_pseudolandmarks.py)

--- a/docs/y_axis_pseudolandmarks.md
+++ b/docs/y_axis_pseudolandmarks.md
@@ -41,3 +41,5 @@ left_landmarks = pcv.outputs.observations['left_lmk']['value']
 **Image of points selected**
 
 ![Screenshot](img/documentation_images/y_axis_pseudolandmarks/yap_output.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/y_axis_pseudolandmarks.py)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
       - 'RGB to LAB': rgb2lab.md
       - 'RGB to HSV': rgb2hsv.md
       - 'White balance': white_balance.md
+    - 'Crop': crop.md
     - 'Crop and Position Mask': crop_position_mask.md
     - 'Dilation': dilate.md
     - 'Distance Transform': distance_transform.md
@@ -77,6 +78,7 @@ nav:
         - 'Calibrate': calibrate.md
         - 'Extract index': extract_index.md
         - 'Extract wavelength': extract_wavelength.md
+        - 'Spectral data objects': Spectral_data.md
     - 'Image Add': image_add.md
     - 'Image Subtract': image_subtract.md
     - 'Invert': invert.md


### PR DESCRIPTION
**Describe your changes**
I received a suggestion from someone that teaches PlantCV in an image analysis course to include links to the source code for functions within the documentation pages. Even though we expect most users will not need to look at the actual code from a PlantCV function, including these links furthers the cause of transparency and open access. 

**Type of update**
* Update to documentation



