### PR TITLE
replace list expression with explicit for loop in segment_image_series

### DIFF
--- a/plantcv/plantcv/segment_image_series.py
+++ b/plantcv/plantcv/segment_image_series.py
@@ -118,7 +118,7 @@ def segment_image_series(imgs_paths, masks_paths, rois, save_labels=True, ksize=
                                                          f"{str(params.device)}_{image_names[n][:-4]}_WSeg.png"))
 
     if save_labels is True:
-        [np.save(os.path.join(params.debug_outdir, f"{image_names[i][:-4]}_labels"),
-                 out_labels[:, :, i]) for i in range(N)]
+        for i in range(N):
+            np.save(os.path.join(params.debug_outdir, f"{image_names[i][:-4]}_labels"), out_labels[:, :, i])
 
     return out_labels


### PR DESCRIPTION
**Describe your changes**
segment_image_series called numpy.save in a for loop within an expression that creates an unassigned list. 
Deepsource recommends not to do that. I replaced the expression with an explicit for loop. 

**Type of update**
Is this a:
* Deepsource fix 

**Associated issues**


**Additional context**


**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/stable/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
