### PR TITLE
Update dependency OpenCV to v4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest]
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@main

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . /tmp
 RUN cd /tmp && sed -i'' -e 's/opencv.*//g' requirements.txt
 
 # Install PlantCV
-RUN cd /tmp && conda install --quiet --yes -c conda-forge --file requirements.txt 'opencv<4' && conda clean --all -f -y
+RUN cd /tmp && conda install --quiet --yes -c conda-forge --file requirements.txt 'opencv' && conda clean --all -f -y
 
 # Install PlantCV Python prerequisites and PlantCV
 RUN cd /tmp && python setup.py install

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@
 # optionally, change channel name with -n {plantcv-dev}
 name: plantcv
 dependencies:
-  - python=3.7
+  - python=3.9
   - matplotlib>=1.5
   - numpy>=1.11
   - pandas
@@ -14,7 +14,7 @@ dependencies:
   - dask
   - dask-jobqueue
   - nb_conda
-  - opencv<4, >=3.4
+  - opencv
   - statsmodels
 channels:
   - conda-forge

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,8 @@ dependencies:
   - nb_conda
   - opencv
   - statsmodels
+  - mkdocs
+  - pytest
 channels:
   - conda-forge
   - defaults

--- a/plantcv/plantcv/roi/roi_methods.py
+++ b/plantcv/plantcv/roi/roi_methods.py
@@ -266,8 +266,7 @@ def multi(img, coord, radius, spacing=None, nrows=None, ncols=None):
                 circle_img = cv2.circle(bin_img, (x, y), radius, 255, -1)
                 overlap_img = overlap_img + circle_img
                 # Make a list of contours and hierarchies
-                _, rc, rh = cv2.findContours(circle_img, cv2.RETR_EXTERNAL,
-                                             cv2.CHAIN_APPROX_NONE)
+                rc, rh = cv2.findContours(circle_img, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)[-2:]
                 roi_contour.append(rc)
                 roi_hierarchy.append(rh)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ scikit-learn
 plotnine
 dask
 dask-jobqueue
-opencv-python<4, >=3.4
+opencv-python
 statsmodels


### PR DESCRIPTION
**Describe your changes**
OpenCV v3 builds in conda-forge no longer have newer versions of Python, which is starting to cause issues building the plantcv-feedstock. This PR releases v3 pins on OpenCV to allow for builds with OpenCV4. It also shifts CI tests from Python v3.6-3.8 to v3.7-3.9.

**Type of update**
Is this a: Update to dependencies

**Associated issues**
Closes #667

