### PR TITLE
Fix format for my header

### DIFF
--- a/plantcv/plantcv/hyperspectral/read_data.py
+++ b/plantcv/plantcv/hyperspectral/read_data.py
@@ -126,9 +126,11 @@ def read_data(filename):
     for i, string in enumerate(hdata):
         if ' = ' in string:
             header_data = string.split(" = ")
+            header_data[0] = header_data[0].lower()
             header_dict.update({header_data[0].rstrip(): header_data[1].rstrip()})
         elif ' : ' in string:
             header_data = string.split(" : ")
+            header_data[0] = header_data[0].lower()
             header_dict.update({header_data[0].rstrip(): header_data[1].rstrip()})
 
     # Reformat wavelengths

--- a/plantcv/plantcv/hyperspectral/read_data.py
+++ b/plantcv/plantcv/hyperspectral/read_data.py
@@ -118,6 +118,7 @@ def read_data(filename):
         hdata = hdata.replace("{\n", "{")
         hdata = hdata.replace("\n}", "}")
         hdata = hdata.replace(" \n ", "")
+        hdata = hdata.replace(" \n", "")
         hdata = hdata.replace(";", "")
     hdata = hdata.split("\n")
 


### PR DESCRIPTION
**Describe your changes**
Fix header format issue to read wavelength values containing a space before a newline in the opening `{` bracket. Also I needed to lowercase `Wavelength` string. [Here](https://gist.github.com/typelogic/2fc0611e02e4a3af8ee3268d43b85275) is the spectral header file where it failed to parse. 

**Type of update**
* Bug fix

**Additional context**
I got this spectral datasets [here](https://sites.google.com/site/hyperspectralcolorimaging/dataset/fruits)