### PR TITLE
scale color correction matrices to 0-255 in quick color check

### DIFF
--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -433,6 +433,10 @@ def quick_color_check(target_matrix, source_matrix, num_chips):
         scale_y_continuous, scale_color_manual, aes
     import pandas as pd
 
+    # Scale matrices back to 0-255
+    target_matrix = 255*target_matrix
+    source_matrix = 255*source_matrix
+
     # Extract and organize matrix info
     tr = target_matrix[:num_chips, 1:2]
     tg = target_matrix[:num_chips, 2:3]


### PR DESCRIPTION
**Describe your changes**
Scale color correction matrices to 0-255 in quick_color_check. After the last update the values of the matrices are between 0-1 but 0-255 is better for visualization

**Type of update**
Is this a:
* Bug fix

**Associated issues**
Complements PR #829 

**Additional context**

