### PR TITLE
Add chip size to find color card

### DIFF
--- a/docs/transform_correct_color.md
+++ b/docs/transform_correct_color.md
@@ -58,16 +58,17 @@ target_matrix, source_matrix, transformation_matrix, corrected_img = pcv.transfo
 
 Automatically detects a color card's location and size. Useful in workflows where color card positioning isn't constant in all images.
 
-**plantcv.transform.find_color_card**(*rgb_img, threshold='adaptgauss', threshvalue=125, blurry=False, background='dark'*)
+**plantcv.transform.find_color_card**(*rgb_img, threshold='adaptgauss', threshvalue=125, blurry=False, background='dark', record_chip_size='median*)
 
 **returns** df, start_coord, spacing
 
 - **Parameters**
-    - rgb_img       = Input RGB image data containing a color card.
-    - threshold     = Optional threshold method, either 'normal', 'otsu', or 'adaptgauss' (default theshold='adaptgauss')
-    - threshvalue   = Optional thresholding value (default threshvalue=125)
-    - blurry        = Optional boolean, if True then image sharpening is applied (default blurry=False)
-    - background    = Optional type of image background, either 'dark' or 'light' (default background='dark')
+    - rgb_img          = Input RGB image data containing a color card.
+    - threshold        = Optional threshold method, either 'normal', 'otsu', or 'adaptgauss' (default theshold='adaptgauss')
+    - threshvalue      = Optional thresholding value (default threshvalue=125)
+    - blurry           = Optional boolean, if True then image sharpening is applied (default blurry=False)
+    - background       = Optional type of image background, either 'dark' or 'light' (default background='dark')
+    - record_chip_size = Optional str for choosing chip size measurement to be recorded, either "median" (default), "mean", or None
 - **Returns**
     - df            = Dataframe of all color card chips found.
     - start_coord   = Two-element tuple of the first chip mask starting x and y coordinate. Useful in [create a color card mask](#create-a-labeled-color-card-mask) function.

--- a/docs/transform_correct_color.md
+++ b/docs/transform_correct_color.md
@@ -58,13 +58,13 @@ target_matrix, source_matrix, transformation_matrix, corrected_img = pcv.transfo
 
 Automatically detects a color card's location and size. Useful in workflows where color card positioning isn't constant in all images.
 
-**plantcv.transform.find_color_card**(*rgb_img, threshold='adaptgauss', threshvalue=125, blurry=False, background='dark', record_chip_size='median*)
+**plantcv.transform.find_color_card**(*rgb_img, threshold_type='adaptgauss', threshvalue=125, blurry=False, background='dark', record_chip_size='median*)
 
 **returns** df, start_coord, spacing
 
 - **Parameters**
     - rgb_img          = Input RGB image data containing a color card.
-    - threshold        = Optional threshold method, either 'normal', 'otsu', or 'adaptgauss' (default theshold='adaptgauss')
+    - threshold_type   = Optional threshold method, either 'normal', 'otsu', or 'adaptgauss' (default theshold_type='adaptgauss')
     - threshvalue      = Optional thresholding value (default threshvalue=125)
     - blurry           = Optional boolean, if True then image sharpening is applied (default blurry=False)
     - background       = Optional type of image background, either 'dark' or 'light' (default background='dark')

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -827,6 +827,8 @@ pages for more details on the input and output variable types.
 * pre v3.0: NA
 * post v3.0: df, start_coord, spacing = **plantcv.transform.find_color_card**(*rgb_img, threshold='adaptgauss', threshvalue=125, blurry=False, background='dark'*)
 * post v3.3: df, start_coord, spacing = **plantcv.transform.find_color_card**(*rgb_img, threshold_type='adaptgauss', threshvalue=125, blurry=False, background='dark'*)
+* post v3.9: df, start_coord, spacing = **plantcv.transform.find_color_card**(*rgb_img, threshold_type='adaptgauss', threshvalue=125, blurry=False, background='dark', record_chip_size='median'*)
+ 
 
 #### plantcv.transform.get_color_matrix
 

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -3,11 +3,11 @@
 import os
 import cv2
 import numpy as np
-from plantcv.plantcv import print_image
-from plantcv.plantcv import plot_image
-from plantcv.plantcv import fatal_error
-from plantcv.plantcv.roi import circle
 from plantcv.plantcv import params
+from plantcv.plantcv import plot_image
+from plantcv.plantcv.roi import circle
+from plantcv.plantcv import print_image
+from plantcv.plantcv import fatal_error
 
 
 def get_color_matrix(rgb_img, mask):
@@ -404,10 +404,10 @@ def quick_color_check(target_matrix, source_matrix, num_chips):
     over saturated color chips or other issues.
 
     Inputs:
-    source_matrix      = a 22x4 matrix containing the average red value, average green value, and
-                             average blue value for each color chip of the source image
-    target_matrix      = a 22x4 matrix containing the average red value, average green value, and
-                             average blue value for each color chip of the target image
+    source_matrix      = an nrowsXncols matrix containing the avg red, green, and blue values for each color chip 
+                            of the source image
+    target_matrix      = an nrowsXncols matrix containing the avg red, green, and blue values for each color chip 
+                            of the target image
     num_chips          = number of color card chips included in the matrices (integer)
 
     :param source_matrix: numpy.ndarray
@@ -509,11 +509,11 @@ def find_color_card(rgb_img, threshold_type='adaptgauss', threshvalue=125, blurr
 
     # Get image attributes
     height, width, channels = rgb_img.shape
-    totalpx = float(height * width)
+    total_pix = float(height * width)
 
     # Minimum and maximum square size based upon 12 MP image
-    minarea = 1000. / 12000000. * totalpx
-    maxarea = 8000000. / 12000000. * totalpx
+    minarea = 1000. / 12000000. * total_pix
+    maxarea = 8000000. / 12000000. * total_pix
 
     # Create gray image for further processing
     gray_img = cv2.cvtColor(rgb_img, cv2.COLOR_BGR2GRAY)

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -4,6 +4,7 @@ import os
 import cv2
 import numpy as np
 from plantcv.plantcv import params
+from plantcv.plantcv import outputs
 from plantcv.plantcv import plot_image
 from plantcv.plantcv.roi import circle
 from plantcv.plantcv import print_image
@@ -742,8 +743,8 @@ def find_color_card(rgb_img, threshold_type='adaptgauss', threshvalue=125, blurr
         elif record_chip_size.upper() == "MEAN":
             chip_size = df.loc[:,"area"].mean()
         else:
-            print(srt(record_chip_size) + " Is not a valid entry for record_chip_size." +
-                  " Must be either 'mean', 'median', or None. ")
+            print(str(record_chip_size) + " Is not a valid entry for record_chip_size." +
+                  " Must be either 'mean', 'median', or None.")
             chip_size = None
         # Store into global measurements
         outputs.add_observation(variable='color_chip_size', trait='size of color card chips identified',

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -474,19 +474,22 @@ def quick_color_check(target_matrix, source_matrix, num_chips):
             print(p1)
 
 
-def find_color_card(rgb_img, threshold_type='adaptgauss', threshvalue=125, blurry=False, background='dark'):
+def find_color_card(rgb_img, threshold_type='adaptgauss', threshvalue=125, blurry=False, background='dark',
+                    record_chip_size="median"):
     """Automatically detects a color card and output info to use in create_color_card_mask function
 
     Algorithm written by Brandon Hurr. Updated and implemented into PlantCV by Haley Schuhl.
 
-    Inputs:
-    rgb_img        = Input RGB image data containing a color card.
-    threshold      = Threshold method, either 'normal', 'otsu', or 'adaptgauss', optional (default 'adaptgauss')
-    threshvalue    = Thresholding value, optional (default 125)
-    blurry         = Bool (default False) if True then image sharpening applied
-    background     = Type of image background either 'dark' or 'light' (default 'dark'); if 'light' then histogram
+        Inputs:
+    rgb_img          = Input RGB image data containing a color card.
+    threshold        = Threshold method, either 'normal', 'otsu', or 'adaptgauss', optional (default 'adaptgauss')
+    threshvalue      = Thresholding value, optional (default 125)
+    blurry           = Bool (default False) if True then image sharpening applied
+    background       = Type of image background either 'dark' or 'light' (default 'dark'); if 'light' then histogram
                         expansion applied to better detect edges, but histogram expansion will be hindered if there
                         is a dark background
+    record_chip_size = Optional str for choosing chip size measurement to be recorded, either "median",
+                        "mean", or None
 
     Returns:
     df             = Dataframe containing information about the filtered contours
@@ -498,6 +501,7 @@ def find_color_card(rgb_img, threshold_type='adaptgauss', threshvalue=125, blurr
     :param threshvalue: int
     :param blurry: bool
     :param background: str
+    :param record_chip_size: str
     :return df: pandas.core.frame.DataFrame
     :return start_coord: tuple
     :return spacing: tuple
@@ -730,5 +734,21 @@ def find_color_card(rgb_img, threshold_type='adaptgauss', threshvalue=125, blurr
         # Smaller spacing measurement might have a chip missing
         spacing = int(max(spacing_short, spacing_long))
         spacing = (spacing, spacing)
+
+
+    if record_chip_size is not None:
+        if record_chip_size.upper() == "MEDIAN":
+            chip_size = df.loc[:,"area"].median()
+        elif record_chip_size.upper() == "MEAN":
+            chip_size = df.loc[:,"area"].mean()
+        else:
+            print(srt(record_chip_size) + " Is not a valid entry for record_chip_size." +
+                  " Must be either 'mean', 'median', or None. ")
+            chip_size = None
+        # Store into global measurements
+        outputs.add_observation(variable='color_chip_size', trait='size of color card chips identified',
+                                method='plantcv.plantcv.transform.find_color_card', scale='none',
+                                datatype=float, value=chip_size, label=str(record_chip_size))
+
 
     return df, start_coord, spacing

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -1,13 +1,11 @@
 # Color Corrections Functions
 
 import os
-import errno
 import cv2
 import numpy as np
 from plantcv.plantcv import print_image
 from plantcv.plantcv import plot_image
 from plantcv.plantcv import fatal_error
-from plantcv.plantcv import params
 from plantcv.plantcv.roi import circle
 from plantcv.plantcv import params
 

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -483,7 +483,7 @@ def find_color_card(rgb_img, threshold_type='adaptgauss', threshvalue=125, blurr
 
         Inputs:
     rgb_img          = Input RGB image data containing a color card.
-    threshold        = Threshold method, either 'normal', 'otsu', or 'adaptgauss', optional (default 'adaptgauss')
+    threshold_type   = Threshold method, either 'normal', 'otsu', or 'adaptgauss', optional (default 'adaptgauss')
     threshvalue      = Thresholding value, optional (default 125)
     blurry           = Bool (default False) if True then image sharpening applied
     background       = Type of image background either 'dark' or 'light' (default 'dark'); if 'light' then histogram
@@ -561,7 +561,7 @@ def find_color_card(rgb_img, threshold_type='adaptgauss', threshvalue=125, blurr
         threshold = cv2.adaptiveThreshold(gaussian, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
                                           cv2.THRESH_BINARY_INV, 51, 2)
     else:
-        fatal_error('Input threshold=' + str(threshold_type) + ' but should be "otsu", "normal", or "adaptgauss"!')
+        fatal_error('Input threshold_type=' + str(threshold_type) + ' but should be "otsu", "normal", or "adaptgauss"!')
 
     # Apply automatic Canny edge detection using the computed median
     canny_edges = skimage.feature.canny(threshold)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4924,6 +4924,37 @@ def test_plantcv_transform_find_color_card_optional_parameters():
                                                                    220], dtype=np.uint8)))
 
 
+def test_plantcv_transform_find_color_card_optional_size_parameters():
+    # Load rgb image
+    rgb_img = cv2.imread(os.path.join(TEST_DATA, TEST_TARGET_IMG_COLOR_CARD))
+    # Test cache directory
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_transform_find_color_card")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    df1, start1, space1 = pcv.transform.find_color_card(rgb_img=rgb_img, record_chip_size="mean")
+    assert pcv.outputs.observations["color_chip_size"]["value"] == 15351.565217391304
+
+
+def test_plantcv_transform_find_color_card_optional_size_parameters_none():
+    pcv.outputs.observations.clear()
+    # Load rgb image
+    rgb_img = cv2.imread(os.path.join(TEST_DATA, TEST_TARGET_IMG_COLOR_CARD))
+    # Test cache directory
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_transform_find_color_card")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    df1, start1, space1 = pcv.transform.find_color_card(rgb_img=rgb_img, record_chip_size=None)
+    with pytest.raises(KeyError):
+        pcv.outputs.observations["color_chip_size"]
+
+
+def test_plantcv_transform_find_color_card_bad_record_chip_size():
+    # Load rgb image
+    rgb_img = cv2.imread(os.path.join(TEST_DATA, TEST_TARGET_IMG))
+    pcv.params.debug = None
+    _, _, _ = pcv.transform.find_color_card(rgb_img=rgb_img, record_chip_size='averageeeed')
+    assert pcv.outputs.observations["color_chip_size"]["value"] == None
+
 def test_plantcv_transform_find_color_card_bad_thresh_input():
     # Load rgb image
     rgb_img = cv2.imread(os.path.join(TEST_DATA, TEST_TARGET_IMG))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4932,7 +4932,7 @@ def test_plantcv_transform_find_color_card_optional_size_parameters():
     os.mkdir(cache_dir)
     pcv.params.debug_outdir = cache_dir
     df1, start1, space1 = pcv.transform.find_color_card(rgb_img=rgb_img, record_chip_size="mean")
-    assert pcv.outputs.observations["color_chip_size"]["value"] == 15351.565217391304
+    assert pcv.outputs.observations["color_chip_size"]["value"] > 15000
 
 
 def test_plantcv_transform_find_color_card_optional_size_parameters_none():


### PR DESCRIPTION
**Describe your changes**
Extend the `pcv.transform.find_color_card` function to optionally measure the average chip size and record it to the Outputs class as an observation. 

**Type of update**
* New feature or feature enhancement

**Additional context**
Users can avoid measuring the average chip size, and choose to use either mean or median as the measure. This capability could remove the need for size markers in images that already have color cards being used for preprocessing. 

[x] update docs
[x] add/update unit testing
[x] add observation to outputs