### PR TITLE
Sort width and height to normalize ratio

### DIFF
--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -621,7 +621,11 @@ def find_color_card(rgb_img, threshold_type='adaptgauss', threshvalue=125, blurr
             center, wh, angle = cv2.minAreaRect(c)  # Rotated rectangle
             mwidth.append(wh[0])
             mheight.append(wh[1])
-            mwhratio.append(wh[0] / wh[1])
+            # In different versions of OpenCV, width and height can be listed in a different order
+            # To normalize the ratio we sort them and take the ratio of the longest / shortest
+            wh_sorted = list(wh)
+            wh_sorted.sort()
+            mwhratio.append(wh_sorted[1] / wh_sorted[0])
             msquare.append(len(approx))
             # If the approx contour has 4 points then we can assume we have 4-sided objects
             if len(approx) == 4 or len(approx) == 5:


### PR DESCRIPTION
**Describe your changes**
Differences in output from `cv2.minAreaRect` in OpenCV < 3.4.10 and 3.4.10 order width and height differently. We use the ratio of width / height to find contours that are square-ish in `pcv.transform.find_color_card`. To normalize the ratio, this pull request updates `find_color_card` to sort the width and height values and take the ratio of the longest / shortest. Since we do not use the orientation of the bounding rectangle in this function, this meets our purpose of determining which boxes are approximately square.

**Type of update**
Is this a: Bug fix - it will allow us to pass tests with OpenCV >= 3.4, including 3.4.10.

