### PR TITLE
stop copying the data, just reference it instead to save memory

### DIFF
--- a/plantcv/plantcv/hyperspectral/extract_index.py
+++ b/plantcv/plantcv/hyperspectral/extract_index.py
@@ -37,8 +37,8 @@ def extract_index(array, index="NDVI", distance=20):
     min_wavelength = float(array.min_wavelength)
 
     # Dictionary of wavelength and it's index in the list
-    wavelength_dict = array.wavelength_dict.copy()
-    array_data = array.array_data.copy()
+    wavelength_dict = array.wavelength_dict
+    array_data = array.array_data
 
     if index.upper() == "NDVI":
         if (max_wavelength + distance) >= 800 and (min_wavelength - distance) <= 670:


### PR DESCRIPTION
**Describe your changes**
The `extract_index` function from the hyperspectral sub-package was copying the dictionary and array data before extract VIs but this is not necessary and will run up the memory needed for a hyperspectral session. 

**Type of update**
Is this a:
* feature enhancement


**Associated issues**
#203 

**Additional context**
Tested and significantly reduced the amount of memory used in an interactive session while carrying out the same workflow steps on the same image data. 