### PR TITLE
Update fill segments measurements

### DIFF
--- a/docs/fill_segments.md
+++ b/docs/fill_segments.md
@@ -16,7 +16,7 @@ Propagate the labels of a segmented skeleton to fill the mask.
 - **Context:**
     - Uses the watershed algorithm to fill the mask propagating the objects' labels.
 - **Output data stored:** Data ('segment_area') automatically gets stored to the [`Outputs` class](outputs.md) when this function is ran without the `stem_objects` parameter.
-    When the optional parameter is utilized then the data variable names will be ('leaf_area') and ('stem_area'). Data variable names are modified with an optional 
+    When the optional parameter is utilized then the data variable names will be ('leaf_area') and ('stem_area'). Data sample names are modified with an optional 
     `label` prefix. 
     These data can always get accessed during a workflow (example below). For more detail about data output see [Summary of Output Observations](output_measurements.md#summary-of-output-observations)
 

--- a/docs/fill_segments.md
+++ b/docs/fill_segments.md
@@ -2,7 +2,7 @@
 
 Propagate the labels of a segmented skeleton to fill the mask.
 
-**plantcv.morphology.fill_segments**(*mask, objects, stem_objects=None, label="default""default"*)
+**plantcv.morphology.fill_segments**(*mask, objects, stem_objects=None, label="default"*)
 
 **returns** filled_img  
 
@@ -15,7 +15,9 @@ Propagate the labels of a segmented skeleton to fill the mask.
     - label        - Optional label parameter, modifies the variable name of observations recorded. (default `label="default"`)
 - **Context:**
     - Uses the watershed algorithm to fill the mask propagating the objects' labels.
-- **Output data stored:** Data ('segment_area') automatically gets stored to the [`Outputs` class](outputs.md) when this function is ran.
+- **Output data stored:** Data ('segment_area') automatically gets stored to the [`Outputs` class](outputs.md) when this function is ran without the `stem_objects` parameter.
+    When the optional parameter is utilized then the data variable names will be ('leaf_area') and ('stem_area'). Data variable names are modified with an optional 
+    `label` prefix. 
     These data can always get accessed during a workflow (example below). For more detail about data output see [Summary of Output Observations](output_measurements.md#summary-of-output-observations)
 
 **Reference Image:** mask, objects drawn as labels

--- a/plantcv/plantcv/morphology/fill_segments.py
+++ b/plantcv/plantcv/morphology/fill_segments.py
@@ -48,11 +48,23 @@ def fill_segments(mask, objects, stem_objects=None, label="default"):
     # Count area in pixels of each segment
     ids, counts = np.unique(filled_mask, return_counts=True)
 
-    outputs.add_observation(sample=label, variable='segment_area', trait='segment area',
-                            method='plantcv.plantcv.morphology.fill_segments',
-                            scale='pixels', datatype=list,
-                            value=counts[1:].tolist(),
-                            label=(ids[1:]-1).tolist())
+    if stem_objects is None:
+        outputs.add_observation(sample=label, variable='segment_area', trait='segment area',
+                                method='plantcv.plantcv.morphology.fill_segments',
+                                scale='pixels', datatype=list,
+                                value=counts[1:].tolist(),
+                                label=(ids[1:]-1).tolist())
+    else:
+        outputs.add_observation(sample=label, variable='leaf_area', trait='segment area',
+                                method='plantcv.plantcv.morphology.fill_segments',
+                                scale='pixels', datatype=list,
+                                value=counts[1:].tolist(),
+                                label=(ids[1:]-1).tolist())
+        outputs.add_observation(sample=label, variable='stem_area', trait='segment area',
+                                method='plantcv.plantcv.morphology.fill_segments',
+                                scale='pixels', datatype=list,
+                                value=counts[1:].tolist(),
+                                label=(ids[1:]-1).tolist())
 
     rgb_vals = color_palette(num=len(labels), saved=False)
     filled_img = np.zeros((h, w, 3), dtype=np.uint8)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3814,7 +3814,7 @@ def test_plantcv_morphology_fill_segments_with_stem():
     pcv.params.debug = "print"
     _ = pcv.morphology.fill_segments(mask, obj, stem_obj)
     pcv.print_results(os.path.join(cache_dir, "results.txt"))
-    num_objects = len(pcv.outputs.observations['default']['segment_area']['value'])
+    num_objects = len(pcv.outputs.observations['default']['leaf_area']['value'])
     assert num_objects == 70
 
 


### PR DESCRIPTION
**Describe your changes**
We added the functionality to fill in and measure the entire stem as one entity, but didn't specifically record a separate observation while doing so. This update makes it so that you can record a general "segment_area" or get out info about "stem_area" and "leaf_area" separately while providing the stem objects to the function separately. 


**Type of update**
Is this a:
* Bug fix
* New feature or feature enhancement
* Update to documentation
* Work in progress

**Associated issues**
Reference associated issue numbers. Does this pull request close any issues?

**Additional context**
Add any other context about the problem here.
