### PR TITLE
Trigger GitHub Actions deployment workflow when a release is published

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -5,7 +5,7 @@ name: deploy
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
**Describe your changes**
Updates the GitHub Actions workflow `publish-package.yml` to trigger when a release is published rather than when it is created. This will allow for draft releases.

**Type of update**
Is this a: Bug fix

**Associated issues**
Closes #809
