### PR TITLE
Add NIR summary stats 

### DIFF
--- a/docs/analyze_NIR_intensity.md
+++ b/docs/analyze_NIR_intensity.md
@@ -16,7 +16,7 @@ the values out to the [Outputs class](outputs.md). Can also return/plot/print ou
     - Near Infrared pixel frequencies within a masked area of an image. 
 - **Example use:**
     - [Use In NIR Tutorial](nir_tutorial.md)
-- **Output data stored:** Data ('nir_frequencies') automatically gets stored to the [`Outputs` class](outputs.md) when this function is ran. 
+- **Output data stored:** Data ('nir_frequencies', 'nir_mean', 'nir_median', 'nir_stdev') automatically gets stored to the [`Outputs` class](outputs.md) when this function is ran. 
     These data can always get accessed during a workflow (example below). For more detail about data output see [Summary of Output Observations](output_measurements.md#summary-of-output-observations)
 
 **Original grayscale image**

--- a/plantcv/plantcv/analyze_nir_intensity.py
+++ b/plantcv/plantcv/analyze_nir_intensity.py
@@ -98,7 +98,7 @@ def analyze_nir_intensity(gray_img, mask, bins=256, histplot=False):
                             method='plantcv.plantcv.analyze_nir_intensity', scale='none', datatype=float,
                             value=masked_nir_mean, label='none')
     outputs.add_observation(variable='nir_median', trait='near-infrared median',
-                            method='plantcv.plantcv.analyze_nir_intensity', scale='frequency', datatype=float,
+                            method='plantcv.plantcv.analyze_nir_intensity', scale='none', datatype=float,
                             value=masked_nir_median, label='none')
     outputs.add_observation(variable='nir_stdev', trait='near-infrared standard deviation',
                             method='plantcv.plantcv.analyze_nir_intensity', scale='frequency', datatype=float,

--- a/plantcv/plantcv/analyze_nir_intensity.py
+++ b/plantcv/plantcv/analyze_nir_intensity.py
@@ -42,6 +42,11 @@ def analyze_nir_intensity(gray_img, mask, bins=256, histplot=False):
     else:
         maxval = 256
 
+    masked_array = gray_img[np.where(mask > 0)]
+    masked_nir_mean = np.average(masked_array)
+    masked_nir_median = np.median(masked_array)
+    masked_nir_std = np.std(masked_array)
+
     # Make a pseudo-RGB image
     rgbimg = cv2.cvtColor(gray_img, cv2.COLOR_GRAY2BGR)
 
@@ -89,6 +94,15 @@ def analyze_nir_intensity(gray_img, mask, bins=256, histplot=False):
     outputs.add_observation(variable='nir_frequencies', trait='near-infrared frequencies',
                             method='plantcv.plantcv.analyze_nir_intensity', scale='frequency', datatype=list,
                             value=hist_nir, label=bin_labels)
+    outputs.add_observation(variable='nir_mean', trait='near-infrared mean',
+                            method='plantcv.plantcv.analyze_nir_intensity', scale='none', datatype=float,
+                            value=masked_nir_mean, label='none')
+    outputs.add_observation(variable='nir_median', trait='near-infrared median',
+                            method='plantcv.plantcv.analyze_nir_intensity', scale='frequency', datatype=float,
+                            value=masked_nir_median, label='none')
+    outputs.add_observation(variable='nir_stdev', trait='near-infrared standard deviation',
+                            method='plantcv.plantcv.analyze_nir_intensity', scale='frequency', datatype=float,
+                            value=masked_nir_std, label='none')
 
     # Store images
     outputs.images.append(analysis_image)

--- a/plantcv/plantcv/analyze_nir_intensity.py
+++ b/plantcv/plantcv/analyze_nir_intensity.py
@@ -101,7 +101,7 @@ def analyze_nir_intensity(gray_img, mask, bins=256, histplot=False):
                             method='plantcv.plantcv.analyze_nir_intensity', scale='none', datatype=float,
                             value=masked_nir_median, label='none')
     outputs.add_observation(variable='nir_stdev', trait='near-infrared standard deviation',
-                            method='plantcv.plantcv.analyze_nir_intensity', scale='frequency', datatype=float,
+                            method='plantcv.plantcv.analyze_nir_intensity', scale='none', datatype=float,
                             value=masked_nir_std, label='none')
 
     # Store images


### PR DESCRIPTION
**Describe your changes**
Add median, mean, and stdev to observations being collected into the Outputs class during the `pcv.analyze_nir` function. Tested to make sure the pixels are being masked properly (0 pixels won't skew summary stats, only data within masked region gets used) and updated docs. 

**Type of update**
Is this a:
* feature enhancement


