### PR TITLE
force unix line endings except for any windows specific files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 plantcv/plantcv/_version.py export-subst
+
+# this should force unix line endings except for any windows specific files
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
**Describe your changes**
use .gitattributes to force unix line endings so windows git doesnt think there were a million changes
exclude windows specific files like .cmd and .bat

https://code.visualstudio.com/docs/remote/troubleshooting#_resolving-git-line-ending-issues-in-containers-resulting-in-many-modified-files


**Additional context**
windows woes