### PR TITLE
added sample column to case without variables

### DIFF
--- a/plantcv/utils/converters.py
+++ b/plantcv/utils/converters.py
@@ -73,7 +73,7 @@ def json2csv(json_file, csv_file):
                                 row = [sample, var, obs[var]["value"][i], obs[var]["label"][i]]
                                 csv.write(",".join(map(str, meta_row + row)) + "\n")
                     else:
-                        csv.write(",".join(map(str, meta_row + [var, "NA", "NA"])) + "\n")
+                        csv.write(",".join(map(str, meta_row + [sample, var, "NA", "NA"])) + "\n")
         csv.close()
     else:
         # If the file does not exist raise an error


### PR DESCRIPTION
**Describe your changes**
When converting JSON file to csv, the multi-trait lines that do no have values (i.e. NA) are missing the 'sample' column/value (line 76) as compared to the normal case (line 73). 
`csv.write(",".join(map(str, meta_row + [var, "NA", "NA"])) + "\n")`
The 'sample' value was added to the list on line 73. 
`csv.write(",".join(map(str, meta_row + [sample, var, "NA", "NA"])) + "\n")`


**Type of update**
Is this a:
* Bug fix

**Associated issues**
This change closes issue #881.

**Additional context**
Before this modification the resulting csv file could result with some rows having one too few columns, resulting in errors during import (at least this was the case using fread of the data.table library from R). With this change everything appears normal.
