### PR TITLE
filter on finite, and calc stats ignoring nan

### DIFF
--- a/plantcv/plantcv/hyperspectral/analyze_index.py
+++ b/plantcv/plantcv/hyperspectral/analyze_index.py
@@ -47,9 +47,11 @@ def analyze_index(index_array, mask, histplot=False, bins=100, min_bin=0, max_bi
 
     # Mask data and collect statistics about pixels within the masked image
     masked_array = index_array.array_data[np.where(mask > 0)]
-    index_mean = np.average(masked_array)
-    index_median = np.median(masked_array)
-    index_std = np.std(masked_array)
+    masked_array = masked_array[np.isfinitie(masked_array)]
+
+    index_mean = np.nanmean(masked_array)
+    index_median = np.nanmedian(masked_array)
+    index_std = np.nanstd(masked_array)
 
     # Set starting point and max bin values
     maxval = max_bin

--- a/plantcv/plantcv/hyperspectral/analyze_index.py
+++ b/plantcv/plantcv/hyperspectral/analyze_index.py
@@ -47,7 +47,7 @@ def analyze_index(index_array, mask, histplot=False, bins=100, min_bin=0, max_bi
 
     # Mask data and collect statistics about pixels within the masked image
     masked_array = index_array.array_data[np.where(mask > 0)]
-    masked_array = masked_array[np.isfinitie(masked_array)]
+    masked_array = masked_array[np.isfinite(masked_array)]
 
     index_mean = np.nanmean(masked_array)
     index_median = np.nanmedian(masked_array)


### PR DESCRIPTION
**Describe your changes**
Update the function `pcv.hyperspectral.analyze_index` to be more robust to NaN values and to also only consider finite values when calculating index statistics even when values range to positive or negative inifinity. 

**Type of update**
Is this a:
* feature enhancement

**Associated issues**
- closes #632 

**Additional context**
Add any other context about the problem here.
