### PR TITLE
Add VIs to extract index

### DIFF
--- a/plantcv/plantcv/hyperspectral/extract_index.py
+++ b/plantcv/plantcv/hyperspectral/extract_index.py
@@ -138,7 +138,7 @@ def extract_index(array, index="NDVI", distance=20):
         else:
             fatal_error("Available wavelengths are not suitable for calculating CARI. Try increasing distance.")
 
-    elif index.upper() == 'CI_rededge':
+    elif index.upper() == 'CI_REDEDGE':
         # Chlorophyll index red edge (Giteson et al., 2003a)
         if (max_wavelength + distance) >= 800 and (min_wavelength - distance) <= 750:
             rededge_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 750)
@@ -374,7 +374,7 @@ def extract_index(array, index="NDVI", distance=20):
         else:
             fatal_error("Available wavelengths are not suitable for calculating VARI. Try increasing distance.")
 
-    elif index.upper() == 'VI_green':
+    elif index.upper() == 'VI_GREED':
         # Vegetation index using green band (Gitelson et al., 2002a)
         if (max_wavelength + distance) >= 670 and (min_wavelength - distance) <= 560:
             red_index   = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 670)

--- a/plantcv/plantcv/hyperspectral/extract_index.py
+++ b/plantcv/plantcv/hyperspectral/extract_index.py
@@ -17,7 +17,7 @@ def extract_index(array, index="NDVI", distance=20):
 
         Inputs:
         array = hyperspectral data instance
-        index = index of interest, either "ndvi", "gdvi", "savi", "pri", "aci", "ari", "cai", "cari", "ci_rededge", "cri1", "cri2", "evi",
+        index = index of interest, "ndvi", "gdvi", "savi", "pri", "aci", "ari", "cai", "cari", "ci_rededge", "cri1", "cri2", "evi",
         "mari", "mcari", "mtci", "ndre", "psnd_chla", "psnd_chlb", "psnd_car", "psri", "pssr1", "pssr2", "pssr3", "rgri", "rvsi", "sipi",
         "sr", "vari", "vi_green", "wbi".
         distance = how lenient to be if the required wavelengths are not available

--- a/plantcv/plantcv/hyperspectral/extract_index.py
+++ b/plantcv/plantcv/hyperspectral/extract_index.py
@@ -17,7 +17,9 @@ def extract_index(array, index="NDVI", distance=20):
 
         Inputs:
         array = hyperspectral data instance
-        index = index of interest, either "ndvi", "gdvi", or "savi"
+        index = index of interest, either "ndvi", "gdvi", "savi", "pri", "aci", "ari", "cai", "cari", "ci_rededge", "cri1", "cri2", "evi",
+        "mari", "mcari", "mtci", "ndre", "psnd_chla", "psnd_chlb", "psnd_car", "psri", "pssr1", "pssr2", "pssr3", "rgri", "rvsi", "sipi",
+        "sr", "vari", "vi_green", "wbi".
         distance = how lenient to be if the required wavelengths are not available
 
         Returns:
@@ -90,7 +92,7 @@ def extract_index(array, index="NDVI", distance=20):
             fatal_error("Available wavelengths are not suitable for calculating PRI. Try increasing distance.")
 
     elif index.upper() == "ACI":
-        #  Van den Berg et al. 2005
+        #  Anthocyanim content index (Van den Berg et al. 2005)
         if (max_wavelength + distance) >= 800 and (min_wavelength - distance) <= 560:
             green_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 560)
             nir_index   = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
@@ -100,17 +102,300 @@ def extract_index(array, index="NDVI", distance=20):
             index_array_raw = green/nir
         else:
             fatal_error("Available wavelengths are not suitable for calculating ACI. Try increasing distance.")
-    
+
     elif index.upper() == "ARI":
-        # Gitelson et al., 2001
+        # Anthocyanin reflectance index (Gitelson et al., 2001)
         if (max_wavelength + distance) >= 700 and (min_wavelength - distance) <= 550:
-            ari550_indes = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 550)
+            ari550_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 550)
             ari700_index   = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 700)
-            ari550 = (array_data[:, :, [ari550_indes]])
+            ari550 = (array_data[:, :, [ari550_index]])
             ari700 = (array_data[:, :, [ari700_index]])
             index_array_raw = (1/ari550)-(1/ari700)
         else:
             fatal_error("Available wavelengths are not suitable for calculating ARI. Try increasing distance.")
+
+    elif index.upper() == 'CAI':
+        # Cellulose absorption index (Daughtry, 2001)
+        if (max_wavelength + distance) >= 2206 and (min_wavelength - distance) <= 2019:
+            cai2019_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 2019)
+            cai2109_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 2109)
+            cai2206_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 2206)
+            cai2019 = (array_data[:, :, [cai2019_index]])
+            cai2109 = (array_data[:, :, [cai2109_index]])
+            cai2206 = (array_data[:, :, [cai2206_index]])
+            index_array_raw = 0.5*(cai2019+cai2206)-cai2109
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating CAI. Try increasing distance.")
+
+    elif index.upper() == 'CARI':
+        # Chlorophyll absorption in reflectance index (Giteson et al., 2003a)
+        if (max_wavelength + distance) >= 700 and (min_wavelength - distance) <= 550:
+            cari550_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 550)
+            cari700_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 700)
+            cari550 = (array_data[:, :, [cari550_index]])
+            cari700 = (array_data[:, :, [cari700_index]])
+            index_array_raw = (1/cari550)-(1/cari700)
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating CARI. Try increasing distance.")
+
+    elif index.upper() == 'CI_rededge':
+        # Chlorophyll index red edge (Giteson et al., 2003a)
+        if (max_wavelength + distance) >= 800 and (min_wavelength - distance) <= 750:
+            rededge_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 750)
+            nir_index     = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
+            rededge = (array_data[:, :, [rededge_index]])
+            nir     = (array_data[:, :, [nir_index]])
+            index_array_raw = nir/rededge - 1
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating CI_rededge. Try increasing distance.")
+
+    elif index.upper() == 'CRI1':
+        # Carotenoid reflectance index (Gitelson et al., 2002b) (note: part 1 of 2)
+        if (max_wavelength + distance) >= 550 and (min_wavelength - distance) <= 510:
+            cri1510_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 510)
+            cri1550_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 550)
+            cri1510 = (array_data[:, :, [cri1510_index]])
+            cri1550 = (array_data[:, :, [cri1550_index]])
+            index_array_raw = 1/cri1510-1/cri1550
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating CRI1. Try increasing distance.")
+
+    elif index.upper() == 'CRI2':
+        # Carotenoid reflectance index (Gitelson et al., 2002b) (note: part 1 of 2)
+        if (max_wavelength + distance) >= 700 and (min_wavelength - distance) <= 510:
+            cri1510_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 510)
+            cri1700_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 700)
+            cri1510 = (array_data[:, :, [cri1510_index]])
+            cri1700 = (array_data[:, :, [cri1700_index]])
+            index_array_raw = 1/cri1510-1/cri1700
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating CRI2. Try increasing distance.")
+
+    elif index.upper() == 'EVI':
+        # Enhanced Vegetation index (Huete et al., 1997)
+        if (max_wavelength + distance) >= 800 and (min_wavelength - distance) <= 470:
+            blue_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 470)
+            red_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 670)
+            nir_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
+            blue = (array_data[:, :, [blue_index]])
+            red = (array_data[:, :, [red_index]])
+            nir = (array_data[:, :, [nir_index]])
+            index_array_raw = 2.5*(nir-red)/(nir+6*red-7.5*blue+1)
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating EVI. Try increasing distance.")
+
+    elif index.upper() == 'MARI':
+        # Modified anthocyanin reflectance index (Gitelson et al., 2001)
+        if (max_wavelength + distance) >= 800 and (min_wavelength - distance) <= 550:
+            mari550_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 550)
+            mari700_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 700)
+            nir_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
+            mari550 = (array_data[:, :, [mari550_index]])
+            mari700 = (array_data[:, :, [mari700_index]])
+            nir = (array_data[:, :, [nir_index]])
+            index_array_raw = ((1/mari550)-(1/mari700))*nir
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating MARI. Try increasing distance.")
+
+    elif index.upper() == 'MCARI':
+        # Modified chlorophyll absorption in reflectance index (Daughtry et al., 2000)
+        if (max_wavelength + distance) >= 700 and (min_wavelength - distance) <= 550:
+            mcari550_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 550)
+            mcari670_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 670)
+            mcari700_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 700)
+            mcari550 = (array_data[:, :, [mcari550_index]])
+            mcari670 = (array_data[:, :, [mcari670_index]])
+            mcari700 = (array_data[:, :, [mcari700_index]])
+            index_array_raw = ((mcari700-mcari670)-0.2*(mcari700-mcari550))*(mcari700/mcari670)
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating MCARI. Try increasing distance.")
+
+    elif index.upper() == 'MTCI':
+        # MERIS terrestrial chlorophyll index (Dash and Curran, 2004)
+        if (max_wavelength + distance) >= 753.75 and (min_wavelength - distance) <= 681.25:
+            mtci68125_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 681.25)
+            mtci70875_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 708.75)
+            mtci75375_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 753.75)
+            mtci68125 = (array_data[:, :, [mtci68125_index]])
+            mtci70875 = (array_data[:, :, [mtci70875_index]])
+            mtci75375 = (array_data[:, :, [mtci75375_index]])
+            index_array_raw = (mtci75375-mtci70875)/(mtci70875-mtci68125)
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating MTCI. Try increasing distance.")
+
+    elif index.upper() == 'NDRE':
+        # Normalized difference red edge (Barnes et al., 2000)
+        if (max_wavelength + distance) >= 790 and (min_wavelength - distance) <= 720:
+            ndre720_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 720)
+            ndre790_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 790)
+            ndre790 = (array_data[:, :, [ndre790_index]])
+            ndre720 = (array_data[:, :, [ndre720_index]])
+            index_array_raw = (ndre790-ndre720)/(ndre790+ndre720)
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating NDRE. Try increasing distance.")
+
+    elif index.upper() == 'PSND_CHLA':
+        # Pigment sensitive normalized difference (Blackburn, 1998) note: chl_a
+        if (max_wavelength + distance) >= 800 and (min_wavelength - distance) <= 675:
+            psndchla675_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 675)
+            psndchla800_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
+            psndchla675 = (array_data[:, :, [psndchla675_index]])
+            psndchla800 = (array_data[:, :, [psndchla800_index]])
+            index_array_raw = (psndchla800-psndchla675)/(psndchla800+psndchla675)
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating PSND_CHLA. Try increasing distance.")
+
+    elif index.upper() == 'PSND_CHLB':
+        # Pigment sensitive normalized difference (Blackburn, 1998) note: chl_b (part 1 of 3)
+        if (max_wavelength + distance) >= 800 and (min_wavelength - distance) <= 650:
+            psndchlb650_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 650)
+            psndchlb800_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
+            psndchlb650 = (array_data[:, :, [psndchlb650_index]])
+            psndchlb800 = (array_data[:, :, [psndchlb800_index]])
+            index_array_raw = (psndchlb800-psndchlb650)/(psndchlb800+psndchlb650)
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating PSND_CHLB. Try increasing distance.")
+
+    elif index.upper() == 'PSND_CAR':
+        # Pigment sensitive normalized difference (Blackburn, 1998) note: chl_b (part 1 of 3)
+        if (max_wavelength + distance) >= 800 and (min_wavelength - distance) <= 500:
+            psndcar500_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 500)
+            psndcar800_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
+            psndcar500 = (array_data[:, :, [psndcar500_index]])
+            psndcar800 = (array_data[:, :, [psndcar800_index]])
+            index_array_raw = (psndcar800-psndcar500)/(psndcar800+psndcar500)
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating PSND_CAR. Try increasing distance.")
+
+    elif index.upper() == 'PSRI':
+        # Plant senescence reflectance index (Merzlyak et al., 1999) note: car (part 1 of 3)
+        if (max_wavelength + distance) >= 750 and (min_wavelength - distance) <= 500:
+            psri500_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 500)
+            psri678_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 678)
+            psri750_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 750)
+            psri500 = (array_data[:, :, [psri500_index]])
+            psri678 = (array_data[:, :, [psri678_index]])
+            psri750 = (array_data[:, :, [psri750_index]])
+            index_array_raw = (psri678-psri500)/psri750
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating PSRI. Try increasing distance.")
+
+    elif index.upper() == 'PSSR1':
+        # Pigment-specific spectral ration (Blackburn, 1998) note: part 1 of 3
+        if (max_wavelength + distance) >= 800 and (min_wavelength - distance) <= 675:
+            pssr1_800_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
+            pssr1_675_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 675)
+            pssr1_800 = (array_data[:, :, [pssr1_800_index]])
+            pssr1_675 = (array_data[:, :, [pssr1_675_index]])
+            index_array_raw = pssr1_800/pssr1_675
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating PSSR1. Try increasing distance.")
+
+    elif index.upper() == 'PSSR2':
+        # Pigment-specific spectral ration (Blackburn, 1998) note: part 2 of 3
+        if (max_wavelength + distance) >= 800 and (min_wavelength - distance) <= 650:
+            pssr2_800_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
+            pssr2_650_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 650)
+            pssr2_800 = (array_data[:, :, [pssr2_800_index]])
+            pssr2_650 = (array_data[:, :, [pssr2_650_index]])
+            index_array_raw = pssr2_800/pssr2_650
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating PSSR2. Try increasing distance.")
+
+    elif index.upper() == 'PSSR3':
+        # Pigment-specific spectral ration (Blackburn, 1998) note: part 3 of 3
+        if (max_wavelength + distance) >= 800 and (min_wavelength - distance) <= 500:
+            pssr3_800_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
+            pssr3_500_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 500)
+            pssr3_800 = (array_data[:, :, [pssr3_800_index]])
+            pssr3_500 = (array_data[:, :, [pssr3_500_index]])
+            index_array_raw = pssr3_800/pssr3_500
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating PSSR3. Try increasing distance.")
+
+    elif index.upper() == 'RGRI':
+        # Red/green ratio index (Gamon and Surfus, 1999)
+        if (max_wavelength + distance) >= 670 and (min_wavelength - distance) <= 560:
+            red_index   = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 670)
+            green_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 560)
+            red   = (array_data[:, :, [red_index]])
+            green = (array_data[:, :, [green_index]])
+            index_array_raw = red / green
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating RGRI. Try increasing distance.")
+
+    elif index.upper() == 'RVSI':
+        # Red-edge vegetation stress index (Metron and Huntington, 1999)
+        if (max_wavelength + distance) >= 752 and (min_wavelength - distance) <= 714:
+            rvsi714_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 714)
+            rvsi733_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 733)
+            rvsi752_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 752)
+            rvsi714 = (array_data[:, :, [rvsi714_index]])
+            rvsi733 = (array_data[:, :, [rvsi733_index]])
+            rvsi752 = (array_data[:, :, [rvsi752_index]])
+            index_array_raw = (rvsi714+rvsi752)/2 - rvsi733
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating RVSI. Try increasing distance.")
+
+    elif index.upper() == 'SIPI':
+        # Structure-intensitive pigment index (Penuelas et al., 1995)
+        if (max_wavelength + distance) >= 800 and (min_wavelength - distance) <= 445:
+            sipi445_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 445)
+            sipi680_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 680)
+            sipi800_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
+            sipi445 = (array_data[:, :, [sipi445_index]])
+            sipi680 = (array_data[:, :, [sipi680_index]])
+            sipi800 = (array_data[:, :, [sipi800_index]])
+            index_array_raw = (sipi800-sipi445)/(sipi800-sipi680)
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating SIPI. Try increasing distance.")
+
+    elif index.upper() == 'SR':
+        # Simple ratio (Jordan, 1969)
+        if (max_wavelength + distance) >= 800 and (min_wavelength - distance) <= 675:
+            sr675_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 675)
+            sr800_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 800)
+            sr675 = (array_data[:, :, [sr675_index]])
+            sr800 = (array_data[:, :, [sr800_index]])
+            index_array_raw = sr800/sr675
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating SR. Try increasing distance.")
+
+    elif index.upper() == 'VARI':
+        # Visible atmospherically resistant index (Gitelson et al., 2002a)
+        if (max_wavelength + distance) >= 670 and (min_wavelength - distance) <= 470:
+            red_index   = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 670)
+            green_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 560)
+            blue_index  = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 470)
+            red    = (array_data[:, :, [red_index]])
+            green  = (array_data[:, :, [green_index]])
+            blue   = (array_data[:, :, [blue_index]])
+            index_array_raw = (green-red)/(green+red-blue)
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating VARI. Try increasing distance.")
+
+    elif index.upper() == 'VI_green':
+        # Vegetation index using green band (Gitelson et al., 2002a)
+        if (max_wavelength + distance) >= 670 and (min_wavelength - distance) <= 560:
+            red_index   = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 670)
+            green_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 560)
+            red    = (array_data[:, :, [red_index]])
+            green  = (array_data[:, :, [green_index]])
+            index_array_raw = (green-red)/(green+red)
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating VI_green. Try increasing distance.")
+
+    elif index.upper() == 'WBI':
+        # Water band index (Peñuelas et al., 1997)
+        if (max_wavelength + distance) >= 800 and (min_wavelength - distance) <= 675:
+            red_index   = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 670)
+            green_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 560)
+            red    = (array_data[:, :, [red_index]])
+            green  = (array_data[:, :, [green_index]])
+            index_array_raw = (green-red)/(green+red)
+        else:
+            fatal_error("Available wavelengths are not suitable for calculating VI_green. Try increasing distance.")
+
     else:
         fatal_error(index + " is not one of the currently available indices for this function. Please open an issue " +
                     "on the PlantCV GitHub account so we can add more handy indicies!")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3705,6 +3705,246 @@ def test_plantcv_hyperspectral_extract_index_ari():
     index_array = pcv.hyperspectral.extract_index(array=array_data, index="ARI", distance=801)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
+def test_plantcv_hyperspectral_extract_index_cai():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_cai")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="CAI", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_cari():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_cari")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="CARI", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_ci_rededge():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_ci_rededge")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="CI_rededge", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_cri():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_cri")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="CRI", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_evi():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_evi")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="EVI", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_mari():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_mari")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="MARI", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_mcari():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_mcari")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="MCARI", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_mtci():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_mtci")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="MTCI", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_ndre():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_ndre")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="NDRE", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_ndre():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_ndre")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="NDRE", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_psnd_chla():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_psnd_chla")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSND_CHLA", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_psnd_chlb():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_psnd_chla")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSND_CHLB", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_psnd_car():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_psnd_car")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSND_CAR", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_psri():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_psri")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSRI", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_pssr1():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_pssr1")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSSR1", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_pssr2():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_pssr2")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSSR2", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_pssr3():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_pssr3")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSSR3", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_rgri():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_rgri")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="RGRI", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_rvsi():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_rvsi")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="RVSI", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_sipi():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_sipi")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="SIPI", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_sr():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_sr")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="SR", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_vari():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_vari")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="VARI", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_vi_green():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_vi_green")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="VI_green", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+def test_plantcv_hyperspectral_extract_index_wbi():
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_wbi")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    pcv.params.debug = None
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="WBI", distance=801)
+    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
 def test_plantcv_hyperspectral_extract_index_ndvi_bad_input():
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     pcv.params.debug=None
@@ -3736,18 +3976,9 @@ def test_plantcv_hyperspectral_extract_index_pri_bad_input():
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     pcv.params.debug = None
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="pri", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PRI", distance=801)
     with pytest.raises(RuntimeError):
         index_array = pcv.hyperspectral.extract_index(array=index_array, index="PRI")
-
-
-def test_plantcv_hyperspectral_extract_index_bad_input_index():
-    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
-    pcv.params.debug = None
-    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="SAVI", distance=801)
-    with pytest.raises(RuntimeError):
-        index_array = pcv.hyperspectral.extract_index(array=index_array, index="SAVII", distance=801)
         
 def test_plantcv_hyperspectral_extract_index_aci_bad_input():
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
@@ -3765,6 +3996,197 @@ def test_plantcv_hyperspectral_extract_index_ari_bad_input():
     with pytest.raises(RuntimeError):
         index_array = pcv.hyperspectral.extract_index(array=index_array, index="ARI")
 
+def test_plantcv_hyperspectral_extract_index_cai_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="CAI", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="CAI")
+
+def test_plantcv_hyperspectral_extract_index_cari_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="CARI", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="CARI")
+
+def test_plantcv_hyperspectral_extract_index_ci_rededge_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="CI_rededge", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="CI_rededge")
+
+def test_plantcv_hyperspectral_extract_index_cri1_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="CRI1", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="CRI1")
+
+def test_plantcv_hyperspectral_extract_index_cri2_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="CRI2", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="CRI2")
+
+def test_plantcv_hyperspectral_extract_index_evi_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="EVI", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="EVI")
+
+def test_plantcv_hyperspectral_extract_index_mari_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="MARI", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="MARI")
+
+def test_plantcv_hyperspectral_extract_index_mcari_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="MCARI", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="MCARI")
+
+def test_plantcv_hyperspectral_extract_index_mtci_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="MTCI", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="MTCI")
+
+def test_plantcv_hyperspectral_extract_index_ndre_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="NDRE", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="NDRE")
+
+def test_plantcv_hyperspectral_extract_index_psnd_chla_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSND_CHLA", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="PSND_CHLA")
+
+def test_plantcv_hyperspectral_extract_index_psnd_chlb_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSND_CHLB", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="PSND_CHLB")
+
+def test_plantcv_hyperspectral_extract_index_psnd_car_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSND_CAR", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="PSND_CAR")
+
+def test_plantcv_hyperspectral_extract_index_psri_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSRI", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="PSRI")
+
+def test_plantcv_hyperspectral_extract_index_pssr1_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSSR1", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="PSSR1")
+
+def test_plantcv_hyperspectral_extract_index_pssr2_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSSR2", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="PSSR2")
+
+def test_plantcv_hyperspectral_extract_index_pssr3_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSSR3", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="PSSR3")
+
+def test_plantcv_hyperspectral_extract_index_rgri_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="RGRI", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="RGRI")
+
+def test_plantcv_hyperspectral_extract_index_rvsi_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="RVSI", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="RVSI")
+
+def test_plantcv_hyperspectral_extract_index_sipi_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="SIPI", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="SIPI")
+
+def test_plantcv_hyperspectral_extract_index_sr_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="SR", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="SR")
+
+def test_plantcv_hyperspectral_extract_index_vari_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="VARI", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="VARI")
+
+def test_plantcv_hyperspectral_extract_index_vi_green_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="VI_green", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="VI_green")
+
+def test_plantcv_hyperspectral_extract_index_wbi_bad_input():
+    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
+    pcv.params.debug=None
+    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="WBI", distance=801)
+    with pytest.raises(RuntimeError):
+        index_array = pcv.hyperspectral.extract_index(array=index_array, index="WBI")
 
 def test_plantcv_hyperspectral_analyze_spectral():
     cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_analyze_spectral")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3939,7 +3939,7 @@ def test_plantcv_hyperspectral_extract_index_ndvi_bad_input():
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     pcv.params.debug=None
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="SAVI", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="NDVI", distance=801)
     with pytest.raises(RuntimeError):
         index_array = pcv.hyperspectral.extract_index(array=index_array, index="NDVI")
 
@@ -3948,7 +3948,7 @@ def test_plantcv_hyperspectral_extract_index_gdvi_bad_input():
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     pcv.params.debug = None
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="SAVI", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="GDVI", distance=801)
     with pytest.raises(RuntimeError):
         index_array = pcv.hyperspectral.extract_index(array=index_array, index="GDVI")
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3676,7 +3676,7 @@ def test_plantcv_hyperspectral_extract_index_savi():
 
 
 def test_plantcv_hyperspectral_extract_index_pri():
-    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_savi")
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_pri")
     os.mkdir(cache_dir)
     pcv.params.debug_outdir = cache_dir
     pcv.params.debug = "plot"
@@ -3783,16 +3783,6 @@ def test_plantcv_hyperspectral_extract_index_mtci():
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
     index_array = pcv.hyperspectral.extract_index(array=array_data, index="MTCI", distance=801)
-    assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
-
-def test_plantcv_hyperspectral_extract_index_ndre():
-    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_hyperspectral_extract_index_ndre")
-    os.mkdir(cache_dir)
-    pcv.params.debug_outdir = cache_dir
-    pcv.params.debug = None
-    spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
-    array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="NDRE", distance=801)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_ndre():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3712,7 +3712,7 @@ def test_plantcv_hyperspectral_extract_index_cai():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="CAI", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="CAI", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_cari():
@@ -3722,7 +3722,7 @@ def test_plantcv_hyperspectral_extract_index_cari():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="CARI", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="CARI", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_ci_rededge():
@@ -3732,7 +3732,7 @@ def test_plantcv_hyperspectral_extract_index_ci_rededge():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="CI_rededge", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="CI_rededge", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_cri():
@@ -3742,7 +3742,7 @@ def test_plantcv_hyperspectral_extract_index_cri():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="CRI", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="CRI", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_evi():
@@ -3752,7 +3752,7 @@ def test_plantcv_hyperspectral_extract_index_evi():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="EVI", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="EVI", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_mari():
@@ -3762,7 +3762,7 @@ def test_plantcv_hyperspectral_extract_index_mari():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="MARI", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="MARI", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_mcari():
@@ -3772,7 +3772,7 @@ def test_plantcv_hyperspectral_extract_index_mcari():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="MCARI", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="MCARI", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_mtci():
@@ -3782,7 +3782,7 @@ def test_plantcv_hyperspectral_extract_index_mtci():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="MTCI", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="MTCI", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_ndre():
@@ -3792,7 +3792,7 @@ def test_plantcv_hyperspectral_extract_index_ndre():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="NDRE", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="NDRE", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_psnd_chla():
@@ -3802,7 +3802,7 @@ def test_plantcv_hyperspectral_extract_index_psnd_chla():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSND_CHLA", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSND_CHLA", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_psnd_chlb():
@@ -3812,7 +3812,7 @@ def test_plantcv_hyperspectral_extract_index_psnd_chlb():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSND_CHLB", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSND_CHLB", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_psnd_car():
@@ -3822,7 +3822,7 @@ def test_plantcv_hyperspectral_extract_index_psnd_car():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSND_CAR", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSND_CAR", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_psri():
@@ -3832,7 +3832,7 @@ def test_plantcv_hyperspectral_extract_index_psri():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSRI", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSRI", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_pssr1():
@@ -3842,7 +3842,7 @@ def test_plantcv_hyperspectral_extract_index_pssr1():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSSR1", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSSR1", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_pssr2():
@@ -3852,7 +3852,7 @@ def test_plantcv_hyperspectral_extract_index_pssr2():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSSR2", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSSR2", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_pssr3():
@@ -3862,7 +3862,7 @@ def test_plantcv_hyperspectral_extract_index_pssr3():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSSR3", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="PSSR3", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_rgri():
@@ -3872,7 +3872,7 @@ def test_plantcv_hyperspectral_extract_index_rgri():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="RGRI", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="RGRI", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_rvsi():
@@ -3882,7 +3882,7 @@ def test_plantcv_hyperspectral_extract_index_rvsi():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="RVSI", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="RVSI", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_sipi():
@@ -3892,7 +3892,7 @@ def test_plantcv_hyperspectral_extract_index_sipi():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="SIPI", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="SIPI", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_sr():
@@ -3902,7 +3902,7 @@ def test_plantcv_hyperspectral_extract_index_sr():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="SR", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="SR", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_vari():
@@ -3912,7 +3912,7 @@ def test_plantcv_hyperspectral_extract_index_vari():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="VARI", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="VARI", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_vi_green():
@@ -3922,7 +3922,7 @@ def test_plantcv_hyperspectral_extract_index_vi_green():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="VI_green", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="VI_green", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_wbi():
@@ -3932,7 +3932,7 @@ def test_plantcv_hyperspectral_extract_index_wbi():
     pcv.params.debug = None
     spectral_filename = os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA)
     array_data = pcv.hyperspectral.read_data(filename=spectral_filename)
-    index_array = pcv.hyperspectral.extract_index(array=array_data, index="WBI", distance=801)
+    index_array = pcv.hyperspectral.extract_index(array=array_data, index="WBI", distance=2000)
     assert np.shape(index_array.array_data) == (1,1600) and np.nanmax(index_array.pseudo_rgb) == 255
 
 def test_plantcv_hyperspectral_extract_index_ndvi_bad_input():


### PR DESCRIPTION
**Describe your changes**
Add new features to extract_index function in hyperspectral subpackage. Include more vegetation indices to be able to calculate. 
List of currently available VIs: "ndvi", "gdvi", "savi", "pri", "aci", "ari", "cai", "cari", "ci_rededge", "cri1", "cri2", "evi", "mari", "mcari", "mtci", "ndre", "psnd_chla", "psnd_chlb", "psnd_car", "psri", "pssr1", "pssr2", "pssr3", "rgri", "rvsi", "sipi", "sr", "vari", "vi_green", "wbi".

**Type of update**
Is this a:
* New feature or feature enhancement
* Work in progress

**Associated issues**
Reference associated issue numbers. Does this pull request close any issues?

**Additional context**
Add any other context about the problem here.