### PR TITLE
support for other dtypes in color correction

### DIFF
--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -236,18 +236,18 @@ def apply_transformation_matrix(source_img, target_img, transformation_matrix):
     # merge corrected color channels onto source_image
     bgr = [b, g, r]
     corrected_img = cv2.merge(bgr)
+    print(corrected_img.dtype)
 
     # return values of the image to the original range
     corrected_img = max_val*np.clip(corrected_img, 0, 1)
-    corrected_img = np.floor(corrected_img)
-    # cast back to original dtype
+    # cast back to original dtype (if uint the value defaults to the closest smaller integer)
     corrected_img = corrected_img.astype(source_dtype)
 
     # For debugging, create a horizontal view of source_img, corrected_img, and target_img to the plotting device
     # plot horizontal comparison of source_img, corrected_img (with rounded elements) and target_img
     out_img = np.hstack([source_img, corrected_img, target_img])
     # Change range of visualization image to 0-255 and convert to uin8
-    out_img = np.floor((255.0/max_val)*out_img).astype(np.uint8)
+    out_img = ((255.0/max_val)*out_img).astype(np.uint8)
     _debug(visual=out_img, filename=os.path.join(params.debug_outdir, str(params.device) + '_corrected.png'))
 
     # return corrected_img

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -246,6 +246,8 @@ def apply_transformation_matrix(source_img, target_img, transformation_matrix):
     # For debugging, create a horizontal view of source_img, corrected_img, and target_img to the plotting device
     # plot horizontal comparison of source_img, corrected_img (with rounded elements) and target_img
     out_img = np.hstack([source_img, corrected_img, target_img])
+    # Change range of visualization image to 0-255 and convert to uin8
+    out_img = np.floor((255.0/max_val)*out_img).astype(np.uint8)
     _debug(visual=out_img, filename=os.path.join(params.debug_outdir, str(params.device) + '_corrected.png'))
 
     # return corrected_img

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -236,7 +236,6 @@ def apply_transformation_matrix(source_img, target_img, transformation_matrix):
     # merge corrected color channels onto source_image
     bgr = [b, g, r]
     corrected_img = cv2.merge(bgr)
-    print(corrected_img.dtype)
 
     # return values of the image to the original range
     corrected_img = max_val*np.clip(corrected_img, 0, 1)

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -37,10 +37,9 @@ def get_color_matrix(rgb_img, mask):
 
     img_dtype = rgb_img.dtype
     # normalization value as max number if the type is unsigned int
+    max_val = 1.0
     if img_dtype.kind == 'u':
         max_val = np.iinfo(img_dtype).max
-    else:
-        max_val = 1.0
 
     # convert to float and normalize to work with values between 0-1
     rgb_img = rgb_img.astype(np.float64)/max_val
@@ -212,10 +211,9 @@ def apply_transformation_matrix(source_img, target_img, transformation_matrix):
 
     source_dtype = source_img.dtype
     # normalization value as max number if the type is unsigned int
+    max_val = 1.0
     if source_dtype.kind == 'u':
         max_val = np.iinfo(source_dtype).max
-    else:
-        max_val = 1.0
     # convert img to float to avoid integer overflow, normalize between 0-1
     source_flt = source_img.astype(np.float64)/max_val
     # find linear, square, and cubic values of source_img color channels

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -37,7 +37,7 @@ def get_color_matrix(rgb_img, mask):
 
     img_dtype = rgb_img.dtype
     # normalization value as max number if the type is unsigned int
-    if img_dtype.kind is 'u':
+    if img_dtype.kind == 'u':
         max_val = np.iinfo(img_dtype).max
     else:
         max_val = 1.0
@@ -212,7 +212,7 @@ def apply_transformation_matrix(source_img, target_img, transformation_matrix):
 
     source_dtype = source_img.dtype
     # normalization value as max number if the type is unsigned int
-    if source_dtype.kind is 'u':
+    if source_dtype.kind == 'u':
         max_val = np.iinfo(source_dtype).max
     else:
         max_val = 1.0

--- a/tests/plantcv/transform/test_color_correction.py
+++ b/tests/plantcv/transform/test_color_correction.py
@@ -129,6 +129,7 @@ def test_apply_transformation(transform_test_data):
     # assert source and corrected have same shape
     assert np.array_equal(corrected_img, corrected_compare)
 
+
 def test_apply_transformation_incorrect_t(transform_test_data):
     """Test for PlantCV."""
     # read in matrices

--- a/tests/plantcv/transform/test_color_correction.py
+++ b/tests/plantcv/transform/test_color_correction.py
@@ -129,7 +129,6 @@ def test_apply_transformation(transform_test_data):
     # assert source and corrected have same shape
     assert np.array_equal(corrected_img, corrected_compare)
 
-
 def test_apply_transformation_incorrect_t(transform_test_data):
     """Test for PlantCV."""
     # read in matrices


### PR DESCRIPTION
**Describe your changes**
Modify the color correction functions so they work with all unsigned integer and float  dtypes (assuming images are between 0-1 for floats).
The normalization to work with values between 0-1 is done depending on the dtype and the corrected image has the same dtype as the source image.

**Type of update**
Is this a:
* Bug fix
* New feature or feature enhancement


**Associated issues**
#883 

**Additional context**
Before this PR the source and target images were normalized by dividing by 255 which is only valid for uint8 dtype
