### PR TITLE
Update deployment workflow to checkout all commits and tags

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -36,6 +36,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@main
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@main
       with:


### PR DESCRIPTION
**Describe your changes**
By default, tags are not cloned by checkout. Versioneer needs tags to create a valid version tag. Without a valid version deployment to PyPI fails.

**Type of update**
Is this a: Bug fix
