### PR TITLE
Add method to Outputs class to save results in multiple formats

### DIFF
--- a/docs/Spectral_data.md
+++ b/docs/Spectral_data.md
@@ -77,4 +77,4 @@ print(str(spectral_data_instance.max_wavelength) + spectral_data_instance.wavele
 > 1000.95nm
 ```
 
-**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/__init__.py)
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/classes.py)

--- a/docs/hyperspectral_tutorial.md
+++ b/docs/hyperspectral_tutorial.md
@@ -254,7 +254,7 @@ Binary mask after [filtering objects by the region of interest](roi_objects.md) 
 
 ```python
     # Write shape and color data to results file
-    pcv.print_results(filename=args.result)
+    pcv.outputs.save_results(filename=args.result)
      
 if __name__ == '__main__':
     main()                                                          
@@ -343,7 +343,7 @@ def main():
     pcv.hyperspectral.analyze_index(array=index_array_gdvi, mask=kept_mask)
     
     # Write shape and color data to results file
-    pcv.print_results(filename=args.result)
+    pcv.outputs.save_results(filename=args.result)
     
 if __name__ == '__main__':
     main()

--- a/docs/jupyter.md
+++ b/docs/jupyter.md
@@ -202,7 +202,7 @@ def main():
     # Jupyter here
     
     # Print data that gets collected into the Outputs 
-    pcv.print_results(args.result)
+    pcv.outputs.save_results(filename=.result, outformat="json")
 
 if __name__ == '__main__':
     main()

--- a/docs/morphology_tutorial.md
+++ b/docs/morphology_tutorial.md
@@ -438,8 +438,7 @@ To deploy a workflow over a full image set please see tutorial on
 [workflow parallelization](pipeline_parallel.md).
 
 ```python
-    # Write shape and color data to results file
-    pcv.print_results(filename=args.result)
+    # Write all data to results file
     pcv.outputs.save_results(filename=args.result)
      
 if __name__ == '__main__':

--- a/docs/morphology_tutorial.md
+++ b/docs/morphology_tutorial.md
@@ -437,6 +437,15 @@ one object while the leaves remain separate.
 To deploy a workflow over a full image set please see tutorial on 
 [workflow parallelization](pipeline_parallel.md).
 
+```python
+    # Write shape and color data to results file
+    pcv.print_results(filename=args.result)
+    pcv.outputs.save_results(filename=args.result)
+     
+if __name__ == '__main__':
+    main()                                                          
+``` 
+
 ## Morphology Script 
 
 In the terminal:

--- a/docs/morphology_tutorial.md
+++ b/docs/morphology_tutorial.md
@@ -549,7 +549,7 @@ def main():
                                                           
                                                           
     # Write out data collected about angles and lengths                                                       
-    pcv.print_results(filename=args.result)
+    pcv.outputs.save_results(filename=args.result)
 
 if __name__ == '__main__':
     main()

--- a/docs/nir_tutorial.md
+++ b/docs/nir_tutorial.md
@@ -485,7 +485,7 @@ Now we can perform the [analysis of pixelwise signal value](analyze_NIR_intensit
     shape_imgs = pcv.analyze_object(img=img, obj=o, mask=m, label="default")
     
     # Write shape and nir data to results file
-    pcv.print_results(filename=args.result)
+    pcv.outputs.save_results(filename=args.result)
     
 # Call program
 if __name__ == '__main__':
@@ -645,7 +645,7 @@ def main():
     shape_imgs = pcv.analyze_object(img=img, obj=o, mask=m, label="default")
     
     # Write shape and nir data to results file
-    pcv.print_results(filename=args.result)
+    pcv.outputs.save_results(filename=args.result)
     
 # Call program
 if __name__ == '__main__':

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -27,16 +27,16 @@ functions:
 * `within_frame`
 * `watershed`
 
-An instance of `Outputs` is created on import automatically as `plantcv.outputs`. The function 
-[pcv.print_results](print_results.md) will print out all the stored measurment data to a text file. 
+An instance of `Outputs` is created on import automatically as `plantcv.outputs`. The method 
+`Outputs.save_results` will save all the stored measurement data to a text file. 
 
 ### Methods
 
 Methods are accessed as plantcv.outputs.*method*.
 
-**clear**: Clears the contents of both measurements and image 
+**clear**(): Clears the contents of both measurements and image 
 
-**add_observation**: Add new measurement or other information
+**add_observation**(*sample, variable, trait, method, scale, datatype, value, label*): Add new measurement or other information
 
 * sample: A sample name or label. Observations are organized by sample name.
 
@@ -47,6 +47,7 @@ Methods are accessed as plantcv.outputs.*method*.
 * method: A name of the measurement method mapped to an external ontology; if there is no exact mapping, an informative description of the measurement procedure.
 
 * scale: Units of the measurement or a scale in which the observations are expressed; if possible, standard units and scales should be used and mapped to existing ontologies; in case of a non-standard scale a full explanation should be given.
+
 * datatype: The type of data to be stored. In JSON, values must be one of the following data types:
     - a string
     - a number
@@ -67,6 +68,11 @@ Methods are accessed as plantcv.outputs.*method*.
 
 * label:  The label for each value, which will be useful when the data is a frequency table (e.g. hues). 
 
+**save_results**(*filename, outformat="json"*): Save results to a file
+
+* filename: Path and name of the output file
+
+* outformat: Output file format (default = "json"). Supports "json" and "csv" formats
 
 **Example use:**
     - [Use In VIS/NIR Tutorial](vis_nir_tutorial.md)
@@ -85,7 +91,7 @@ shape_img = pcv.analyze_object(img, obj, mask, label="default")
 plant_area = pcv.outputs.observations['default']['pixel_area']['value']
 
 # Write shape data to results file
-pcv.print_results(filename=args.result)
+pcv.outputs.save_results(filename=args.result, outformat="json")
 
 # Will will print out results again, so clear the outputs before running NIR analysis 
 pcv.outputs.clear()
@@ -96,7 +102,7 @@ nir_imgs = pcv.analyze_nir_intensity(nir2, nir_combinedmask, 256, label="default
 shape_img = pcv.analyze_object(nir2, nir_combined, nir_combinedmask, label="default")
 
 # Write the NIR and shape data to a file 
-pcv.print_results(filename=args.coresult)
+pcv.outputs.save_results(filename=args.coresult, outformat="json")
 
 ```
 
@@ -119,8 +125,8 @@ pcv.outputs.add_observation(sample='default', variable='percent_diseased',
                             value=percent_diseased, label='percent')
 
 # Write custom data to results file
-pcv.print_results(filename=args.result)
+pcv.outputs.save_results(filename=args.result, outformat="json")
 
 ```
 
-**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/__init__.py)
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/classes.py)

--- a/docs/params.md
+++ b/docs/params.md
@@ -80,4 +80,4 @@ roi_contour, roi_hierarchy = pcv.roi.rectangle(x=100, y=100, h=200, w=200, img=i
 
 ![Screenshot](img/documentation_images/params/thickness3.jpg)
 
-**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/__init__.py)
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/classes.py)

--- a/docs/print_results.md
+++ b/docs/print_results.md
@@ -1,5 +1,8 @@
 ## Print Measurement Results 
 
+!!! warning
+    `plantcv.print_results` is deprecated and will be removed in a future version.
+
 An [Outputs](outputs.md) class has been added that automatically stores measurements collected by the following 
 functions:
 

--- a/docs/psII_tutorial.md
+++ b/docs/psII_tutorial.md
@@ -231,7 +231,7 @@ The next step is to analyze the plant object for traits such as [shape](analyze_
     pseudocolored_img = pcv.visualize.pseudocolor(gray_img=fvfm_img, mask=cleaned_mask, cmap='jet')
 
     # Write shape and nir data to results file
-    pcv.print_results(filename=args.result)
+    pcv.outputs.save_results(filename=args.result)
 
 if __name__ == '__main__':
     main()
@@ -320,7 +320,7 @@ def main():
     pseudocolored_img = pcv.visualize.pseudocolor(gray_img=fvfm_img, mask=cleaned_mask, cmap='jet')
 
     # Write shape and fv/fm data to results file
-    pcv.print_results(filename=args.result)
+    pcv.outputs.save_results(filename=args.result)
 
 if __name__ == '__main__':
     main()

--- a/docs/roi_multi.md
+++ b/docs/roi_multi.md
@@ -91,7 +91,7 @@ for i in range(0, len(rois1)):
     filename = args.result[:-4] + "_" + str(i) + ".txt" 
     with open(filename, "w") as r:
         r.write(metadata)
-    pcv.print_results(filename=filename)
+    pcv.outputs.save_results(filename=filename)
     # Clear the measurements stored globally into the Outputs class
     pcv.outputs.clear()
     

--- a/docs/thermal_tutorial.md
+++ b/docs/thermal_tutorial.md
@@ -249,7 +249,7 @@ of customization since it is intended to just make figures.
                                            min_value=31, max_value=35)
                                            
     # Write shape and thermal data to results file
-    pcv.print_results(filename=args.result)
+    pcv.outputs.save_results(filename=args.result)
   
 if __name__ == '__main__':
     main()
@@ -396,7 +396,7 @@ def main():
                                            min_value=31, max_value=35)
                                            
     # Write shape and thermal data to results file
-    pcv.print_results(filename=args.result)
+    pcv.outputs.save_results(filename=args.result)
   
 if __name__ == '__main__':
     main()

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -515,6 +515,22 @@ pages for more details on the input and output variable types.
 * pre v3.0dev2: device, maskpath, analysis_images = **plantcv.output_mask**(*device, img, mask, filename, outdir=None, mask_only=False, debug=None*)
 * post v3.0dev2: imgpath, maskpath, analysis_images = **plantcv.output_mask**(*img, mask, filename, outdir=None, mask_only=False*)
 
+#### plantcv.outputs.add_observation
+
+* pre v3.3: NA
+* post v3.3: **plantcv.outputs.add_observation**(*variable, trait, method, scale, datatype, value, label*)
+* post v3.11: **plantcv.outputs.add_observation**(*sample, variable, trait, method, scale, datatype, value, label*)
+
+#### plantcv.outputs.clear
+
+* pre v3.2: NA
+* post v3.2: **plantcv.outputs.clear**()
+
+#### plantcv.outputs.save_results
+
+* pre v3.12: NA
+* post v3.12: **plantcv.outputs.save_results**(*filename, outformat="json"*)
+
 #### plantcv.photosynthesis.analyze_fvfm
 * pre v3.10: see plantcv.fluor_fvfm
 * post v3.10: analysis_images = **plantcv.photosynthesis.analyze_fvfm**(*fdark, fmin, fmax, mask, bins=256*)

--- a/docs/vis_nir_tutorial.md
+++ b/docs/vis_nir_tutorial.md
@@ -364,7 +364,7 @@ The next step is to analyze the plant object for traits such as [horizontal heig
     pseudocolored_img = pcv.visualize.pseudocolor(gray_img=s, mask=kept_mask, cmap='jet')
 
     # Write shape and color data to results file
-    pcv.print_results(filename=args.result)
+    pcv.outputs.save_results(filename=args.result)
     
     # Will will print out results again, so clear the outputs before running NIR analysis 
     pcv.outputs.clear()
@@ -576,7 +576,7 @@ def main():
     pseudocolored_img = pcv.visualize.pseudocolor(gray_img=s, mask=kept_mask, cmap='jet')
 
     # Write shape and color data to results file
-    pcv.print_results(filename=args.result)
+    pcv.outputs.save_results(filename=args.result)
     
     # Will will print out results again, so clear the outputs before running NIR analysis 
     pcv.outputs.clear()
@@ -608,7 +608,7 @@ def main():
     pcv.print_image(nir_shape_image, os.path.join(pcv.params.debug_outdir, 'shape.png'))
 
     # Save data to coresult file 
-    pcv.print_results(filename=args.coresult)
+    pcv.outputs.save_results(filename=args.coresult)
     
 if __name__ == '__main__':
   main()

--- a/docs/vis_nir_tutorial.md
+++ b/docs/vis_nir_tutorial.md
@@ -470,7 +470,7 @@ The next step is to [get the matching NIR](get_nir.md) image, [resize](transform
 Write co-result data out to a file.
 
 ```python
-    pcv.print_result(filename=args.coresult)
+    pcv.outputs.save_results(filename=args.coresult)
     
 if __name__ == '__main__':
     main()

--- a/docs/vis_tutorial.md
+++ b/docs/vis_tutorial.md
@@ -424,7 +424,7 @@ The next step is to analyze the plant object for traits such as [horizontal heig
     pseudocolored_img = pcv.visualize.pseudocolor(gray_img=s, mask=mask, cmap='jet')
 
     # Write shape and color data to results file
-    pcv.print_results(filename=args.result)
+    pcv.outputs.save_results(filename=args.result)
   
 if __name__ == '__main__':
     main()
@@ -605,7 +605,7 @@ def main():
     pseudocolored_img = pcv.visualize.pseudocolor(gray_img=s, mask=mask, cmap='jet')
 
     # Write shape and color data to results file
-    pcv.print_results(filename=args.result)
+    pcv.outputs.save_results(filename=args.result)
 
 if __name__ == '__main__':
     main()

--- a/docs/watershed.md
+++ b/docs/watershed.md
@@ -17,7 +17,7 @@ Needs a mask file which specifies area which is object is white, and background 
 - **Context:**
     - Used to segment image into parts
     - Data automatically gets stored into the [Outputs class](outputs.md). Users can look at the data collected at any point during 
-    the workflow by using [pcv.print_results](print_results.md) which prints all stored data to a .json file.
+    the workflow by using [pcv.outputs.save_results](outputs.md) which saves all stored data to a .json file.
 - **Output data stored:** Data ('estimated_object_count') automatically gets stored to the [`Outputs` class](outputs.md) when this function is ran. 
     These data can always get accessed during a workflow (example below). For more detail about data output see [Summary of Output Observations](output_measurements.md#summary-of-output-observations)
 

--- a/plantcv/plantcv/analyze_object.py
+++ b/plantcv/plantcv/analyze_object.py
@@ -180,7 +180,7 @@ def analyze_object(img, obj, mask, label="default"):
                             value=caliper_length, label='pixels')
     outputs.add_observation(sample=label, variable='center_of_mass', trait='center of mass',
                             method='plantcv.plantcv.analyze_object', scale='none', datatype=tuple,
-                            value=(cmx, cmy), label='none')
+                            value=(cmx, cmy), label=("x", "y"))
     outputs.add_observation(sample=label, variable='convex_hull_vertices', trait='convex hull vertices',
                             method='plantcv.plantcv.analyze_object', scale='none', datatype=int,
                             value=hull_vertices, label='none')
@@ -189,7 +189,7 @@ def analyze_object(img, obj, mask, label="default"):
                             value=in_bounds, label='none')
     outputs.add_observation(sample=label, variable='ellipse_center', trait='ellipse center',
                             method='plantcv.plantcv.analyze_object', scale='none', datatype=tuple,
-                            value=(center[0], center[1]), label='none')
+                            value=(center[0], center[1]), label=("x", "y"))
     outputs.add_observation(sample=label, variable='ellipse_major_axis', trait='ellipse major axis length',
                             method='plantcv.plantcv.analyze_object', scale='pixels', datatype=int,
                             value=major_axis_length, label='pixels')

--- a/plantcv/plantcv/print_results.py
+++ b/plantcv/plantcv/print_results.py
@@ -1,7 +1,5 @@
 # Print Numerical Data
 
-import json
-import os
 from plantcv.plantcv import outputs
 
 
@@ -14,13 +12,7 @@ def print_results(filename):
     :param filename: str
     :return:
     """
-
-    if os.path.isfile(filename):
-        with open(filename, 'r') as f:
-            hierarchical_data = json.load(f)
-            hierarchical_data["observations"] = outputs.observations
-    else:
-        hierarchical_data = {"metadata": {}, "observations": outputs.observations}
-
-    with open(filename, mode='w') as f:
-        json.dump(hierarchical_data, f)
+    print("""Deprecation warning: plantcv.print_results will be removed in a future version.
+             Please use plantcv.outputs.save_results instead.
+          """)
+    outputs.save_results(filename=filename, outformat="json")

--- a/tests/data/data_results.csv
+++ b/tests/data/data_results.csv
@@ -1,0 +1,8 @@
+sample,trait,value,label
+default,string,string,none
+default,boolean,1,none
+default,list,1,1
+default,list,2,2
+default,list,3,3
+default,tuple,1,1
+default,tuple,2,2

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1124,9 +1124,6 @@ def test_plantcv_analyze_bound_horizontal():
     # Test with debug = None
     pcv.params.debug = None
     _ = pcv.analyze_bound_horizontal(img=img, obj=object_contours, mask=mask, line_position=1756)
-    # Copy a test file to the cache directory
-    shutil.copyfile(os.path.join(TEST_DATA, "data_results.txt"), os.path.join(cache_dir, "data_results.txt"))
-    pcv.print_results(os.path.join(cache_dir, "data_results.txt"))
     assert len(pcv.outputs.observations["default"]) == 7
 
 
@@ -1159,8 +1156,6 @@ def test_plantcv_analyze_bound_horizontal_neg_y():
     _ = pcv.analyze_bound_horizontal(img=img, obj=object_contours, mask=mask, line_position=-1000)
     _ = pcv.analyze_bound_horizontal(img=img, obj=object_contours, mask=mask, line_position=0)
     _ = pcv.analyze_bound_horizontal(img=img, obj=object_contours, mask=mask, line_position=2056)
-    shutil.copyfile(os.path.join(TEST_DATA, "data_results.txt"), os.path.join(cache_dir, "data_results.txt"))
-    pcv.print_results(os.path.join(cache_dir, "data_results.txt"))
     assert pcv.outputs.observations['default']['height_above_reference']['value'] == 713
 
 
@@ -1185,7 +1180,6 @@ def test_plantcv_analyze_bound_vertical():
     # Test with debug = None
     pcv.params.debug = None
     _ = pcv.analyze_bound_vertical(img=img, obj=object_contours, mask=mask, line_position=1000)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     assert pcv.outputs.observations['default']['width_left_reference']['value'] == 94
 
 
@@ -1202,7 +1196,6 @@ def test_plantcv_analyze_bound_vertical_grayscale_image():
     # Test with a grayscale reference image and debug="plot"
     pcv.params.debug = "plot"
     _ = pcv.analyze_bound_vertical(img=img, obj=object_contours, mask=mask, line_position=1000)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     assert pcv.outputs.observations['default']['width_left_reference']['value'] == 94
     pcv.outputs.clear()
 
@@ -1222,7 +1215,6 @@ def test_plantcv_analyze_bound_vertical_neg_x():
     # Test with debug="plot", line position that will trigger -x
     pcv.params.debug = "plot"
     _ = pcv.analyze_bound_vertical(img=img, obj=object_contours, mask=mask, line_position=2454)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     assert pcv.outputs.observations['default']['width_left_reference']['value'] == 441
 
 
@@ -1241,7 +1233,6 @@ def test_plantcv_analyze_bound_vertical_small_x():
     # Test with debug='plot', line position that will trigger -x, and two channel object
     pcv.params.debug = "plot"
     _ = pcv.analyze_bound_vertical(img=img, obj=object_contours, mask=mask, line_position=1)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     assert pcv.outputs.observations['default']['width_right_reference']['value'] == 441
 
 
@@ -1311,7 +1302,6 @@ def test_plantcv_analyze_nir():
     # Test with debug = None
     pcv.params.debug = None
     _ = pcv.analyze_nir_intensity(gray_img=img, mask=mask, bins=256, histplot=True)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     result = len(pcv.outputs.observations['default']['nir_frequencies']['value'])
     assert result == 256
 
@@ -1426,7 +1416,6 @@ def test_plantcv_analyze_thermal_values():
     _ = pcv.analyze_thermal_values(thermal_array=img, mask=mask, histplot=True, label="prefix")
     pcv.params.debug = "plot"
     thermal_hist = pcv.analyze_thermal_values(thermal_array=img, mask=mask, histplot=True)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     assert thermal_hist is not None and pcv.outputs.observations['default']['median_temp']['value'] == 33.20922
 
 
@@ -2304,7 +2293,6 @@ def test_plantcv_landmark_reference_pt_dist():
     _ = pcv.landmark_reference_pt_dist(points_r=[], centroid_r=(0, 0), bline_r=(0, 0))
     _ = pcv.landmark_reference_pt_dist(points_r=points_rescaled, centroid_r=centroid_rescaled,
                                        bline_r=bottomline_rescaled, label="prefix")
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     assert len(pcv.outputs.observations['prefix'].keys()) == 8
 
 
@@ -2898,7 +2886,6 @@ def test_plantcv_report_size_marker_detect():
     pcv.params.debug = None
     images = pcv.report_size_marker_area(img=img, roi_contour=roi_contour, roi_hierarchy=roi_hierarchy, marker='detect',
                                          objcolor='light', thresh_channel='s', thresh=120)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     pcv.outputs.clear()
     assert len(images) != 0
 
@@ -3309,7 +3296,6 @@ def test_plantcv_watershed_segmentation():
     # Test with debug = None
     pcv.params.debug = None
     _ = pcv.watershed_segmentation(rgb_img=img, mask=mask, distance=10)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     assert pcv.outputs.observations['default']['estimated_object_count']['value'] > 9
 
 
@@ -3432,7 +3418,6 @@ def test_plantcv_x_axis_pseudolandmarks():
     # Test with debug = None
     pcv.params.debug = None
     top, bottom, center_v = pcv.x_axis_pseudolandmarks(obj=obj_contour, mask=mask, img=img)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     pcv.outputs.clear()
     assert all([all([i == j] for i, j in zip(np.shape(top), (20, 1, 2))),
                 all([i == j] for i, j in zip(np.shape(bottom), (20, 1, 2))),
@@ -3496,7 +3481,6 @@ def test_plantcv_y_axis_pseudolandmarks():
     # Test with debug = None
     pcv.params.debug = None
     left, right, center_h = pcv.y_axis_pseudolandmarks(obj=obj_contour, mask=mask, img=img)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     pcv.outputs.clear()
     assert all([all([i == j] for i, j in zip(np.shape(left), (20, 1, 2))),
                 all([i == j] for i, j in zip(np.shape(right), (20, 1, 2))),
@@ -3518,7 +3502,6 @@ def test_plantcv_y_axis_pseudolandmarks_small_obj():
     pcv.params.debug = "plot"
     pcv.outputs.clear()
     left, right, center_h = pcv.y_axis_pseudolandmarks(obj=obj_contour, mask=mask, img=img)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     pcv.outputs.clear()
     assert all([all([i == j] for i, j in zip(np.shape(left), (20, 1, 2))),
                 all([i == j] for i, j in zip(np.shape(right), (20, 1, 2))),
@@ -3533,7 +3516,6 @@ def test_plantcv_y_axis_pseudolandmarks_bad_input():
     obj_contour = np.array([])
     pcv.params.debug = None
     result = pcv.y_axis_pseudolandmarks(obj=obj_contour, mask=mask, img=img)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     pcv.outputs.clear()
     assert all([i == j] for i, j in zip(result, [("NA", "NA"), ("NA", "NA"), ("NA", "NA")]))
 
@@ -3687,7 +3669,6 @@ def test_plantcv_morphology_segment_curvature():
     pcv.params.debug = "plot"
     pcv.outputs.clear()
     _ = pcv.morphology.segment_curvature(segmented_img, seg_objects)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     assert len(pcv.outputs.observations['default']['segment_curvature']['value']) == 22
 
 
@@ -3705,7 +3686,6 @@ def test_plantcv_morphology_check_cycles():
     _ = pcv.morphology.check_cycles(mask)
     pcv.params.debug = None
     _ = pcv.morphology.check_cycles(mask)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     assert pcv.outputs.observations['default']['num_cycles']['value'] == 1
 
 
@@ -3806,7 +3786,6 @@ def test_plantcv_morphology_fill_segments():
     _ = pcv.morphology.fill_segments(mask, obj, label="prefix")
     pcv.params.debug = "plot"
     _ = pcv.morphology.fill_segments(mask, obj)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     tests = [pcv.outputs.observations['default']['segment_area']['value'][42] == 5529,
              pcv.outputs.observations['default']['segment_area']['value'][20] == 5057,
              pcv.outputs.observations['default']['segment_area']['value'][49] == 3323]
@@ -3829,7 +3808,6 @@ def test_plantcv_morphology_fill_segments_with_stem():
     stem_obj = obj[0:4]
     pcv.params.debug = "print"
     _ = pcv.morphology.fill_segments(mask, obj, stem_obj)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     num_objects = len(pcv.outputs.observations['default']['leaf_area']['value'])
     assert num_objects == 70
 
@@ -3847,7 +3825,6 @@ def test_plantcv_morphology_segment_angle():
     _ = pcv.morphology.segment_angle(segmented_img=segmented_img, objects=segment_objects, label="prefix")
     pcv.params.debug = "plot"
     _ = pcv.morphology.segment_angle(segmented_img, segment_objects)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     assert len(pcv.outputs.observations['default']['segment_angle']['value']) == 22
 
 
@@ -3878,7 +3855,6 @@ def test_plantcv_morphology_segment_euclidean_length():
     _ = pcv.morphology.segment_euclidean_length(segmented_img, segment_objects, label="prefix")
     pcv.params.debug = "plot"
     _ = pcv.morphology.segment_euclidean_length(segmented_img, segment_objects)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     assert len(pcv.outputs.observations['default']['segment_eu_length']['value']) == 22
 
 
@@ -3904,7 +3880,6 @@ def test_plantcv_morphology_segment_path_length():
     _ = pcv.morphology.segment_path_length(segmented_img, segment_objects, label="prefix")
     pcv.params.debug = "plot"
     _ = pcv.morphology.segment_path_length(segmented_img, segment_objects)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     assert len(pcv.outputs.observations['default']['segment_path_length']['value']) == 22
 
 
@@ -3953,7 +3928,6 @@ def test_plantcv_morphology_segment_tangent_angle():
     _ = pcv.morphology.segment_tangent_angle(skel, objs, 2, label="prefix")
     pcv.params.debug = "plot"
     _ = pcv.morphology.segment_tangent_angle(skel, objs, 2)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     assert len(pcv.outputs.observations['default']['segment_tangent_angle']['value']) == 73
 
 
@@ -3987,7 +3961,6 @@ def test_plantcv_morphology_segment_insertion_angle():
     _ = pcv.morphology.segment_insertion_angle(pruned, segmented_img, leaf_obj, stem_obj, 3, label="prefix")
     pcv.params.debug = "print"
     _ = pcv.morphology.segment_insertion_angle(pruned, segmented_img, leaf_obj, stem_obj, 10)
-    pcv.print_results(os.path.join(cache_dir, "results.txt"))
     assert pcv.outputs.observations['default']['segment_insertion_angle']['value'][:6] == ['NA', 'NA', 'NA',
                                                                                         24.956918822001636,
                                                                                         50.7313343343401,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -978,6 +978,60 @@ def test_plantcv_outputs_add_observation_invalid_type():
                                 datatype=list, value=np.array([2]), label=[])
 
 
+def test_plantcv_outputs_save_results_json_newfile(tmpdir):
+    # Create a test tmp directory
+    cache_dir = tmpdir.mkdir("sub")
+    outfile = os.path.join(cache_dir, "results.json")
+    # Create output instance
+    outputs = pcv.Outputs()
+    outputs.add_observation(sample='default', variable='test', trait='test variable', method='test', scale='none',
+                            datatype=str, value="test", label="none")
+    outputs.save_results(filename=outfile, outformat="json")
+    with open(outfile, "r") as fp:
+        results = json.load(fp)
+        assert results["observations"]["default"]["test"]["value"] == "test"
+
+
+def test_plantcv_outputs_save_results_json_existing_file(tmpdir):
+    # Create a test tmp directory
+    cache_dir = tmpdir.mkdir("sub")
+    outfile = os.path.join(cache_dir, "data_results.txt")
+    shutil.copyfile(os.path.join(TEST_DATA, "data_results.txt"), outfile)
+    # Create output instance
+    outputs = pcv.Outputs()
+    outputs.add_observation(sample='default', variable='test', trait='test variable', method='test', scale='none',
+                            datatype=str, value="test", label="none")
+    outputs.save_results(filename=outfile, outformat="json")
+    with open(outfile, "r") as fp:
+        results = json.load(fp)
+        assert results["observations"]["default"]["test"]["value"] == "test"
+
+
+def test_plantcv_outputs_save_results_csv(tmpdir):
+    # Create a test tmp directory
+    cache_dir = tmpdir.mkdir("sub")
+    outfile = os.path.join(cache_dir, "results.csv")
+    testfile = os.path.join(TEST_DATA, "data_results.csv")
+    # Create output instance
+    outputs = pcv.Outputs()
+    outputs.add_observation(sample='default', variable='string', trait='string variable', method='string', scale='none',
+                            datatype=str, value="string", label="none")
+    outputs.add_observation(sample='default', variable='boolean', trait='boolean variable', method='boolean',
+                            scale='none', datatype=bool, value=True, label="none")
+    outputs.add_observation(sample='default', variable='list', trait='list variable', method='list',
+                            scale='none', datatype=list, value=[1, 2, 3], label=[1, 2, 3])
+    outputs.add_observation(sample='default', variable='tuple', trait='tuple variable', method='tuple',
+                            scale='none', datatype=tuple, value=(1, 2), label=(1, 2))
+    outputs.add_observation(sample='default', variable='tuple_list', trait='list of tuples variable',
+                            method='tuple_list', scale='none', datatype=list, value=[(1, 2), (3, 4)], label=[1, 2])
+    outputs.save_results(filename=outfile, outformat="csv")
+    with open(outfile, "r") as fp:
+        results = fp.read()
+    with open(testfile, "r") as fp:
+        test_results = fp.read()
+    assert results == test_results
+
+
 def test_plantcv_transform_warp_smaller():
     img = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_COLOR),-1)
     bimg = cv2.imread(os.path.join(TEST_DATA, TEST_INPUT_BINARY),-1)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2660,6 +2660,14 @@ def test_plantcv_print_image_plotnine():
     assert os.path.exists(filename) is True
 
 
+def test_plantcv_print_results(tmpdir):
+    # Create a tmp directory
+    cache_dir = tmpdir.mkdir("sub")
+    outfile = os.path.join(cache_dir, "results.json")
+    pcv.print_results(filename=outfile)
+    assert os.path.exists(outfile)
+
+
 def test_plantcv_readimage_native():
     # Test with debug = None
     pcv.params.debug = None


### PR DESCRIPTION
**Describe your changes**
As discussed in #689, this PR adds a new method (`save_results`) to the `Outputs` class. `Outputs.save_results` supports two output formats, JSON and CSV. The code from `plantcv.print_results` was moved to the `save_results` method and a deprecation warning is now printed via `print_results`. When run with `outformat = "json"`, `Outputs.save_results` has the same functionality as `plantcv.print_results`. When run with `outformat = "csv"`, a single CSV table in "long" format is produced that is compatible with use in R. CSV format is useful for a user who runs workflows only in Jupyter or wants to utilize data for testing from Jupyter. The output format JSON must be used for parallel workflows as before.

If we adopt this change, users will need to migrate workflows from `pcv.print_results(args.result)` to `pcv.outputs.save_results(args.result)` before `pcv.print_results` is removed.

**Type of update**
Is this a: New feature or feature enhancement

**Associated issues**
#688

