### PR TITLE
Fix PlantCV release deployment workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -26,7 +26,9 @@ jobs:
         pip install pytest
         pip install -r requirements.txt
     - name: Cross-platform tests
-      run: py.test tests/
+      run: |
+        python setup.py install
+        py.test tests/
 
   deploy:
     needs: build


### PR DESCRIPTION
**Describe your changes**
Fixes the GitHub Actions release deployment workflow. We need to install PlantCV before running tests.

**Type of update**
Is this a: Bug fix
