### PR TITLE
preference to conda-forge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,5 @@
 # run: conda env create --file environment.yml
+# optionally, change channel name with -n {plantcv-dev}
 name: plantcv
 dependencies:
   - python=3.7
@@ -15,5 +16,5 @@ dependencies:
   - nb_conda
   - opencv<4, >=3.4
 channels:
-  - defaults
   - conda-forge
+  - defaults


### PR DESCRIPTION
prioritize conda-forge over defaults channel in dev environment  to match channel used for release dependencies
