### PR TITLE
changed order of debug images to match output

### DIFF
--- a/plantcv/plantcv/rectangle_mask.py
+++ b/plantcv/plantcv/rectangle_mask.py
@@ -69,6 +69,6 @@ def rectangle_mask(img, p1, p2, color="black"):
     if params.debug == 'print':
         print_image(bnk, os.path.join(params.debug_outdir, str(params.device) + '_roi.png'))
     elif params.debug == 'plot':
-        plot_image(bnk, cmap="gray")
         plot_image(img1, cmap="gray")
+        plot_image(bnk, cmap="gray")
     return img1, bnk, contour, hierarchy

--- a/plantcv/plantcv/threshold/threshold_methods.py
+++ b/plantcv/plantcv/threshold/threshold_methods.py
@@ -454,8 +454,8 @@ def custom_range(img, lower_thresh, upper_thresh, channel='gray'):
         print_image(mask, os.path.join(params.debug_outdir,
                                        str(params.device) + channel + 'custom_thresh_mask.png'))
     elif params.debug == 'plot':
-        plot_image(masked_img)
         plot_image(mask)
+        plot_image(masked_img)
 
     return mask, masked_img
 


### PR DESCRIPTION
**Describe your changes**
This one has been bugging me a while. when thresholding and making rectangle mask the debug images are displayed in the opposite order that they are output.  I can never remember the order and that should be an intuitive reminder.

**Type of update**
Is this a:
* Bug fix

**Associated issues**
no issues

**Additional context**
Does not break output, only the order that debug='plot' images are displayed.