### PR TITLE
Create debug module

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -167,19 +167,25 @@ import cv2
 import os
 
 # Import functions from within plantcv
-from plantcv.plantcv import params 
-from plantcv.plantcv import plot_image
-from plantcv.plantcv import print_image
+from plantcv.plantcv import params
+from plantcv.plantcv._debug import _debug
 ```
 
 Here is a sample of a new function. Arguments should be defined.
-Generally, functions should utilize the global `debug` parameter from the [params](params.md) class.
-Users can set `pcv.params.debug `
+Generally, functions should utilize the private function `_debug` to produce visualization results.
+Users can set `pcv.params.debug`
 to `None` (default), "print" (to file), or "plot" (to screen if using [Jupyter](jupyter.md) notebooks or X11).
-Functions should also increment the `device` number, which is a counter for image processing steps that is autoincremented by functions that use `params`.
-Note that the inputs and outputs are documented with Python docstrings.
+Functions should also increment the `device` number, which is a counter for image processing steps that is 
+autoincremented by functions that use `params`. Note that the inputs and outputs are documented with Python docstrings.
 
 ```python
+# Import external packages
+import numpy as np
+import cv2
+import os
+from plantcv.plantcv import params
+from plantcv.plantcv._debug import _debug
+
 
 def new_function(img):
     """New function.
@@ -199,16 +205,14 @@ def new_function(img):
 
     returnval1 = some_code_on_img(img)
     
-    if params.debug == "print":
-        print_image(img, os.path.join(params.debug_outdir, str(params.device) + '_new_function.jpg'))
-    elif params.debug == 'plot':
-        plot_image(img)
+    _debug(visual=returnval1, filename=os.path.join(params.debug_outdir, str(params.device) + '_new_function.jpg'))
 
     return returnval1
 
 ```
 
-If you need to call other PlantCV functions from within your contributed function, be sure to disable debugging until you are ready to show your own debug images.
+If you need to call other PlantCV functions from within your contributed function, be sure to disable debugging until 
+you are ready to show your own debug images.
 
 To do this, follow these four steps:
   1. Store the value of params.debug
@@ -219,11 +223,11 @@ To do this, follow these four steps:
 Here is a sample of a PlantCV function that calls on other PlantCV functions:
 
 ```python
-import plantcv.plantcv.params
-import plantcv.plantcv.example_plantcv_function
-import plantcv.plantcv.another_plantcv_function
-import plantcv.plantcv.print_image
-import plantcv.plantcv.plot_image
+from plantcv.plantcv import params
+from plantcv.plantcv._debug import _debug
+from plantcv.plantcv import example_plantcv_function
+from plantcv.plantcv import another_plantcv_function
+
 
 def new_function_calling_plantcv(img):
     """New function calling another plantcv function.
@@ -252,11 +256,8 @@ def new_function_calling_plantcv(img):
 
     # Reset debug mode
     params.debug = debug
-
-    if params.debug == 'print':
-        print_image(final_img, os.path.join(params.debug_outdir, str(params.device) + '_new_function.jpg'))
-    elif params.debug == 'plot':
-        plot_image(final_img)
+    
+    _debug(visual=final_img, filename=os.path.join(params.debug_outdir, str(params.device) + '_new_function.jpg'))
 
     return final_img
 

--- a/plantcv/plantcv/_debug.py
+++ b/plantcv/plantcv/_debug.py
@@ -1,0 +1,23 @@
+# Debugging module
+
+from plantcv.plantcv import params
+from plantcv.plantcv import print_image
+from plantcv.plantcv import plot_image
+
+
+def _debug(visual, filename=None):
+    """Save or display a visual for debugging.
+
+    Inputs:
+    visual   - An image or plot to display for debugging
+    filename - An optional filename to save the visual to (default: None)
+
+    :param visual: numpy.ndarray
+    :param filename: str
+    """
+    if params.debug == "print":
+        # If debug is print, save the image to a file
+        print_image(img=visual, filename=filename)
+    elif params.debug == "plot":
+        # If debug is plot, print to the plotting device
+        plot_image(img=visual)

--- a/plantcv/plantcv/analyze_color.py
+++ b/plantcv/plantcv/analyze_color.py
@@ -7,6 +7,7 @@ from plotnine import ggplot, aes, geom_line, scale_x_continuous, scale_color_man
 from plantcv.plantcv import fatal_error
 from plantcv.plantcv import params
 from plantcv.plantcv import outputs
+from plantcv.plantcv._debug import _debug
 
 
 def analyze_color(rgb_img, mask, hist_plot_type=None, label="default"):
@@ -145,11 +146,8 @@ def analyze_color(rgb_img, mask, hist_plot_type=None, label="default"):
     # Plot or print the histogram
     if hist_plot_type is not None:
         params.device += 1
-        if params.debug == 'print':
-            hist_fig.save(os.path.join(params.debug_outdir, str(params.device) + '_analyze_color_hist.png'),
-                          verbose=False)
-        elif params.debug == 'plot':
-            print(hist_fig)
+        _debug(visual=hist_fig,
+               filename=os.path.join(params.debug_outdir, str(params.device) + '_analyze_color_hist.png'))
 
     # Store into global measurements
     # RGB signal values are in an unsigned 8-bit scale of 0-255

--- a/plantcv/plantcv/analyze_object.py
+++ b/plantcv/plantcv/analyze_object.py
@@ -3,11 +3,10 @@
 import os
 import cv2
 import numpy as np
-from plantcv.plantcv import print_image
-from plantcv.plantcv import plot_image
 from plantcv.plantcv import params
 from plantcv.plantcv import outputs
 from plantcv.plantcv import within_frame
+from plantcv.plantcv._debug import _debug
 
 
 def analyze_object(img, obj, mask, label="default"):
@@ -204,22 +203,16 @@ def analyze_object(img, obj, mask, label="default"):
                             method='plantcv.plantcv.analyze_object', scale='none', datatype=float,
                             value=float(eccentricity), label='none')
 
-    if params.debug is not None:
-        params.device += 1
-        cv2.drawContours(ori_img, obj, -1, (255, 0, 0), params.line_thickness)
-        cv2.drawContours(ori_img, [hull], -1, (255, 0, 255), params.line_thickness)
-        cv2.line(ori_img, (x, y), (x + width, y), (255, 0, 255), params.line_thickness)
-        cv2.line(ori_img, (int(cmx), y), (int(cmx), y + height), (255, 0, 255), params.line_thickness)
-        cv2.circle(ori_img, (int(cmx), int(cmy)), 10, (255, 0, 255), params.line_thickness)
-        cv2.line(ori_img, (tuple(caliper_transpose[caliper_length - 1])), (tuple(caliper_transpose[0])), (255, 0, 255),
-                 params.line_thickness)
-        if params.debug == 'print':
-            print_image(ori_img, os.path.join(params.debug_outdir, str(params.device) + '_shapes.png'))
-        elif params.debug == 'plot':
-            if len(np.shape(img)) == 3:
-                plot_image(ori_img)
-            else:
-                plot_image(ori_img, cmap='gray')
+    # Debugging output
+    params.device += 1
+    cv2.drawContours(ori_img, obj, -1, (255, 0, 0), params.line_thickness)
+    cv2.drawContours(ori_img, [hull], -1, (255, 0, 255), params.line_thickness)
+    cv2.line(ori_img, (x, y), (x + width, y), (255, 0, 255), params.line_thickness)
+    cv2.line(ori_img, (int(cmx), y), (int(cmx), y + height), (255, 0, 255), params.line_thickness)
+    cv2.circle(ori_img, (int(cmx), int(cmy)), 10, (255, 0, 255), params.line_thickness)
+    cv2.line(ori_img, (tuple(caliper_transpose[caliper_length - 1])), (tuple(caliper_transpose[0])), (255, 0, 255),
+             params.line_thickness)
+    _debug(visual=ori_img, filename=os.path.join(params.debug_outdir, str(params.device) + '_shapes.png'))
 
     # Store images
     outputs.images.append(analysis_images)

--- a/plantcv/plantcv/readimage.py
+++ b/plantcv/plantcv/readimage.py
@@ -5,10 +5,9 @@ import cv2
 import numpy as np
 import pandas as pd
 from plantcv.plantcv import fatal_error
-from plantcv.plantcv import print_image
-from plantcv.plantcv import plot_image
 from plantcv.plantcv import params
 from plantcv.plantcv.hyperspectral import read_data
+from plantcv.plantcv._debug import _debug
 
 
 def readimage(filename, mode="native"):
@@ -54,9 +53,7 @@ def readimage(filename, mode="native"):
     # Split path from filename
     path, img_name = os.path.split(filename)
 
-    if params.debug == "print":
-        print_image(img, os.path.join(params.debug_outdir, "input_image.png"))
-    elif params.debug == "plot":
-        plot_image(img)
+    # Debugging visualization
+    _debug(visual=img, filename=os.path.join(params.debug_outdir, "input_image.png"))
 
     return img, path, img_name

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1306,52 +1306,33 @@ def test_plantcv_analyze_nir():
 
 
 def test_plantcv_analyze_object():
-    # Test cache directory
-    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_analyze_object")
-    os.mkdir(cache_dir)
-    pcv.params.debug_outdir = cache_dir
+    # Test with debug = None
+    pcv.params.debug = None
     # Read in test data
     img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_COLOR))
     mask = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_BINARY), -1)
     contours_npz = np.load(os.path.join(TEST_DATA, TEST_INPUT_CONTOURS), encoding="latin1")
     obj_contour = contours_npz['arr_0']
-    # max_obj = max(obj_contour, key=len)
-    # Test with debug = "print"
-    pcv.params.debug = "print"
-    _ = pcv.analyze_object(img=img, obj=obj_contour, mask=mask, label="prefix")
-    # Test with debug = "plot"
-    pcv.params.debug = "plot"
-    _ = pcv.analyze_object(img=img, obj=obj_contour, mask=mask)
-    # Test with debug = None
-    pcv.params.debug = None
     obj_images = pcv.analyze_object(img=img, obj=obj_contour, mask=mask)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     pcv.outputs.clear()
     assert len(obj_images) != 0
 
 
 def test_plantcv_analyze_object_grayscale_input():
-    # Test cache directory
-    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_analyze_object_grayscale_input")
-    os.mkdir(cache_dir)
-    pcv.params.debug_outdir = cache_dir
+    # Test with debug = None
+    pcv.params.debug = None
     # Read in test data
     img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_COLOR), 0)
     mask = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_BINARY), -1)
     contours_npz = np.load(os.path.join(TEST_DATA, TEST_INPUT_CONTOURS), encoding="latin1")
     obj_contour = contours_npz['arr_0']
-    # max_obj = max(obj_contour, key=len)
-    # Test with debug = "plot"
-    pcv.params.debug = "plot"
     obj_images = pcv.analyze_object(img=img, obj=obj_contour, mask=mask)
     assert len(obj_images) != 1
 
 
 def test_plantcv_analyze_object_zero_slope():
-    # Test cache directory
-    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_analyze_object_zero_slope")
-    os.mkdir(cache_dir)
-    pcv.params.debug_outdir = cache_dir
+    # Test with debug = None
+    pcv.params.debug = None
     # Create a test image
     img = np.zeros((50, 50, 3), dtype=np.uint8)
     img[10:11, 10:40, 0] = 255
@@ -1365,17 +1346,13 @@ def test_plantcv_analyze_object_zero_slope():
                             [[26, 10]], [[25, 10]], [[24, 10]], [[23, 10]], [[22, 10]], [[21, 10]], [[20, 10]],
                             [[19, 10]], [[18, 10]], [[17, 10]], [[16, 10]], [[15, 10]], [[14, 10]], [[13, 10]],
                             [[12, 10]], [[11, 10]]], dtype=np.int32)
-    # Test with debug = None
-    pcv.params.debug = None
     obj_images = pcv.analyze_object(img=img, obj=obj_contour, mask=mask)
     assert len(obj_images) != 0
 
 
 def test_plantcv_analyze_object_longest_axis_2d():
-    # Test cache directory
-    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_analyze_object_longest_axis_2d")
-    os.mkdir(cache_dir)
-    pcv.params.debug_outdir = cache_dir
+    # Test with debug = None
+    pcv.params.debug = None
     # Create a test image
     img = np.zeros((50, 50, 3), dtype=np.uint8)
     img[0:5, 45:49, 0] = 255
@@ -1385,17 +1362,13 @@ def test_plantcv_analyze_object_longest_axis_2d():
                             [[48, 3]], [[48, 2]], [[48, 1]], [[47, 1]], [[46, 1]], [[1, 1]], [[1, 2]],
                             [[1, 3]], [[1, 4]], [[2, 4]], [[3, 4]], [[4, 4]], [[4, 3]], [[4, 2]],
                             [[4, 1]], [[3, 1]], [[2, 1]]], dtype=np.int32)
-    # Test with debug = None
-    pcv.params.debug = None
     obj_images = pcv.analyze_object(img=img, obj=obj_contour, mask=mask)
     assert len(obj_images) != 0
 
 
 def test_plantcv_analyze_object_longest_axis_2e():
-    # Test cache directory
-    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_analyze_object_longest_axis_2e")
-    os.mkdir(cache_dir)
-    pcv.params.debug_outdir = cache_dir
+    # Test with debug = None
+    pcv.params.debug = None
     # Create a test image
     img = np.zeros((50, 50, 3), dtype=np.uint8)
     img[10:15, 10:40, 0] = 255
@@ -1410,22 +1383,17 @@ def test_plantcv_analyze_object_longest_axis_2e():
                             [[27, 10]], [[26, 10]], [[25, 10]], [[24, 10]], [[23, 10]], [[22, 10]], [[21, 10]],
                             [[20, 10]], [[19, 10]], [[18, 10]], [[17, 10]], [[16, 10]], [[15, 10]], [[14, 10]],
                             [[13, 10]], [[12, 10]], [[11, 10]]], dtype=np.int32)
-    # Test with debug = None
-    pcv.params.debug = None
     obj_images = pcv.analyze_object(img=img, obj=obj_contour, mask=mask)
     assert len(obj_images) != 0
 
 
 def test_plantcv_analyze_object_small_contour():
-    # Test cache directory
-    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_analyze_object_small_contour")
-    os.mkdir(cache_dir)
+    # Test with debug = None
+    pcv.params.debug = None
     # Read in test data
     img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_COLOR))
     mask = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_BINARY), -1)
     obj_contour = [np.array([[[0, 0]], [[0, 50]], [[50, 50]], [[50, 0]]], dtype=np.int32)]
-    # Test with debug = None
-    pcv.params.debug = None
     obj_images = pcv.analyze_object(img=img, obj=obj_contour, mask=mask)
     assert obj_images is None
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2632,17 +2632,10 @@ def test_plantcv_print_image_plotnine():
 
 
 def test_plantcv_readimage_native():
-    # Test cache directory
-    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_readimage")
-    os.mkdir(cache_dir)
-    pcv.params.debug_outdir = cache_dir
-    # Test with debug = "print"
-    pcv.params.debug = "print"
-    _ = pcv.readimage(filename=os.path.join(TEST_DATA, TEST_INPUT_COLOR), mode='rgba')
-    # Test with debug = "plot"
-    pcv.params.debug = "plot"
-    _ = pcv.readimage(filename=os.path.join(TEST_DATA, TEST_INPUT_COLOR))
+    # Test with debug = None
     pcv.params.debug = None
+    _ = pcv.readimage(filename=os.path.join(TEST_DATA, TEST_INPUT_COLOR), mode='rgba')
+    _ = pcv.readimage(filename=os.path.join(TEST_DATA, TEST_INPUT_COLOR))
     img, path, img_name = pcv.readimage(filename=os.path.join(TEST_DATA, TEST_INPUT_COLOR), mode='native')
     # Assert that the image name returned equals the name of the input image
     # Assert that the path of the image returned equals the path of the input image
@@ -2657,6 +2650,7 @@ def test_plantcv_readimage_native():
 
 
 def test_plantcv_readimage_grayscale():
+    # Test with debug = None
     pcv.params.debug = None
     _, _, _ = pcv.readimage(filename=os.path.join(TEST_DATA, TEST_INPUT_GRAY), mode="grey")
     img, path, img_name = pcv.readimage(filename=os.path.join(TEST_DATA, TEST_INPUT_GRAY), mode="gray")
@@ -2664,24 +2658,28 @@ def test_plantcv_readimage_grayscale():
 
 
 def test_plantcv_readimage_rgb():
+    # Test with debug = None
     pcv.params.debug = None
     img, path, img_name = pcv.readimage(filename=os.path.join(TEST_DATA, TEST_INPUT_GRAY), mode="rgb")
     assert len(np.shape(img)) == 3
 
 
 def test_plantcv_readimage_rgba_as_rgb():
+    # Test with debug = None
     pcv.params.debug = None
     img, path, img_name = pcv.readimage(filename=os.path.join(TEST_DATA, TEST_INPUT_RGBA), mode="native")
     assert np.shape(img)[2] == 3
 
 
 def test_plantcv_readimage_csv():
+    # Test with debug = None
     pcv.params.debug = None
     img, path, img_name = pcv.readimage(filename=os.path.join(TEST_DATA, TEST_INPUT_THERMAL_CSV), mode="csv")
     assert len(np.shape(img)) == 2
 
 
 def test_plantcv_readimage_envi():
+    # Test with debug = None
     pcv.params.debug = None
     array_data = pcv.readimage(filename=os.path.join(HYPERSPECTRAL_TEST_DATA, HYPERSPECTRAL_DATA), mode="envi")
     if sys.version_info[0] < 3:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1230,33 +1230,24 @@ def test_plantcv_analyze_bound_vertical_small_x():
 def test_plantcv_analyze_color():
     # Clear previous outputs
     pcv.outputs.clear()
-    # Test cache directory
-    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_analyze_color")
-    os.mkdir(cache_dir)
-    pcv.params.debug_outdir = cache_dir
+    # Test with debug = None
+    pcv.params.debug = None
     # Read in test data
     img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_COLOR))
     mask = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_BINARY), -1)
-    # Test with debug = "print"
-    pcv.params.debug = "print"
     _ = pcv.analyze_color(rgb_img=img, mask=mask, hist_plot_type="all")
     _ = pcv.analyze_color(rgb_img=img, mask=mask, hist_plot_type=None, label="prefix")
-
-    # Test with debug = "plot"
-    pcv.params.debug = "plot"
     _ = pcv.analyze_color(rgb_img=img, mask=mask, hist_plot_type=None)
     _ = pcv.analyze_color(rgb_img=img, mask=mask, hist_plot_type='lab')
     _ = pcv.analyze_color(rgb_img=img, mask=mask, hist_plot_type='hsv')
     _ = pcv.analyze_color(rgb_img=img, mask=mask, hist_plot_type=None)
-
-    # Test with debug = None
-    pcv.params.debug = None
     _ = pcv.analyze_color(rgb_img=img, mask=mask, hist_plot_type='rgb')
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     assert pcv.outputs.observations['default']['hue_median']['value'] == 84.0
 
 
 def test_plantcv_analyze_color_incorrect_image():
+    # Test with debug = None
+    pcv.params.debug = None
     img_binary = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_BINARY), -1)
     mask = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_BINARY), -1)
     with pytest.raises(RuntimeError):
@@ -1264,18 +1255,20 @@ def test_plantcv_analyze_color_incorrect_image():
 
 
 def test_plantcv_analyze_color_bad_hist_type():
+    # Test with debug = None
+    pcv.params.debug = None
     img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_COLOR))
     mask = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_BINARY), -1)
-    pcv.params.debug = "plot"
     with pytest.raises(RuntimeError):
         _ = pcv.analyze_color(rgb_img=img, mask=mask, hist_plot_type='bgr')
 
 
 def test_plantcv_analyze_color_incorrect_hist_plot_type():
+    # Test with debug = None
+    pcv.params.debug = None
     img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_COLOR))
     mask = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_BINARY), -1)
     with pytest.raises(RuntimeError):
-        pcv.params.debug = "plot"
         _ = pcv.analyze_color(rgb_img=img, mask=mask, hist_plot_type="bgr")
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -949,6 +949,17 @@ PIXEL_VALUES = "pixel_inspector_rgb_values.txt"
 # ##########################
 # Tests for the main package
 # ##########################
+@pytest.mark.parametrize("debug", ["print", "plot"])
+def test_plantcv_debug(debug, tmpdir):
+    from plantcv.plantcv._debug import _debug
+    # Create a test tmp directory
+    img_outdir = tmpdir.mkdir("sub")
+    pcv.params.debug = debug
+    img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_COLOR))
+    _debug(visual=img, filename=os.path.join(img_outdir, TEST_INPUT_COLOR))
+    assert True
+
+
 def test_plantcv_transform_warp_smaller():
     img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_COLOR),-1)
     bimg = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_BINARY),-1)


### PR DESCRIPTION
**Describe your changes**
Adds a private function `_debug` that handles the decision-making to save or display visuals for debugging steps. The if/elif blocks in each PlantCV function that determine whether to use `pcv.print_image` or `pcv.plot_image` can be removed and replaced with a call to `_debug`:

```python
from plantcv.plantcv import params
from plantcv.plantcv._debug import _debug
_debug(visual=img, filename=os.path.join(params.debug_outdir, str(params.device) + "_debug_img.png")
```

Tests for each PlantCV function will no longer need to run each function with debug = "print" or "plot" enabled.

**Type of update**
Is this a: New feature or feature enhancement

**Associated issues**
#706, #713 
