### PR TITLE
python2 incompatibility: non-ascii character

### DIFF
--- a/plantcv/plantcv/hyperspectral/extract_index.py
+++ b/plantcv/plantcv/hyperspectral/extract_index.py
@@ -395,7 +395,7 @@ def extract_index(array, index="NDVI", distance=20):
             fatal_error("Available wavelengths are not suitable for calculating VI_green. Try increasing distance.")
 
     elif index.upper() == 'WBI':
-        # Water band index (Peñuelas et al., 1997)
+        # Water band index (Penuelas et al., 1997)
         if (max_wavelength + distance) >= 800 and (min_wavelength - distance) <= 675:
             red_index   = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 670)
             green_index = _find_closest(np.array([float(i) for i in wavelength_dict.keys()]), 560)


### PR DESCRIPTION
Removed non-ascii character in line 398

Resolved error when importing library
>>> from plantcv import plantcv as pcv
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jberry/Programs/plantcv/plantcv/plantcv/__init__.py", line 144, in <module>
    from plantcv.plantcv import hyperspectral
  File "/home/jberry/Programs/plantcv/plantcv/plantcv/hyperspectral/__init__.py", line 5, in <module>
    from plantcv.plantcv.hyperspectral.extract_index import extract_index
  File "/home/jberry/Programs/plantcv/plantcv/plantcv/hyperspectral/extract_index.py", line 398
SyntaxError: Non-ASCII character '\xc3' in file /home/jberry/Programs/plantcv/plantcv/plantcv/hyperspectral/extract_index.py on line 398, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details