### PR TITLE
update param name from rgb_img to img

### DIFF
--- a/docs/custom_range_threshold.md
+++ b/docs/custom_range_threshold.md
@@ -1,14 +1,14 @@
 ## Custom Range Threshold
 
-Creates a binary image (mask) and a masked image from an RGB image based on the user defined threshold values. 
+Creates a binary image (mask) and a masked image from an RGB or grayscale image based on the user defined threshold values. 
 The threshold color-spaces that can be used are grayscale, RGB, HSV, or LAB.
 
-**plantcv.threshold.custom_range**(*rgb_img, lower_thresh, upper_thresh, channel='RGB'*)
+**plantcv.threshold.custom_range**(*img, lower_thresh, upper_thresh, channel='RGB'*)
 
 **returns** mask, masked_img
 
 - **Parameters:**
-    - rgb_img - RGB image data
+    - img - RGB image data
     - lower_thresh - List of lower threshold values (0-255)
     - upper_thresh - List of upper threshold values (0-255)
     - channel - Color-space channels of interest (either 'RGB', 'HSV', 'LAB', or 'gray')
@@ -27,12 +27,12 @@ pcv.params.debug = "print"
 
 # Read in the image
 
-img, path, filename = pcv.readimage("rgb_example_img.jpg")
+img, path, filename = pcv.readimage(filename="rgb_example_img.jpg")
 
 # Create masked image from a color image based RGB color-space and threshold values. 
 # for lower and upper_thresh list as: thresh = [red_thresh, green_thresh, blue_thresh]
 
-mask, masked_img = pcv.threshold.custom_range(rgb_img=img, lower_thresh=[10,10,10], upper_thresh=[100,255,100], channel='RGB')
+mask, masked_img = pcv.threshold.custom_range(img=img, lower_thresh=[10,10,10], upper_thresh=[100,255,100], channel='RGB')
 ```
 **Original image (RGB Color-space)**
 
@@ -56,13 +56,13 @@ pcv.params.debug = "print"
 
 # Read in the image
 
-img, path, filename = pcv.readimage("hsv_example_img.jpg")
+img, path, filename = pcv.readimage(filename="hsv_example_img.jpg")
 
 # Create masked image from a color image based HSV color-space and threshold values. 
 # for lower and upper_thresh list as: thresh = [hue_thresh, saturation_thresh, value_thresh]
 
 
-mask, masked_img = pcv.threshold.custom_range(rgb_img=img, lower_thresh=[30,65,20], upper_thresh=[70,255,220], channel='HSV')
+mask, masked_img = pcv.threshold.custom_range(img=img, lower_thresh=[30,65,20], upper_thresh=[70,255,220], channel='HSV')
 ```
 
 **Original image (HSV Color-space)**
@@ -87,13 +87,13 @@ pcv.params.debug = "print"
 
 # Read in the image
 
-img, path, filename = pcv.readimage("lab_example_img.jpg")
+img, path, filename = pcv.readimage(filename="lab_example_img.jpg")
 
 # Create masked image from a color image based LAB color-space and threshold values.
 # for lower and upper_thresh list as: thresh = [L_thresh, A_thresh, B_thresh]
 
  
-mask, masked_img = pcv.threshold.custom_range(rgb_img=img, lower_thresh=[0,0,158], upper_thresh=[255,255,255], channel='LAB')
+mask, masked_img = pcv.threshold.custom_range(img=img, lower_thresh=[0,0,158], upper_thresh=[255,255,255], channel='LAB')
 ```
 
 **Original image (LAB Color-space)**
@@ -119,12 +119,12 @@ pcv.params.debug = "print"
 
 # Read in the image
 
-gray_img, path, filename = pcv.readimage("gray_example_img.jpg")
+gray_img, path, filename = pcv.readimage(filename="gray_example_img.jpg")
 
 # Create masked image based grayscale color-space and threshold values. 
 # Note that a grayscale image is used. pcv.threshold.custom_range works with both RGB and gray input images. 
 
-mask, masked_img = pcv.threshold.custom_range(rgb_img=gray_img, lower_thresh=[39], upper_thresh=[100], channel='gray')
+mask, masked_img = pcv.threshold.custom_range(img=gray_img, lower_thresh=[39], upper_thresh=[100], channel='gray')
 ```
 
 **Original image (Grayscale Color-space)**

--- a/docs/nir_tutorial.md
+++ b/docs/nir_tutorial.md
@@ -119,11 +119,11 @@ We start by [subtracting](image_subtract.md) the background.
     # Threshold the image of interest using the two-sided custom range function (keep what is between 50-190)
     
     # Inputs:
-    #   rgb_img - RGB image data 
+    #   img - RGB or grayscale image data 
     #   lower_thresh - List of lower threshold values 
     #   upper_thresh - List of upper threshold values
     #   channel - Color-space channels of interest (either 'RGB', 'HSV', 'LAB', or 'gray')
-    bkg_sub_thres_img, masked_img = pcv.threshold.custom_range(rgb_img=bkg_sub_img, lower_thresh=[50], 
+    bkg_sub_thres_img, masked_img = pcv.threshold.custom_range(img=bkg_sub_img, lower_thresh=[50], 
                                                                upper_thresh=[190], channel='gray')
 
 ```
@@ -562,7 +562,7 @@ def main():
     bkg_sub_img = pcv.image_subtract(gray_img1=img, gray_img2=img_bkgrd)
         
     # Threshold the image of interest using the two-sided custom range function (keep what is between 50-190)
-    bkg_sub_thres_img = pcv.threshold.custom_range(rgb_img=bkg_sub_img, lower_thresh=[50],
+    bkg_sub_thres_img = pcv.threshold.custom_range(img=bkg_sub_img, lower_thresh=[50],
                                                    upper_thresh=[190], channel='gray')
     
     # Laplace filtering (identify edges based on 2nd derivative)

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -657,6 +657,7 @@ pages for more details on the input and output variable types.
 
 * pre v3.3: NA
 * post v3.3: mask, masked_img = **plantcv.threshold.custom_range**(*rgb_img, lower_thresh, upper_thresh, channel='RGB'*)**
+* post v3.8: mask, masked_img = **plantcv.threshold.custom_range**(*img, lower_thresh, upper_thresh, channel='RGB'*)**
 
 #### plantcv.threshold.gaussian
 

--- a/plantcv/plantcv/threshold/threshold_methods.py
+++ b/plantcv/plantcv/threshold/threshold_methods.py
@@ -316,7 +316,7 @@ def texture(gray_img, ksize, threshold, offset=3, texture_method='dissimilarity'
     return bin_img
 
 
-def custom_range(rgb_img, lower_thresh, upper_thresh, channel='gray'):
+def custom_range(img, lower_thresh, upper_thresh, channel='gray'):
     """Creates a thresholded image and mask from an RGB image and threshold values.
 
     Inputs:
@@ -329,7 +329,7 @@ def custom_range(rgb_img, lower_thresh, upper_thresh, channel='gray'):
     mask         = Mask, binary image
     masked_img   = Masked image, keeping the part of image of interest
 
-    :param rgb_img: numpy.ndarray
+    :param img: numpy.ndarray
     :param lower_thresh: list
     :param upper_thresh: list
     :param channel: str
@@ -345,7 +345,7 @@ def custom_range(rgb_img, lower_thresh, upper_thresh, channel='gray'):
                         "upper_thresh=255")
 
         # Convert the RGB image to HSV colorspace
-        hsv_img = cv2.cvtColor(rgb_img, cv2.COLOR_BGR2HSV)
+        hsv_img = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
 
         # Separate channels
         hue = hsv_img[:, :, 0]
@@ -358,7 +358,7 @@ def custom_range(rgb_img, lower_thresh, upper_thresh, channel='gray'):
         v_mask = cv2.inRange(value, lower_thresh[2], upper_thresh[2])
 
         # Apply the masks to the image
-        result = cv2.bitwise_and(rgb_img, rgb_img, mask=h_mask)
+        result = cv2.bitwise_and(img, img, mask=h_mask)
         result = cv2.bitwise_and(result, result, mask=s_mask)
         masked_img = cv2.bitwise_and(result, result, mask=v_mask)
 
@@ -375,9 +375,9 @@ def custom_range(rgb_img, lower_thresh, upper_thresh, channel='gray'):
                         "upper_thresh=255")
 
         # Separate channels (pcv.readimage reads RGB images in as BGR)
-        blue = rgb_img[:, :, 0]
-        green = rgb_img[:, :, 1]
-        red = rgb_img[:, :, 2]
+        blue = img[:, :, 0]
+        green = img[:, :, 1]
+        red = img[:, :, 2]
 
         # Make a mask for each channel
         b_mask = cv2.inRange(blue, lower_thresh[0], upper_thresh[0])
@@ -385,7 +385,7 @@ def custom_range(rgb_img, lower_thresh, upper_thresh, channel='gray'):
         r_mask = cv2.inRange(red, lower_thresh[2], upper_thresh[2])
 
         # Apply the masks to the image
-        result = cv2.bitwise_and(rgb_img, rgb_img, mask=b_mask)
+        result = cv2.bitwise_and(img, img, mask=b_mask)
         result = cv2.bitwise_and(result, result, mask=g_mask)
         masked_img = cv2.bitwise_and(result, result, mask=r_mask)
 
@@ -402,7 +402,7 @@ def custom_range(rgb_img, lower_thresh, upper_thresh, channel='gray'):
                         "upper_thresh=255")
 
         # Convert the RGB image to LAB colorspace
-        lab_img = cv2.cvtColor(rgb_img, cv2.COLOR_BGR2LAB)
+        lab_img = cv2.cvtColor(img, cv2.COLOR_BGR2LAB)
 
         # Separate channels (pcv.readimage reads RGB images in as BGR)
         lightness = lab_img[:, :, 0]
@@ -415,7 +415,7 @@ def custom_range(rgb_img, lower_thresh, upper_thresh, channel='gray'):
         by_mask = cv2.inRange(blue_yellow, lower_thresh[2], upper_thresh[2])
 
         # Apply the masks to the image
-        result = cv2.bitwise_and(rgb_img, rgb_img, mask=l_mask)
+        result = cv2.bitwise_and(img, img, mask=l_mask)
         result = cv2.bitwise_and(result, result, mask=gm_mask)
         masked_img = cv2.bitwise_and(result, result, mask=by_mask)
 
@@ -429,17 +429,17 @@ def custom_range(rgb_img, lower_thresh, upper_thresh, channel='gray'):
         if not (len(lower_thresh) == 1 and len(upper_thresh) == 1):
             fatal_error("If useing a grayscale colorspace, 1 threshold is needed for both the " +
                         "lower_thresh and upper_thresh.")
-        if len(np.shape(rgb_img))==3:
+        if len(np.shape(img))==3:
             # Convert RGB image to grayscale colorspace
-            gray_img = cv2.cvtColor(rgb_img, cv2.COLOR_BGR2GRAY)
+            gray_img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
         else:
-            gray_img = rgb_img
+            gray_img = img
 
         # Make a mask
         mask = cv2.inRange(gray_img, lower_thresh[0], upper_thresh[0])
 
         # Apply the masks to the image
-        masked_img = cv2.bitwise_and(rgb_img, rgb_img, mask=mask)
+        masked_img = cv2.bitwise_and(img, img, mask=mask)
 
     else:
         fatal_error(str(channel) + " is not a valid colorspace. Channel must be either 'RGB', 'HSV', or 'gray'.")

--- a/plantcv/plantcv/threshold/threshold_methods.py
+++ b/plantcv/plantcv/threshold/threshold_methods.py
@@ -320,7 +320,7 @@ def custom_range(img, lower_thresh, upper_thresh, channel='gray'):
     """Creates a thresholded image and mask from an RGB image and threshold values.
 
     Inputs:
-    rgb_img      = RGB image data
+    img      = RGB or grayscale image data
     lower_thresh = List of lower threshold values (0-255)
     upper_thresh = List of upper threshold values (0-255)
     channel      = Color-space channels of interest (RGB, HSV, LAB, or gray)


### PR DESCRIPTION
**Describe your changes**
The function `pcv.threshold.custom_range` had an input parameter named `rgb_img` which is inaccurate since the function also works on grayscale images. These updates correct the parameter name to the more general `img` in 

**Type of update**
Is this a:
* Bug fix
* Update to documentation

**Associated issues**
* closes #546

