### PR TITLE
update dockerfile to conda-forge

### DIFF
--- a/vice/Dockerfile
+++ b/vice/Dockerfile
@@ -15,7 +15,7 @@ USER jovyan
 # install plantcv
 RUN conda update -n base conda \
     && conda install jupyterlab=0.35.4 nb_conda \
-    && conda create -n plantcv -c bioconda plantcv nb_conda \
+    && conda create -n plantcv -c conda-forge plantcv nb_conda \
     && conda clean -tipsy \
     && fix-permissions $CONDA_DIR
 


### PR DESCRIPTION
The vice dockerfile is still refering to bioconda instead of conda-forge for pcv > 3.8 (i think thats what it was)

I'm looking at these because I was wondering if we could tag the docker images with the version# instead of 'latest'  It looks like a new docker image is created for every merge into master. is that correct? I have no idea how it gets uploaded though.  However for the sake of creating reproducible environments for analyses it would make more sense to tag the image files with the released version number.  can you make a 'latest' alias to the latest version?


