### PR TITLE
fix duplicate on workflow metadata image (path+name+name)

### DIFF
--- a/plantcv/parallel/job_builder.py
+++ b/plantcv/parallel/job_builder.py
@@ -62,7 +62,7 @@ def job_builder(meta, config):
             coimg_meta["metadata"]["image"] = {
                 "label": "image file",
                 "datatype": "<class 'str'>",
-                "value": os.path.join(coimg['path'], meta[img]['coimg'])
+                "value": coimg['path']
             }
             # Valid metadata
             for m in list(config.metadata_terms.keys()):
@@ -76,7 +76,7 @@ def job_builder(meta, config):
         img_meta["metadata"]["image"] = {
                 "label": "image file",
                 "datatype": "<class 'str'>",
-                "value": os.path.join(meta[img]['path'], img)
+                "value": meta[img]['path']
             }
         # Valid metadata
         for m in list(config.metadata_terms.keys()):


### PR DESCRIPTION
**Describe your changes**
The workflow parallelization was duplicating the name of the image for the metadata "image". Removed the concatenation of the path (including name) and the name. 

**Type of update**
Is this a bug fix


