### PR TITLE
Update random sample method

### DIFF
--- a/plantcv/utils/sample_images.py
+++ b/plantcv/utils/sample_images.py
@@ -6,7 +6,7 @@ from plantcv.plantcv import fatal_error
 
 def sample_images(source_path, dest_path, num=100):
     if not os.path.exists(source_path):
-        raise IOError("Directory does not exist: {0}".format(source_path))
+        raise IOError(f"Directory does not exist: {source_path}")
 
     if not os.path.exists(dest_path):
         os.makedirs(dest_path)  # exist_ok argument does not exist in python 2
@@ -31,8 +31,7 @@ def sample_images(source_path, dest_path, num=100):
 
         # Check to make sure number of imgs to select is less than number of images found
         if num > len(line_array):
-            fatal_error("Number of images found ({0}) less than 'num'.".
-                            format(len(line_array)))
+            fatal_error(f"Number of images found ({len(line_array)}) less than 'num'.")
 
         for i in range(0, num):
             r = random.randint(0, len(line_array) - 1)
@@ -62,8 +61,7 @@ def sample_images(source_path, dest_path, num=100):
 
         # Check to make sure number of imgs to select is less than number of images found
         if num > len(img_element_array):
-            fatal_error("Number of images found ({0}) less than 'num'.".
-                            format(len(img_element_array)))
+            fatal_error(f"Number of images found ({len(img_element_array)}) less than 'num'.")
 
         # Get random images
         for i in range(0, num):

--- a/plantcv/utils/sample_images.py
+++ b/plantcv/utils/sample_images.py
@@ -36,11 +36,12 @@ def sample_images(source_path, dest_path, num=100):
         out_file.write(header)
 
         # Get random snapshots
-        random_index = random.sample(range(0, len(line_array)), num)
+        random_index = random.sample(range(0, len(line_array) - 1), num)
         for i in random_index:
-            out_file.write(','.join(line_array[i]))
-            snap_path = os.path.join(source_path, "snapshot" + line_array[i][1])
-            folder_path = os.path.join(dest_path, "snapshot" + line_array[i][1])
+            row = line_array[int(i)]
+            out_file.write(','.join(row))
+            snap_path = os.path.join(source_path, "snapshot" + row[1])
+            folder_path = os.path.join(dest_path, "snapshot" + row[1])
             if not os.path.exists(folder_path):
                 os.mkdir(folder_path)  # the beginning of folder_path (dest_path) already exists from above
             for root, dirs, files in os.walk(snap_path):
@@ -62,4 +63,4 @@ def sample_images(source_path, dest_path, num=100):
         random_index = random.sample(range(0, len(img_element_array) - 1), num)
         # Copy images over to destination
         for i in random_index:
-            shutil.copy(img_element_array[i], dest_path)
+            shutil.copy(img_element_array[int(i)], dest_path)

--- a/plantcv/utils/sample_images.py
+++ b/plantcv/utils/sample_images.py
@@ -12,8 +12,6 @@ def sample_images(source_path, dest_path, num=100):
         os.makedirs(dest_path)  # exist_ok argument does not exist in python 2
 
     img_element_array = []
-    sample_array = []
-    num_images = []
     img_extensions = ['.png', '.jpg', '.jpeg', '.tif', '.tiff', '.gif']
 
     # If SnapshotInfo exists then need to make a new csv for the random image sample
@@ -33,19 +31,16 @@ def sample_images(source_path, dest_path, num=100):
         if num > len(line_array):
             fatal_error(f"Number of images found ({len(line_array)}) less than 'num'.")
 
-        for i in range(0, num):
-            r = random.randint(0, len(line_array) - 1)
-            while r in num_images:
-                r = random.randint(0, len(line_array) - 1)
-            sample_array.append(line_array[r])
-            num_images.append(r)
-
+        # Create SnapshotInfo file
         out_file = open(os.path.join(dest_path, 'SnapshotInfo.csv'), 'w')
         out_file.write(header)
-        for element in sample_array:
-            out_file.write(','.join(element))
-            snap_path = os.path.join(source_path, "snapshot" + element[1])
-            folder_path = os.path.join(dest_path, "snapshot" + element[1])
+
+        # Get random snapshots
+        random_index = random.sample(range(0, len(line_array)), num)
+        for i in random_index:
+            out_file.write(','.join(line_array[i]))
+            snap_path = os.path.join(source_path, "snapshot" + line_array[i][1])
+            folder_path = os.path.join(dest_path, "snapshot" + line_array[i][1])
             if not os.path.exists(folder_path):
                 os.mkdir(folder_path)  # the beginning of folder_path (dest_path) already exists from above
             for root, dirs, files in os.walk(snap_path):
@@ -64,13 +59,7 @@ def sample_images(source_path, dest_path, num=100):
             fatal_error(f"Number of images found ({len(img_element_array)}) less than 'num'.")
 
         # Get random images
-        for i in range(0, num):
-            r = random.randint(0, len(img_element_array) - 1)
-            while r in num_images:
-                r = random.randint(0, len(img_element_array) - 1)
-            sample_array.append(img_element_array[r])
-            num_images.append(r)
-
+        random_index = random.sample(range(0, len(img_element_array) - 1), num)
         # Copy images over to destination
-        for element in sample_array:
-            shutil.copy(element, dest_path)
+        for i in random_index:
+            shutil.copy(img_element_array[i], dest_path)

--- a/plantcv/utils/sample_images.py
+++ b/plantcv/utils/sample_images.py
@@ -57,7 +57,7 @@ def sample_images(source_path, dest_path, num=100):
                 # Check file type so that only images get copied over
                 name, ext = os.path.splitext(file)
                 if ext.lower() in img_extensions:
-                    img_element_array.append(os.path.join(root,file))
+                    img_element_array.append(os.path.join(root, file))
 
         # Check to make sure number of imgs to select is less than number of images found
         if num > len(img_element_array):


### PR DESCRIPTION
**Describe your changes**
The coverage report for the current version of `pcv.utils.sample_images` sometimes loses coverage on a line based on whether or not a random integer is chosen twice by chance. This PR updates the random sampling method to choose a range of random array indices using the `random.sample` approach to choose `num` random indices without replacement in one selection instead of in a loop. This should stabilize coverage.

**Type of update**
Is this a:
* Feature enhancement

