### PR TITLE
Pcv.apply mask rgb img to img

### DIFF
--- a/docs/hyperspectral_tutorial.md
+++ b/docs/hyperspectral_tutorial.md
@@ -334,7 +334,7 @@ def main():
                                                                   roi_type='partial')
   
     # Apply the mask of the leaf to the entire datacube, and store it where the datacube is stored.
-    spectral_array.array_data = pcv.apply_mask(rgb_img=spectral_array.array_data, mask=kept_mask, mask_color="black")
+    spectral_array.array_data = pcv.apply_mask(img=spectral_array.array_data, mask=kept_mask, mask_color="black")
                                                                
     # Extract reflectance intensity data and store it out to the Outputs class. 
     analysis_img = pcv.hyperspectral.analyze_spectral(array=spectral_array, mask=kept_mask, histplot=True)

--- a/docs/vis_nir_tutorial.md
+++ b/docs/vis_nir_tutorial.md
@@ -216,10 +216,10 @@ The purpose of this mask is to exclude as much background with simple thresholdi
     # Apply Mask (for VIS images, mask_color=white)
     
     # Inputs:
-    #   rgb_img - RGB image data 
+    #   img - RGB image data 
     #   mask - Binary mask image data 
     #   mask_color - 'white' or 'black' 
-    masked = pcv.apply_mask(rgb_img=img, mask=bs, mack_color='white')
+    masked = pcv.apply_mask(img=img, mask=bs, mack_color='white')
     
 ```
 
@@ -542,7 +542,7 @@ def main():
     bs = pcv.logical_and(bin_img1=s_mblur, bin_img2=b_cnt)
 
     # Apply Mask (for VIS images, mask_color=white)
-    masked = pcv.apply_mask(rgb_img=img, mask=bs, mask_color='white')
+    masked = pcv.apply_mask(img=img, mask=bs, mask_color='white')
 
     # Identify objects
     id_objects,obj_hierarchy = pcv.find_objects(img=masked, mask=bs)


### PR DESCRIPTION
**Describe your changes**
Changed rgb_img to img inside of the pcv.apply_mask() parameters for the vis-nir and hyperspectral tutorials.

**Type of update**
Is this a:
* Bug fix
* Update to documentation

**Associated issues**
#692 
