### PR TITLE
cast contour tuple as a list in find_objects

### DIFF
--- a/plantcv/plantcv/find_objects.py
+++ b/plantcv/plantcv/find_objects.py
@@ -32,6 +32,8 @@ def find_objects(img, mask):
     if len(np.shape(ori_img)) == 2:
         ori_img = cv2.cvtColor(ori_img, cv2.COLOR_GRAY2BGR)
     objects, hierarchy = cv2.findContours(mask1, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+    # Cast tuple objects as a list
+    objects = list(objects)
     for i, cnt in enumerate(objects):
         cv2.drawContours(ori_img, objects, i, (255, 102, 255), -1, lineType=8, hierarchy=hierarchy)
 


### PR DESCRIPTION
**Describe your changes**
Cast the contours output from cv2.findContours as a list (they now are given as a tuple) 

**Type of update**
Is this a:
* Bug fix

**Associated issues**


**Additional context**
Some morphology tests failed in the unrelated PR #829. 
The problem seems to be that in the version of OpenCV used by the tests in GitHub (3.4.16.57) the contours in findContours
are given as a tuple instead of as a list. Those tests pass locally using OpenCV 3.4.14.
