### PR TITLE
Pcv.cluster contours splitimg accept non rgb images

### DIFF
--- a/docs/cluster_contours_splitimg.md
+++ b/docs/cluster_contours_splitimg.md
@@ -3,12 +3,12 @@
 This function takes clustered contours and splits them into multiple images, also does a check to make sure that
 the number of inputted filenames matches the number of clustered contours.
 
-**plantcv.cluster_contour_splitimg**(*rgb_img, grouped_contour_indexes, contours, hierarchy, outdir=None, file=None, filenames=None*)
+**plantcv.cluster_contour_splitimg**(*img, grouped_contour_indexes, contours, hierarchy, outdir=None, file=None, filenames=None*)
 
 **returns** output_paths, output_imgs, output_masks
 
 - **Parameters:**
-    - rgb_img - RGB image data
+    - img - image data
     - grouped_contour_indexes - output of cluster_contours, indexes of clusters of contours
     - contours - contours to cluster, output of cluster_contours
     - hierarchy - object hierarchy
@@ -39,7 +39,7 @@ pcv.params.debug = "print"
 # Cluster Contours and Split into Separate Images
 
 out = './examples/'
-output_path, imgs, masks = pcv.cluster_contour_splitimg(rgb_img, clusters_i, contours, 
+output_path, imgs, masks = pcv.cluster_contour_splitimg(img, clusters_i, contours, 
                                                         hierarchy, out, file, 
                                                         filenames=None)
                                            

--- a/docs/multi-plant_tutorial.md
+++ b/docs/multi-plant_tutorial.md
@@ -365,7 +365,7 @@ for an example.
     # also does a check to make sure that the number of inputted filenames matches the number
     # of clustered contours. If no filenames are given then the objects are just numbered
     # Inputs:
-    #    img                     = ideally a masked RGB image.
+    #    img                     = ideally a masked image.
     #    grouped_contour_indexes = output of cluster_contours, indexes of clusters of contours
     #    contours                = contours to cluster, output of cluster_contours
     #    hierarchy               = object hierarchy

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -248,6 +248,7 @@ pages for more details on the input and output variable types.
 * pre v3.0dev2: device, output_path = **plantcv.cluster_contour_splitimg**(*device, img, grouped_contour_indexes, contours, hierarchy, outdir=None, file=None, filenames=None, debug=None*)
 * post v3.0dev2: output_path = **plantcv.cluster_contour_splitimg**(*rgb_img, grouped_contour_indexes, contours, hierarchy, outdir=None, file=None, filenames=None*)
 * post v3.3: output_path, output_imgs, output_masks = **plantcv.cluster_contour_splitimg**(*rgb_img, grouped_contour_indexes, contours, hierarchy, outdir=None, file=None, filenames=None*)
+* post v3.12 output_path, output_imgs, output_masks = **plantcv.cluster_contour_splitimg**(*img, grouped_contour_indexes, contours, hierarchy, outdir=None, file=None, filenames=None*)
 
 #### plantcv.cluster_contours
 

--- a/plantcv/plantcv/cluster_contour_splitimg.py
+++ b/plantcv/plantcv/cluster_contour_splitimg.py
@@ -9,7 +9,7 @@ from plantcv.plantcv import apply_mask
 from plantcv.plantcv import params
 
 
-def cluster_contour_splitimg(rgb_img, grouped_contour_indexes, contours, hierarchy, outdir=None, file=None,
+def cluster_contour_splitimg(img, grouped_contour_indexes, contours, hierarchy, outdir=None, file=None,
                              filenames=None):
 
     """
@@ -17,7 +17,7 @@ def cluster_contour_splitimg(rgb_img, grouped_contour_indexes, contours, hierarc
     the number of inputted filenames matches the number of clustered contours.
 
     Inputs:
-    rgb_img                 = RGB image data
+    img                     = image data
     grouped_contour_indexes = output of cluster_contours, indexes of clusters of contours
     contours                = contours to cluster, output of cluster_contours
     hierarchy               = hierarchy of contours, output of find_objects
@@ -30,7 +30,7 @@ def cluster_contour_splitimg(rgb_img, grouped_contour_indexes, contours, hierarc
     Returns:
     output_path             = array of paths to output images
 
-    :param rgb_img: numpy.ndarray
+    :param img: numpy.ndarray
     :param grouped_contour_indexes: list
     :param contours: list
     :param hierarchy: numpy.ndarray
@@ -119,9 +119,9 @@ def cluster_contour_splitimg(rgb_img, grouped_contour_indexes, contours, hierarc
         else:
             savename = os.path.join(".", group_names[y])
             savename1 = os.path.join(".", group_names1[y])
-        iy, ix, iz = np.shape(rgb_img)
+        iy, ix, iz = np.shape(img)
         mask = np.zeros((iy, ix, 3), dtype=np.uint8)
-        masked_img = np.copy(rgb_img)
+        masked_img = np.copy(img)
         for a in x:
             if hierarchy[0][a][3] > -1:
                 cv2.drawContours(mask, contours, a, (0, 0, 0), -1, lineType=8, hierarchy=hierarchy)

--- a/plantcv/plantcv/cluster_contour_splitimg.py
+++ b/plantcv/plantcv/cluster_contour_splitimg.py
@@ -119,7 +119,7 @@ def cluster_contour_splitimg(img, grouped_contour_indexes, contours, hierarchy, 
         else:
             savename = os.path.join(".", group_names[y])
             savename1 = os.path.join(".", group_names1[y])
-        iy, ix, iz = np.shape(img)
+        iy, ix = np.shape(img)[:2]
         mask = np.zeros((iy, ix, 3), dtype=np.uint8)
         masked_img = np.copy(img)
         for a in x:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1750,7 +1750,7 @@ def test_plantcv_cluster_contours_splitimg_grayscale():
     cluster_contours = [clusters[arr_n] for arr_n in clusters]
     obj_hierarchy = hierachy['arr_0']
     pcv.params.debug = None
-    output_path, imgs, masks = pcv.cluster_contour_splitimg_grayscale(img=img1, grouped_contour_indexes=cluster_contours,
+    output_path, imgs, masks = pcv.cluster_contour_splitimg(img=img1, grouped_contour_indexes=cluster_contours,
                                                             contours=roi_contours, hierarchy=obj_hierarchy, outdir=None,
                                                             file=None,
                                                             filenames=None)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1734,6 +1734,29 @@ def test_plantcv_cluster_contours_splitimg():
     assert len(output_path) != 0
 
 
+def test_plantcv_cluster_contours_splitimg_grayscale():
+    # Test cache directory
+    cache_dir = os.path.join(TEST_TMPDIR, "test_plantcv_cluster_contours_splitimg_grayscale")
+    os.mkdir(cache_dir)
+    pcv.params.debug_outdir = cache_dir
+    # Read in test data
+    img1 = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_MULTI), 0)
+    contours = np.load(os.path.join(TEST_DATA, TEST_INPUT_MULTI_CONTOUR), encoding="latin1")
+    clusters = np.load(os.path.join(TEST_DATA, TEST_INPUT_ClUSTER_CONTOUR), encoding="latin1")
+    hierachy = np.load(os.path.join(TEST_DATA, TEST_INPUT_MULTI_HIERARCHY), encoding="latin1")
+    cluster_names = os.path.join(TEST_DATA, TEST_INPUT_GENOTXT)
+    cluster_names_too_many = os.path.join(TEST_DATA, TEST_INPUT_GENOTXT_TOO_MANY)
+    roi_contours = [contours[arr_n] for arr_n in contours]
+    cluster_contours = [clusters[arr_n] for arr_n in clusters]
+    obj_hierarchy = hierachy['arr_0']
+    pcv.params.debug = None
+    output_path, imgs, masks = pcv.cluster_contour_splitimg_grayscale(img=img1, grouped_contour_indexes=cluster_contours,
+                                                            contours=roi_contours, hierarchy=obj_hierarchy, outdir=None,
+                                                            file=None,
+                                                            filenames=None)
+    assert len(output_path) != 0
+
+
 def test_plantcv_color_palette():
     # Return a color palette
     colors = pcv.color_palette(num=10, saved=False)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1707,27 +1707,27 @@ def test_plantcv_cluster_contours_splitimg():
     obj_hierarchy = hierachy['arr_0']
     # Test with debug = "print"
     pcv.params.debug = "print"
-    _, _, _ = pcv.cluster_contour_splitimg(rgb_img=img1, grouped_contour_indexes=cluster_contours,
+    _, _, _ = pcv.cluster_contour_splitimg(img=img1, grouped_contour_indexes=cluster_contours,
                                            contours=roi_contours,
                                            hierarchy=obj_hierarchy, outdir=cache_dir, file=None, filenames=None)
-    _, _, _ = pcv.cluster_contour_splitimg(rgb_img=img1, grouped_contour_indexes=[[0]], contours=[],
+    _, _, _ = pcv.cluster_contour_splitimg(img=img1, grouped_contour_indexes=[[0]], contours=[],
                                            hierarchy=np.array([[[1, -1, -1, -1]]]))
-    _, _, _ = pcv.cluster_contour_splitimg(rgb_img=img1, grouped_contour_indexes=cluster_contours,
+    _, _, _ = pcv.cluster_contour_splitimg(img=img1, grouped_contour_indexes=cluster_contours,
                                            contours=roi_contours,
                                            hierarchy=obj_hierarchy, outdir=cache_dir, file='multi', filenames=None)
 
     # Test with debug = "plot"
     pcv.params.debug = "plot"
-    _, _, _ = pcv.cluster_contour_splitimg(rgb_img=img1, grouped_contour_indexes=cluster_contours,
+    _, _, _ = pcv.cluster_contour_splitimg(img=img1, grouped_contour_indexes=cluster_contours,
                                            contours=roi_contours,
                                            hierarchy=obj_hierarchy, outdir=None, file=None, filenames=cluster_names)
-    _, _, _ = pcv.cluster_contour_splitimg(rgb_img=img1, grouped_contour_indexes=cluster_contours,
+    _, _, _ = pcv.cluster_contour_splitimg(img=img1, grouped_contour_indexes=cluster_contours,
                                            contours=roi_contours,
                                            hierarchy=obj_hierarchy, outdir=None, file=None,
                                            filenames=cluster_names_too_many)
     # Test with debug = None
     pcv.params.debug = None
-    output_path, imgs, masks = pcv.cluster_contour_splitimg(rgb_img=img1, grouped_contour_indexes=cluster_contours,
+    output_path, imgs, masks = pcv.cluster_contour_splitimg(img=img1, grouped_contour_indexes=cluster_contours,
                                                             contours=roi_contours, hierarchy=obj_hierarchy, outdir=None,
                                                             file=None,
                                                             filenames=None)


### PR DESCRIPTION
**Describe your changes**
Previously the splitimg() function did not take in non RGB images, which was changed.

**Type of update**
Is this a:
* New feature or feature enhancement
* Update to documentation

**Associated issues**
#700 

