### PR TITLE
Update Dockerfile recipe to fix missing libGL dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ MAINTAINER PlantCV <ddpsc.plantcv@gmail.com>
 
 USER root
 
+RUN apt-get update && apt-get install -y libgl1-mesa-glx && rm -rf /var/lib/apt/lists/*
+
 # Install PlantCV
 RUN conda install --quiet --yes -c conda-forge \
     "matplotlib>=1.5" \
@@ -12,7 +14,7 @@ RUN conda install --quiet --yes -c conda-forge \
     "scipy<1.3" \
     "scikit-image<0.15" \
     plotnine \
-    "py-opencv<4,>=3.4" && \
+    "opencv<4,>=3.4" && \
     conda clean --all -f -y
 
 # Copy source files


### PR DESCRIPTION
**Describe your changes**
Attempting to run the PlantCV Docker image resulted in an error: `ImportError: libGL.so.1: cannot open shared object file: No such file or directory` as noted in #579. To fix this the apt package `libgl1-mesa-glx` package needs to be installed in the container. This pull request installs it and changes the name of the `opencv` conda package used to be consistent with the `bioconda` PlantCV package.

**Type of update**
Is this a: Bug fix

**Associated issues**
Closes issue #579 

**Additional context**
Merging this PR with master will immediately trigger a new Docker build to fix the issue without a new official release.