### PR TITLE
Use colour-science package for wavelength conversion

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - dask-jobqueue
   - nb_conda
   - opencv<4, >=3.4
+  - colour-science
 channels:
   - conda-forge
   - defaults

--- a/plantcv/plantcv/visualize/hyper_histogram.py
+++ b/plantcv/plantcv/visualize/hyper_histogram.py
@@ -5,87 +5,11 @@ import numpy as np
 import pandas as pd
 from plantcv.plantcv._debug import _debug
 from plantcv.plantcv import fatal_error, params, color_palette
-from plotnine import ggplot, aes, geom_line, scale_color_manual
+from plotnine import ggplot, aes, geom_line, scale_color_manual, theme_classic
 from plantcv.plantcv.visualize import histogram
 from plantcv.plantcv.hyperspectral import _find_closest
 from scipy.spatial import distance
-
-'''
-    == A few notes about color ==
-
-    Color   Wavelength(nm) Frequency(THz)
-    Red     620-750        484-400
-    Orange  590-620        508-484
-    Yellow  570-590        526-508
-    Green   495-570        606-526
-    Blue    450-495        668-606
-    Violet  380-450        789-668
-
-    f is frequency (cycles per second)
-    l (lambda) is wavelength (meters per cycle)
-    e is energy (Joules)
-    h (Plank's constant) = 6.6260695729 x 10^-34 Joule*seconds
-                         = 6.6260695729 x 10^-34 m^2*kg/seconds
-    c = 299792458 meters per second
-    f = c/l
-    l = c/f
-    e = h*f
-    e = c*h/l
-
-    List of peak frequency responses for each type of 
-    photoreceptor cell in the human eye:
-        S cone: 437 nm
-        M cone: 533 nm
-        L cone: 564 nm
-        rod:    550 nm in bright daylight, 498 nm when dark adapted. 
-                Rods adapt to low light conditions by becoming more sensitive.
-                Peak frequency response shifts to 498 nm.
-'''
-
-
-def _wavelength_to_rgb(wavelength, gamma=0.8):
-    """
-    reference: "Wavelength to RGB in Python." Noah.org, . 20 Sep 2014, 06:38 UTC. 1 Apr 2021, 19:06
-    <https://www.noah.org/mediawiki-1.34.2/index.php?title=Wavelength_to_RGB_in_Python&oldid=7665>.
-    http://www.noah.org/wiki/Wavelength_to_RGB_in_Python
-
-    This converts a given wavelength of light to an approximate RGB color value. The wavelength must be given in
-    nanometers in the range from 380 nm through 750 nm (789 THz through 400 THz).
-
-    Based on code by Dan Bruton
-    http://www.physics.sfasu.edu/astro/color/spectra.html
-
-    Inputs:
-    wavelength: wavelength of a visible wavelength in nanometers range: (380, 750)
-    gamma: (optional) gamma correction. default value = 0.8
-
-    Returns
-    :param wavelength: float
-    :param gamma: (optional) float
-    :return: tuple
-    """
-
-    wavelength = float(wavelength)
-    if 380 <= wavelength <= 440:
-        attenuation = 0.3 + 0.7 * (wavelength - 380) / (440 - 380)
-        r, g, b = ((-(wavelength - 440) / (440 - 380)) * attenuation) ** gamma, 0.0, (1.0 * attenuation) ** gamma
-    elif 440 <= wavelength <= 490:
-        r, g, b = 0.0, ((wavelength - 440) / (490 - 440)) ** gamma, 1.0
-    elif 490 <= wavelength <= 510:
-        r, g, b = 0.0, 1.0, (-(wavelength - 510) / (510 - 490)) ** gamma
-    elif 510 <= wavelength <= 580:
-        r, g, b = ((wavelength - 510) / (580 - 510)) ** gamma, 1.0, 0.0
-    elif 580 <= wavelength <= 645:
-        r, g, b = 1.0, (-(wavelength - 645) / (645 - 580)) ** gamma, 0.0
-    elif 645 <= wavelength <= 750:
-        attenuation = 0.3 + 0.7 * (750 - wavelength) / (750 - 645)
-        r, g, b = (1.0 * attenuation) ** gamma, 0.0, 0.0
-    # else:
-    #     R, G, B = 0.0, 0.0, 0.0
-    r *= 255
-    g *= 255
-    b *= 255
-    return int(r), int(g), int(b)
+import colour
 
 
 def _rgb_to_webcode(rgb_values):
@@ -146,9 +70,9 @@ def hyper_histogram(array, mask=None, bins=100, lower_bound=None, upper_bound=No
     match_ids = [_find_closest(wls, wv) for wv in wvlengths]
 
     # check if in the visible wavelengths range
-    ids_vis = [idx for (idx, wv) in enumerate(wvlengths) if 380 <= wv <= 750]
+    ids_vis = [idx for (idx, wv) in enumerate(wvlengths) if 390 <= wv <= 830]
     # invisible wavelengths
-    ids_inv = [idx for (idx, wv) in enumerate(wvlengths) if wv < 380 or wv > 750]
+    ids_inv = [idx for (idx, wv) in enumerate(wvlengths) if wv < 390 or wv > 830]
 
     colors = [tuple(x) for x in color_palette(len(wvlengths))]
     if len(ids_vis) < len(wvlengths):
@@ -158,9 +82,26 @@ def hyper_histogram(array, mask=None, bins=100, lower_bound=None, upper_bound=No
     if len(ids_inv) < len(wvlengths):
         colors_vis = []
         colors_inv = colors
+
+        # Color matching function
+        cmfs = colour.MSDS_CMFS["CIE 2012 10 Degree Standard Observer"]
+        matrix = np.array([[3.24062548, -1.53720797, -0.49862860],
+                           [-0.96893071, 1.87575606, 0.04151752],
+                           [0.05571012, -0.20402105, 1.05699594]]
+                          )
         for i in ids_vis:
             # colors_vis.append(_wavelength_to_rgb(wvlengths[i], gamma=0.8))
-            color_vis = _wavelength_to_rgb(wvlengths[i], gamma=0.8)
+            # color_vis = _wavelength_to_rgb(wvlengths[i], gamma=0.8)
+            # Convert wavelength to RGB
+            rgb = colour.XYZ_to_RGB(colour.wavelength_to_XYZ(wvlengths[i], cmfs),
+                                    illuminant_XYZ=np.array([0.9, 0.9]),
+                                    illuminant_RGB=np.array([0.9, 0.9]),
+                                    chromatic_adaptation_transform="Bradford",
+                                    matrix_XYZ_to_RGB=matrix)
+            # Set negative values to zero before scaling
+            rgb[np.where(rgb < 0)] = 0
+            # Convert float RGB to 8-bit unsigned integer
+            color_vis = colour.io.convert_bit_depth(rgb, "uint8")
             colors_vis.append(color_vis)
         # calculate the distances between every pair of (R,G,B) colors
         dists = distance.cdist(colors_vis, colors_inv, 'euclidean')
@@ -205,7 +146,8 @@ def hyper_histogram(array, mask=None, bins=100, lower_bound=None, upper_bound=No
     fig_hist = (ggplot(df_hist, aes(x='reflectance', y='proportion of pixels (%)',
                                     color='Wavelength (' + array.wavelength_units + ')'))
                 + geom_line()
-                + scale_color_manual(color_codes)
+                + scale_color_manual(color_codes, expand=(0, 0))
+                + theme_classic()
                 )
     params.debug = debug
     _debug(fig_hist, filename=os.path.join(params.debug_outdir, str(params.device) + '_histogram.png'))

--- a/plantcv/plantcv/visualize/hyper_histogram.py
+++ b/plantcv/plantcv/visualize/hyper_histogram.py
@@ -1,6 +1,7 @@
 # Help visualize histograms for hyperspectral images
 
 import os
+import sys
 import numpy as np
 import pandas as pd
 from plantcv.plantcv._debug import _debug
@@ -13,9 +14,17 @@ import colour
 
 
 def _rgb_to_webcode(rgb_values):
+    """Convert (R,G,B) colors to web color codes (HTML color codes)
+    Input:
+    rgb_values = a tuple of RGB values
+
+    Return:
+    webcode    = corresponding web color code (starts with #, e.g. #00FF00)
+
+    :param rgb_values: tuple
+    :return: webcode: str
     """
-    RGB_value: a tuple of RGB values (0~255, uint8)
-    """
+
     webcode = "#"
     for value in rgb_values:
         code_ = hex(value).replace('0x', '')
@@ -27,14 +36,21 @@ def _rgb_to_webcode(rgb_values):
 def hyper_histogram(array, mask=None, bins=100, lower_bound=None, upper_bound=None,
                     title=None, wvlengths=[480, 550, 670]):
     """This function calculates the histogram of selected wavelengths hyperspectral images
-    The color of the histogram is based on the wavelength: if the wavelength is in the range of visible spectrum
+    The color of the histograms are based on the wavelength if the wavelength is in the range of visible spectrum;
+    otherwise, random colors are assigned
+
     Inputs:
     array        = Hyperspectral data instance
-    mask         = Binary mask made from selected contours
-    wvlengths    = (optional) list of wavelengths to show histograms. default = [480,550,670]
+    mask         = binary mask, if provided, calculate histogram from masked area only (default=None)
+    bins         = divide the data into n evenly spaced bins (default=100)
+    lower_bound  = the lower bound of the bins (x-axis min value) (default=None)
+    upper_bound  = the upper bound of the bins (x-axis max value) (default=None)
+    title        = a custom title for the plot (default=None)
+    wvlengths    = (optional) list of wavelengths to show histograms (default = [480,550,670],  i.e. only show
+                                                                    histograms for blue, green, and red bands)
 
     Returns:
-    fig_hist = histogram figure
+    fig_hist      = histogram figure
 
     :param array: plantcv.plantcv.classes.Spectral_data
     :param mask: numpy.ndarray
@@ -46,39 +62,40 @@ def hyper_histogram(array, mask=None, bins=100, lower_bound=None, upper_bound=No
     :return fig_hist: plotnine.ggplot.ggplot
     """
 
-    # always sort desired wavelengths
+    # Always sort desired wavelengths
     wvlengths.sort()
 
+    # Available wavelengths of the spectral data
     wl_keys = array.wavelength_dict.keys()
     wls = np.array([float(i) for i in wl_keys])
 
-    # spectral resolution of the spectral data
+    # Spectral resolution of the spectral data
     diffs = [wls[i] - wls[i - 1] for i in range(1, len(wls))]
     spc_res = sum(diffs) / len(diffs)
 
-    # check if the distance is greater than 2x the spectral resolution
+    # Check if the distance is greater than 2x the spectral resolution
+    # If the distance > 2x resolution, it is considered being out of available ranges
     checks = []
     for i in range(0, len(wvlengths)):
         checks.append(array.min_wavelength - wvlengths[i] > 2 * spc_res)
         checks.append(wvlengths[i] - array.max_wavelength > 2 * spc_res)
-
     if np.any(checks):
         fatal_error(f"At least one band is too far from the available wavelength range: "
                     f"({array.min_wavelength},{array.max_wavelength})!")
 
-    # find indices of bands whose wavelengths are closest to desired ones
+    # Find indices of bands whose wavelengths are closest to desired ones
     match_ids = [_find_closest(wls, wv) for wv in wvlengths]
 
-    # check if in the visible wavelengths range
+    # Check if in the visible wavelengths range
     ids_vis = [idx for (idx, wv) in enumerate(wvlengths) if 390 <= wv <= 830]
-    # invisible wavelengths
     ids_inv = [idx for (idx, wv) in enumerate(wvlengths) if wv < 390 or wv > 830]
 
+    # Prepare random colors in case there are invisible wavelengths
     colors = [tuple(x) for x in color_palette(len(wvlengths))]
     if len(ids_vis) < len(wvlengths):
-        print("Warning: at least one of the desired wavelengths is not in the visible spectrum range!")
-        # if len(ids_inv) == len(wvlengths): # All wavelengths in invisible range
-        #     colors = [tuple(x) for x in color_palette(len(wvlengths))]
+        print("Warning: at least one of the desired wavelengths is not in the visible spectrum range!", file=sys.stderr)
+
+    # If there are at least one band in the visible range, get the corresponding rgb value tuple based on the wavelength
     if len(ids_inv) < len(wvlengths):
         colors_vis = []
         colors_inv = colors
@@ -87,12 +104,9 @@ def hyper_histogram(array, mask=None, bins=100, lower_bound=None, upper_bound=No
         cmfs = colour.MSDS_CMFS["CIE 2012 10 Degree Standard Observer"]
         matrix = np.array([[3.24062548, -1.53720797, -0.49862860],
                            [-0.96893071, 1.87575606, 0.04151752],
-                           [0.05571012, -0.20402105, 1.05699594]]
-                          )
+                           [0.05571012, -0.20402105, 1.05699594]])
         for i in ids_vis:
-            # colors_vis.append(_wavelength_to_rgb(wvlengths[i], gamma=0.8))
-            # color_vis = _wavelength_to_rgb(wvlengths[i], gamma=0.8)
-            # Convert wavelength to RGB
+            # Convert wavelength to (R,G,B) colors
             rgb = colour.XYZ_to_RGB(colour.wavelength_to_XYZ(wvlengths[i], cmfs),
                                     illuminant_XYZ=np.array([0.9, 0.9]),
                                     illuminant_RGB=np.array([0.9, 0.9]),
@@ -103,9 +117,9 @@ def hyper_histogram(array, mask=None, bins=100, lower_bound=None, upper_bound=No
             # Convert float RGB to 8-bit unsigned integer
             color_vis = colour.io.convert_bit_depth(rgb, "uint8")
             colors_vis.append(color_vis)
-        # calculate the distances between every pair of (R,G,B) colors
+        # Calculate the distances between every pair of (R,G,B) colors
         dists = distance.cdist(colors_vis, colors_inv, 'euclidean')
-        # exclude those colors "too close" to visible colors
+        # exclude those colors representing invisible bands that are "too close" to visible colors
         exclude = np.argmin(dists, axis=1)
         colors_inv = [c for (i, c) in enumerate(colors_inv) if i not in exclude]
         j_vis, j_inv = 0, 0
@@ -127,6 +141,7 @@ def hyper_histogram(array, mask=None, bins=100, lower_bound=None, upper_bound=No
     params.debug = None
     color_codes = []
 
+    # Create a dataframe for all histogram related information (using the "histogram" function in "visualization" subpackage)
     for i_wv, (wv, color) in enumerate(zip(wvlengths, colors)):
         idx = match_ids[i_wv]
         code_c = _rgb_to_webcode(color)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ plotnine
 dask
 dask-jobqueue
 opencv-python<4, >=3.4
+colour-science


### PR DESCRIPTION
**Describe your changes**
@DannieSheng this PR is an updated version of the visualize_hyper_histogram branch that uses a different method for converting wavelengths to RGB color values. I'm a little concerned about using the code from http://www.noah.org/wiki/Wavelength_to_RGB_in_Python because the license is not clear.

As an alternative, I found the package `colour-science` (https://www.colour-science.org/) that has a lot of cool features and can convert wavelengths to other color models. The code here uses it instead for you to review. It can convert wavelengths between 390 and 830 nm. I'm not sure it's still working with the non-visible wavelengths like you had it before:

<img width="738" alt="Screen Shot 2021-06-15 at 11 31 19 PM" src="https://user-images.githubusercontent.com/6233508/122158245-ec69ad00-ce31-11eb-8998-b25d76ec659c.png">



