### PR TITLE
Update Dockerfile to fix outdated dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,20 +5,14 @@ USER root
 
 RUN apt-get update && apt-get install -y libgl1-mesa-glx && rm -rf /var/lib/apt/lists/*
 
-# Install PlantCV
-RUN conda install --quiet --yes -c conda-forge \
-    "matplotlib>=1.5" \
-    "numpy>=1.11" \
-    pandas \
-    python-dateutil \
-    "scipy<1.3" \
-    "scikit-image<0.15" \
-    plotnine \
-    "opencv<4,>=3.4" && \
-    conda clean --all -f -y
-
 # Copy source files
 COPY . /tmp
+
+# Change working directory and modify requirements.txt
+RUN cd /tmp && sed -i'' -e 's/opencv.*//g' requirements.txt
+
+# Install PlantCV
+RUN cd /tmp && conda install --quiet --yes -c conda-forge --file requirements.txt 'opencv<4' && conda clean --all -f -y
 
 # Install PlantCV Python prerequisites and PlantCV
 RUN cd /tmp && python setup.py install


### PR DESCRIPTION
**Describe your changes**
The `Dockerfile` had hardcoded dependencies for PlantCV. When we change dependency versions or add/remove dependencies, we have to update `requirements.txt`, `environment.yml` (for user convenience), and `Dockerfile`. This pull request modifies the `Dockerfile` to install dependencies (other than OpenCV) from the `requirements.txt` file instead. The Docker container should now be built with the correct dependencies each time without manually updating the `Dockerfile`.

**Type of update**
Is this a: Bug fix

**Additional context**
The Docker container has not been updating recently due to failed builds. In addition to the fix above, I enabled notifications from Docker Hub so we will be made aware of any container build failures.
