### PR TITLE
Update OpenCV function call for cross-version compatibility

### DIFF
--- a/plantcv/plantcv/roi/roi_methods.py
+++ b/plantcv/plantcv/roi/roi_methods.py
@@ -299,7 +299,7 @@ def multi(img, coord, radius, spacing=None, nrows=None, ncols=None):
             circle_img = cv2.circle(bin_img, (x, y), radius, 255, -1)
             overlap_img = overlap_img + circle_img
             # Make a list of contours and hierarchies
-            _, rc, rh = cv2.findContours(circle_img, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)
+            rc, rh = cv2.findContours(circle_img, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)[-2:]
             roi_contour.append(rc)
             roi_hierarchy.append(rh)
     else:


### PR DESCRIPTION
**Describe your changes**
Updates the `pcv.roi.multi` function to modify the `cv2.findContours` function call to only keep the last two output items (the contours and hierarchy). The current code expects a third output before these that only exists in OpenCV 3 but not version 4. Since the first output was not used, it can be discarded for cross-compatibility between 3 and 4.

**Type of update**
Is this a:
* Minor update

**Associated issues**
#667
