### PR TITLE
Test GitHub Actions workflows on Windows and macOS

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,8 +16,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
-        os: [ubuntu-latest]
+        # python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8]
+        # os: [ubuntu-latest]
+        os: [macos-latest]
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,55 +3,55 @@
 
 name: builds
 
-on:
-  push:
-    # Run when master is updated
-    branches: [ master ]
-  pull_request:
-    # Run on pull requests against master
-    branches: [ master ]
+#on:
+#  push:
+#    # Run when master is updated
+#    branches: [ master ]
+#  pull_request:
+#    # Run on pull requests against master
+#    branches: [ master ]
 
-jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # python-version: [3.6, 3.7, 3.8]
-        python-version: [3.8]
-        # os: [ubuntu-latest]
-        os: [macos-latest]
-    env:
-      OS: ${{ matrix.os }}
-      PYTHON: ${{ matrix.python-version }}
-
-    steps:
-    - uses: actions/checkout@master
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@master
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest pytest-cov
-        pip install -r requirements.txt
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test and generate coverage report
-      # Run coverage analysis on pytest tests
-      run: |
-        python setup.py install
-        py.test --cov-report=xml --cov=plantcv tests/
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@master
-      with:
-        #
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-        flags: unittests
-        env_vars: OS,PYTHON
-        fail_ci_if_error: true
+#jobs:
+#  build:
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      matrix:
+#        # python-version: [3.6, 3.7, 3.8]
+#        python-version: [3.8]
+#        # os: [ubuntu-latest]
+#        os: [macos-latest]
+#    env:
+#      OS: ${{ matrix.os }}
+#      PYTHON: ${{ matrix.python-version }}
+#
+#    steps:
+#    - uses: actions/checkout@master
+#    - name: Set up Python ${{ matrix.python-version }}
+#      uses: actions/setup-python@master
+#      with:
+#        python-version: ${{ matrix.python-version }}
+#    - name: Install dependencies
+#      run: |
+#        python -m pip install --upgrade pip
+#        pip install flake8 pytest pytest-cov
+#        pip install -r requirements.txt
+#    - name: Lint with flake8
+#      run: |
+#        # stop the build if there are Python syntax errors or undefined names
+#        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+#        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+#        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+#    - name: Test and generate coverage report
+#      # Run coverage analysis on pytest tests
+#      run: |
+#        python setup.py install
+#        py.test --cov-report=xml --cov=plantcv tests/
+#    - name: Upload coverage to Codecov
+#      uses: codecov/codecov-action@master
+#      with:
+#        #
+#        token: ${{ secrets.CODECOV_TOKEN }}
+#        file: ./coverage.xml
+#        flags: unittests
+#        env_vars: OS,PYTHON
+#        fail_ci_if_error: true

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -4,8 +4,12 @@
 name: deploy
 
 on:
-  release:
-    types: [created]
+  push:
+    # Run when master is updated
+    branches: [ master ]
+  pull_request:
+    # Run on pull requests against master
+    branches: [ master ]
 
 jobs:
   build:
@@ -25,28 +29,27 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest
         pip install -r requirements.txt
-    - name: Cross-platform tests
-      run: |
-        python setup.py test
+    - name: Test on ${{ matrix.os }}
+      run: py.test tests/
 
-  deploy:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@master
-    - name: Set up Python
-      uses: actions/setup-python@master
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+#  deploy:
+#
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#    - uses: actions/checkout@master
+#    - name: Set up Python
+#      uses: actions/setup-python@master
+#      with:
+#        python-version: '3.x'
+#    - name: Install dependencies
+#      run: |
+#        python -m pip install --upgrade pip
+#        pip install setuptools wheel twine
+#    - name: Build and publish
+#      env:
+#        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+#        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+#      run: |
+#        python setup.py sdist bdist_wheel
+#        twine upload dist/*


### PR DESCRIPTION
**Describe your changes**
Pull request tests are only done on Linux with multiple versions of Python. For the deployment workflow we only test with the latest Python but on Linux, macOS, and Windows. We got to test this but tests on macOS and Windows stuck on `plantcv.parallel.multiprocess`. This PR is for testing the main GitHub Actions workflow with macOS and Windows to figure out how to work around the issue.

**Type of update**
Is this a: Work in progress

- [ ] Demonstrate a modified CI workflow, without other changes, does not work on macOS/Windows as expected.