### PR TITLE
fix plotting bug when debug=None

### DIFF
--- a/plantcv/plantcv/__init__.py
+++ b/plantcv/plantcv/__init__.py
@@ -1,8 +1,5 @@
 import os
 import matplotlib
-# If there is no display or a matplotlib backend already defined, use the non-GUI backend
-if "DISPLAY" not in os.environ and "MPLBACKEND" not in os.environ:
-    matplotlib.use("Agg")
 
 observations = {}
 

--- a/plantcv/plantcv/plot_image.py
+++ b/plantcv/plantcv/plot_image.py
@@ -23,17 +23,17 @@ def plot_image(img, cmap=None):
         matplotlib.rcParams['figure.dpi'] = params.dpi
         # If the image is color then OpenCV stores it as BGR, we plot it as RGB
         if len(dimensions) == 3:
-            fig = plt.figure()
+            plt.figure()
             plt.imshow(cv2.cvtColor(img, cv2.COLOR_BGR2RGB))
             plt.show()
 
         elif cmap is None and len(dimensions) == 2:
-            fig = plt.figure()
+            plt.figure()
             plt.imshow(img, cmap="gray")
             plt.show()
 
         elif cmap is not None and len(dimensions) == 2:
-            fig = plt.figure()
+            plt.figure()
             plt.imshow(img, cmap=cmap)
             plt.show()
 

--- a/plantcv/plantcv/plot_image.py
+++ b/plantcv/plantcv/plot_image.py
@@ -23,14 +23,17 @@ def plot_image(img, cmap=None):
         matplotlib.rcParams['figure.dpi'] = params.dpi
         # If the image is color then OpenCV stores it as BGR, we plot it as RGB
         if len(dimensions) == 3:
+            fig = plt.figure()
             plt.imshow(cv2.cvtColor(img, cv2.COLOR_BGR2RGB))
             plt.show()
 
         elif cmap is None and len(dimensions) == 2:
+            fig = plt.figure()
             plt.imshow(img, cmap="gray")
             plt.show()
 
         elif cmap is not None and len(dimensions) == 2:
+            fig = plt.figure()
             plt.imshow(img, cmap=cmap)
             plt.show()
 

--- a/plantcv/plantcv/threshold/threshold_methods.py
+++ b/plantcv/plantcv/threshold/threshold_methods.py
@@ -245,10 +245,11 @@ def triangle(gray_img, max_value, object_type="light", xstep=1):
     # Additional figures created by this method, if debug is on
     if params.debug is not None:
         if params.debug == 'print':
-            plt.plot(hist)
-            plt.title('Threshold value = {t}'.format(t=autothreshval))
-            plt.axis([0, 256, 0, max(hist)])
-            plt.grid(True)
+            fig, ax = plt.subplots()
+            ax.plot(hist)
+            ax.set(title='Threshold value = {t}'.format(t=autothreshval))
+            ax.axis([0, 256, 0, max(hist)])
+            ax.grid(True)
             fig_name_hist = os.path.join(params.debug_outdir,
                                          str(params.device) + '_triangle_thresh_hist_' + str(autothreshval) + ".png")
             # write the figure to current directory
@@ -257,9 +258,10 @@ def triangle(gray_img, max_value, object_type="light", xstep=1):
             plt.clf()
         elif params.debug == 'plot':
             print('Threshold value = {t}'.format(t=autothreshval))
-            plt.plot(hist)
-            plt.axis([0, 256, 0, max(hist)])
-            plt.grid(True)
+            fig, ax = plt.subplots()
+            ax.plot(hist)
+            ax.axis([0, 256, 0, max(hist)])
+            ax.grid(True)
             plt.show()
 
     return bin_img

--- a/plantcv/plantcv/threshold/threshold_methods.py
+++ b/plantcv/plantcv/threshold/threshold_methods.py
@@ -245,7 +245,7 @@ def triangle(gray_img, max_value, object_type="light", xstep=1):
     # Additional figures created by this method, if debug is on
     if params.debug is not None:
         if params.debug == 'print':
-            fig, ax = plt.subplots()
+            _, ax = plt.subplots()
             ax.plot(hist)
             ax.set(title='Threshold value = {t}'.format(t=autothreshval))
             ax.axis([0, 256, 0, max(hist)])
@@ -258,7 +258,7 @@ def triangle(gray_img, max_value, object_type="light", xstep=1):
             plt.clf()
         elif params.debug == 'plot':
             print('Threshold value = {t}'.format(t=autothreshval))
-            fig, ax = plt.subplots()
+            _, ax = plt.subplots()
             ax.plot(hist)
             ax.axis([0, 256, 0, max(hist)])
             ax.grid(True)

--- a/plantcv/plantcv/visualize/pseudocolor.py
+++ b/plantcv/plantcv/visualize/pseudocolor.py
@@ -112,10 +112,11 @@ def pseudocolor(gray_img, obj=None, mask=None, cmap=None, background="image", mi
             fatal_error(
                 "Background type {0} is not supported. Please use 'white', 'black', or 'image'.".format(background))
 
+        fig = plt.figure()
         # Pseudocolor the image, plot the background first
         pseudo_img1 = plt.imshow(bkg_img, cmap=bkg_cmap)
         # Overlay the masked grayscale image with the user input colormap
-        plt.imshow(masked_img, cmap=cmap, vmin=min_value, vmax=max_value)
+        pseudo_img2 = plt.imshow(masked_img, cmap=cmap, vmin=min_value, vmax=max_value)
 
         if colorbar:
             plt.colorbar(fraction=0.033, pad=0.04)
@@ -132,6 +133,7 @@ def pseudocolor(gray_img, obj=None, mask=None, cmap=None, background="image", mi
         pseudo_img = plt.gcf()
 
     else:
+        fig = plt.figure()
         # Pseudocolor the image
         pseudo_img1 = plt.imshow(gray_img1, cmap=cmap, vmin=min_value, vmax=max_value)
 

--- a/plantcv/plantcv/visualize/pseudocolor.py
+++ b/plantcv/plantcv/visualize/pseudocolor.py
@@ -131,17 +131,6 @@ def pseudocolor(gray_img, obj=None, mask=None, cmap=None, background="image", mi
         # Store the current figure
         pseudo_img = plt.gcf()
 
-        # Print or plot if debug is turned on
-        if params.debug == 'print':
-            plt.savefig(os.path.join(params.debug_outdir, str(params.device) + '_pseudocolored.png'), dpi=params.dpi)
-            plt.close()
-        elif params.debug == 'plot':
-            plot_image(pseudo_img1)
-            # Use non-blocking mode in case the function is run more than once
-            plt.show(block=False)
-        elif params.debug is None:
-            plt.show(block=False)
-
     else:
         # Pseudocolor the image
         pseudo_img1 = plt.imshow(gray_img1, cmap=cmap, vmin=min_value, vmax=max_value)
@@ -160,16 +149,18 @@ def pseudocolor(gray_img, obj=None, mask=None, cmap=None, background="image", mi
 
         pseudo_img = plt.gcf()
 
-        # Print or plot if debug is turned on
+
+    # Print or plot if debug is turned on
+    if params.debug is not None:
         if params.debug == 'print':
-            plt.savefig(os.path.join(params.debug_outdir, str(params.device) + '_pseudocolored.png'), dpi=params.dpi)
-            pseudo_img.clear()
+            plt.savefig(os.path.join(params.debug_outdir, str(
+                params.device) + '_pseudocolored.png'), dpi=params.dpi)
             plt.close()
         elif params.debug == 'plot':
             plot_image(pseudo_img1)
             # Use non-blocking mode in case the function is run more than once
             plt.show(block=False)
-        elif params.debug is None:
-            plt.show(block=False)
+    else:
+        plt.close()
 
     return pseudo_img

--- a/plantcv/plantcv/visualize/pseudocolor.py
+++ b/plantcv/plantcv/visualize/pseudocolor.py
@@ -112,11 +112,11 @@ def pseudocolor(gray_img, obj=None, mask=None, cmap=None, background="image", mi
             fatal_error(
                 "Background type {0} is not supported. Please use 'white', 'black', or 'image'.".format(background))
 
-        fig = plt.figure()
+        plt.figure()
         # Pseudocolor the image, plot the background first
-        pseudo_img1 = plt.imshow(bkg_img, cmap=bkg_cmap)
+        plt.imshow(bkg_img, cmap=bkg_cmap)
         # Overlay the masked grayscale image with the user input colormap
-        pseudo_img2 = plt.imshow(masked_img, cmap=cmap, vmin=min_value, vmax=max_value)
+        plt.imshow(masked_img, cmap=cmap, vmin=min_value, vmax=max_value)
 
         if colorbar:
             plt.colorbar(fraction=0.033, pad=0.04)
@@ -133,9 +133,9 @@ def pseudocolor(gray_img, obj=None, mask=None, cmap=None, background="image", mi
         pseudo_img = plt.gcf()
 
     else:
-        fig = plt.figure()
+        plt.figure()
         # Pseudocolor the image
-        pseudo_img1 = plt.imshow(gray_img1, cmap=cmap, vmin=min_value, vmax=max_value)
+        plt.imshow(gray_img1, cmap=cmap, vmin=min_value, vmax=max_value)
 
         if colorbar:
             # Include the colorbar
@@ -159,7 +159,6 @@ def pseudocolor(gray_img, obj=None, mask=None, cmap=None, background="image", mi
                 params.device) + '_pseudocolored.png'), dpi=params.dpi)
             plt.close()
         elif params.debug == 'plot':
-            plot_image(pseudo_img1)
             # Use non-blocking mode in case the function is run more than once
             plt.show(block=False)
     else:


### PR DESCRIPTION
**Describe your changes**
I removed the plotting in pseudocolor() when debug=None because it causes issues if the matplotlib backend is not set correctly.  I also removed setting the display in  `__init__.py` because I think matplotlib takes care of this appropriately.  I added a plt.close() for the current figure at the end of pseudocolor() if debug=None.  this prevents the duplicate colorbars when running pseudocolor() multiple times but does NOT prevent the return of the figure handle. see comments in #620 for example.

I tested is on Windows with an ipython terminal, a .py script run with ipython, and using the plantcv workflow method. I also tested with debug='plot' and debug='print' in an ipython terminal on Windows.  Also tested successfully with jupyter notebook 

**Type of update**
Is this a:
* Bug fix 

**Associated issues**
closes #620 

