### PR TITLE
Update CI/CD workflows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,10 +6,10 @@ name: builds
 on:
   push:
     # Run when master is updated
-    branches: [ master ]
+    branches: [ master, 4.x ]
   pull_request:
     # Run on pull requests against master
-    branches: [ master ]
+    branches: [ master, 4.x ]
 
 jobs:
   build:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@master
       with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@main
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@master
+      uses: actions/setup-python@main
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@main
     - name: Set up Python ${{ matrix.os }}
-      uses: actions/setup-python@master
+      uses: actions/setup-python@main
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -26,17 +26,16 @@ jobs:
         pip install pytest
         pip install -r requirements.txt
     - name: Cross-platform tests
-      run: |
-        python setup.py test
+      run: py.test tests/
 
   deploy:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - name: Set up Python
-      uses: actions/setup-python@master
+      uses: actions/setup-python@main
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: [3.8]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - name: Set up Python ${{ matrix.os }}
       uses: actions/setup-python@master
       with:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -29,7 +29,7 @@ jobs:
       run: py.test tests/
 
   deploy:
-
+    needs: build
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
**Describe your changes**
This PR updates our continuous integration and delivery workflows in a few ways:

1. Updates GitHub Actions checkouts from their new default (main) branches.
2. Runs tests in the packaging workflow using `pytest` directly to bypass an issue on macOS and Windows.
3. Makes the `deploy` packaging Actions job dependent on the proceeding `build` job. I.e. we should only upload packages to PyPI if tests pass. 

**Type of update**
Is this a: Bug fix
