### PR TITLE
relocate tests for `transform_warp`

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -5714,6 +5714,71 @@ def test_plantcv_transform_nonuniform_illumination_gray():
     corrected = pcv.transform.nonuniform_illumination(img=gray_img, ksize=11)
     assert np.shape(corrected) == np.shape(gray_img)
 
+
+def test_plantcv_transform_warp_default():
+    pcv.params.debug = "plot"
+    img = create_test_img((12, 10, 3))
+    refimg = create_test_img((12, 10, 3))
+    pts = [(0, 0),(1, 0),(0, 3),(4, 4)]
+    refpts = [(0, 0),(1, 0),(0, 3),(4, 4)]
+    warped_img, mat = pcv.transform.warp(img, refimg, pts, refpts, method="default")
+    assert mat.shape == (3, 3)
+
+
+def test_plantcv_transform_warp_lmeds():
+    pcv.params.debug = "plot"
+    img = create_test_img((10, 10, 3))
+    refimg = create_test_img((11, 11))
+    pts = [(0, 0), (1, 0), (0, 3), (4, 4)]
+    refpts = [(0, 0), (1, 0), (0, 3), (4, 4)]
+    warped_img, mat = pcv.transform.warp(img, refimg, pts, refpts, method="lmeds")
+    assert mat.shape == (3, 3)
+
+
+def test_plantcv_transform_warp_rho():
+    pcv.params.debug = "plot"
+    img = create_test_img_bin((10, 10))
+    refimg = create_test_img((11, 11))
+    pts = [(0, 0), (1, 0), (0, 3), (4, 4)]
+    refpts = [(0, 0), (1, 0), (0, 3), (4, 4)]
+    warped_img, mat = pcv.transform.warp(img, refimg, pts, refpts, method="rho")
+    assert mat.shape == (3, 3)
+
+
+def test_plantcv_transform_warp_ransac():
+    pcv.params.debug = "plot"
+    img = create_test_img((100, 150))
+    refimg = create_test_img((10, 15))
+    pts = [(0, 0), (149, 0), (99, 149), (0, 99), (3, 3)]
+    refpts = [(0, 0), (0, 14), (9, 14), (0, 9), (3, 3)]
+    warped_img, mat = pcv.transform.warp(img, refimg, pts, refpts, method="ransac")
+    assert mat.shape == (3, 3)
+
+
+@pytest.mark.parametrize("pts, refpts", [
+    [[(0,0)],[(0,0),(0,1)]],  # different # of points provided for img and refimg
+    [[(0,0)],[(0,0)]],  # not enough pairs of points provided
+    [[(0, 0), (0, 14), (9, 14), (0, 9), (3, 3)],
+     [(0, 0), (149, 0), (99, 149), (0, 99), (3, 3)]]  # homography not able to be calculated (cannot converge)
+])
+def test_plantcv_transform_warp_err(pts, refpts):
+    img = create_test_img((10, 15))
+    refimg = create_test_img((100, 150))
+    method = "rho"
+    with pytest.raises(RuntimeError):
+        pcv.transform.warp(img, refimg, pts, refpts, method=method)
+
+
+def test_plantcv_transform_warp_align():
+    img = create_test_img((10, 10, 3))
+    refimg = create_test_img((11, 11))
+    mat = np.array([[ 1.00000000e+00,  1.04238500e-15, -7.69185075e-16],
+                    [ 1.44375646e-16,  1.00000000e+00,  0.00000000e+00],
+                    [-5.41315251e-16,  1.78930521e-15,  1.00000000e+00]])
+    warp_img = pcv.transform.warp_align(img=img, mat=mat, refimg=refimg)
+    assert warp_img.shape == (11, 11, 3)
+
+
 # ##############################
 # Tests for the threshold subpackage
 # ##############################
@@ -5969,70 +6034,6 @@ def create_test_img_bin(sz_img):
     img = np.zeros(sz_img)
     img[3:7, 2:8] = 1
     return img
-
-
-def test_plantcv_transform_warp_default():
-    pcv.params.debug = "plot"
-    img = create_test_img((12, 10, 3))
-    refimg = create_test_img((12, 10, 3))
-    pts = [(0, 0),(1, 0),(0, 3),(4, 4)]
-    refpts = [(0, 0),(1, 0),(0, 3),(4, 4)]
-    warped_img, mat = pcv.transform.warp(img, refimg, pts, refpts, method="default")
-    assert mat.shape == (3, 3)
-
-
-def test_plantcv_transform_warp_lmeds():
-    pcv.params.debug = "plot"
-    img = create_test_img((10, 10, 3))
-    refimg = create_test_img((11, 11))
-    pts = [(0, 0), (1, 0), (0, 3), (4, 4)]
-    refpts = [(0, 0), (1, 0), (0, 3), (4, 4)]
-    warped_img, mat = pcv.transform.warp(img, refimg, pts, refpts, method="lmeds")
-    assert mat.shape == (3, 3)
-
-
-def test_plantcv_transform_warp_rho():
-    pcv.params.debug = "plot"
-    img = create_test_img_bin((10, 10))
-    refimg = create_test_img((11, 11))
-    pts = [(0, 0), (1, 0), (0, 3), (4, 4)]
-    refpts = [(0, 0), (1, 0), (0, 3), (4, 4)]
-    warped_img, mat = pcv.transform.warp(img, refimg, pts, refpts, method="rho")
-    assert mat.shape == (3, 3)
-
-
-def test_plantcv_transform_warp_ransac():
-    pcv.params.debug = "plot"
-    img = create_test_img((100, 150))
-    refimg = create_test_img((10, 15))
-    pts = [(0, 0), (149, 0), (99, 149), (0, 99), (3, 3)]
-    refpts = [(0, 0), (0, 14), (9, 14), (0, 9), (3, 3)]
-    warped_img, mat = pcv.transform.warp(img, refimg, pts, refpts, method="ransac")
-    assert mat.shape == (3, 3)
-
-
-@pytest.mark.parametrize("pts, refpts", [
-    [[(0,0)],[(0,0),(0,1)]],  # different # of points provided for img and refimg
-    [[(0,0)],[(0,0)]],  # not enough pairs of points provided
-    [[(0, 0), (0, 14), (9, 14), (0, 9), (3, 3)],
-     [(0, 0), (149, 0), (99, 149), (0, 99), (3, 3)]]  # homography not able to be calculated (cannot converge)
-])
-def test_plantcv_transform_warp_err(pts, refpts):
-    img = create_test_img((10, 15))
-    refimg = create_test_img((100, 150))
-    method = "rho"
-    with pytest.raises(RuntimeError):
-        pcv.transform.warp(img, refimg, pts, refpts, method=method)
-
-
-def test_plantcv_transform_warp_align():
-    img = create_test_img((10, 10, 3))
-    refimg = create_test_img((11, 11))
-    mat = np.array([[ 1.00000000e+00,  1.04238500e-15, -7.69185075e-16],
-                    [ 1.44375646e-16,  1.00000000e+00,  0.00000000e+00],
-                    [-5.41315251e-16,  1.78930521e-15,  1.00000000e+00]])
-    warp_img = pcv.transform.warp_align(img=img, mat=mat, refimg=refimg)
-    assert warp_img.shape == (11, 11, 3)
 
 
 @pytest.mark.parametrize("bad_type", ["native", "nan", "inf"])


### PR DESCRIPTION
**Describe your changes**
A clear and concise description of what changes are made by this pull request.
I realized the tests for `transform_warp` were not placed together with other `transform` functions, so I moved these tests.

**Type of update**
Is this a:
* Bug fix
* Small changes in `tests.py`
