### PR TITLE
standard color correction matrix function

### DIFF
--- a/docs/std_color_matrix.md
+++ b/docs/std_color_matrix.md
@@ -1,58 +1,67 @@
 ## Color Matrix
 
-Computes the average *R*, *G*, *B* values for each region in the RGB image denoted by the gray-scale mask and saves them in a matrix of n x 4, where n = the number of color chips represented in the mask.
+Returns a color matrix with the standard *R*, *G*, *B* values compatible with the x-rite ColorCheker Classic,
+ColorChecker Mini, and ColorChecker Passport targets.
 
-**plantcv.transform.get_color_matrix**(*rgb_img, mask*)
+Source: https://en.wikipedia.org/wiki/ColorChecker
 
-**returns** headers, color_matrix
+**plantcv.transform.std_color_matrix**(*pos=0*)
+
+**returns** color_matrix
 
 - **Parameters**
-    - rgb_img - RGB image with color chips visualized
-    - mask    - a gray-scale img with unique values for each segmented space, representing unique, discrete color chips.
+    - pos - reference value indicating orientation of the color card. The reference
+    is based on the position of the white chip:
+
+        - pos = 0: bottom-left corner  
+        - pos = 1: bottom-right corner
+        - pos = 2: top-right corner
+        - pos = 3: top-left corner
 
 - **Returns**
-    - color_matrix - a *n* x 4 matrix containing the average red value, average green value, and average blue value for each color chip.
-    - headers      - a list of 4 headers corresponding to the 4 columns of color_matrix respectively
+    - color_matrix - a *n* x 4 matrix containing the standard red, green, and blue
+    values for each color chip
+
+
 
 - **Example use:**
-    - [Color Correction Tutorial](tutorials/transform_color_correction_tutorial.md)
+    - Tutorial in progress
 
 ```python
 
 from plantcv import plantcv as pcv
 
-rgb_img, imgpath, imgname = pcv.readimage(filename="target_img.png")
-mask, maskpath, maskname = pcv.readimage(filename="mask_img.png")
+std_color_matrix = pcv.transform.std_color_matrix(pos=0)
 
-headers, color_matrix = pcv.transform.get_color_matrix(rgb_img=rgb_img, mask=mask)
+# use fixed point notation for printing the matrix
+np.set_printoptions(precision=2, suppress=True)
 
-print(headers)
-print(color_matrix)
+print(std_color_matrix)
 
-
-    ['chip_number', 'r_avg', 'g_avg', 'b_avg']
-    [[  10.       20.7332   33.672    92.7748]
-     [  20.      203.508    79.774    25.77  ]
-     [  30.       54.6916   34.0924   26.0352]
-     [  40.      193.2972  203.198   199.4544]
-     [  50.       40.2052   92.0536   37.222 ]
-     [  60.       36.9256   52.4976  123.6224]
-     [  70.      177.7984  103.3772   85.1672]
-     [  80.      119.4276  128.4068  126.6948]
-     [  90.      141.9036   34.0584   22.5056]
-     [ 100.      160.9764   50.3872   47.6984]
-     [ 110.       51.994    73.584   107.734 ]
-     [ 120.       65.9104   69.5172   68.482 ]
-     [ 130.      227.1652  183.1696   30.1332]
-     [ 140.       35.9472   25.4984   47.3424]
-     [ 150.       39.51     52.9624   26.3956]
-     [ 160.       32.8148   34.8512   35.5284]
-     [ 170.      146.522    55.7016   94.7452]
-     [ 180.      114.6672  155.3968   42.5688]
-     [ 190.       84.2172   88.8424  134.2356]
-     [ 200.       34.5308   90.4592  132.9108]
-     [ 210.      207.1596  128.736    28.7744]
-     [ 220.       74.632   158.8224  144.3724]]
+        [[ 10.     0.45   0.32   0.27]
+         [ 20.     0.76   0.59   0.51]
+         [ 30.     0.38   0.48   0.62]
+         [ 40.     0.34   0.42   0.26]
+         [ 50.     0.52   0.5    0.69]
+         [ 60.     0.4    0.74   0.67]
+         [ 70.     0.84   0.49   0.17]
+         [ 80.     0.31   0.36   0.65]
+         [ 90.     0.76   0.35   0.39]
+         [100.     0.37   0.24   0.42]
+         [110.     0.62   0.74   0.25]
+         [120.     0.88   0.64   0.18]
+         [130.     0.22   0.24   0.59]
+         [140.     0.27   0.58   0.29]
+         [150.     0.69   0.21   0.24]
+         [160.     0.91   0.78   0.12]
+         [170.     0.73   0.34   0.58]
+         [180.     0.03   0.52   0.63]
+         [190.     0.95   0.95   0.95]
+         [200.     0.78   0.78   0.78]
+         [210.     0.63   0.63   0.63]
+         [220.     0.48   0.48   0.47]
+         [230.     0.33   0.33   0.33]
+         [240.     0.2    0.2    0.2 ]]
 
 ```
 **Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/transform/color_correction.py)

--- a/docs/std_color_matrix.md
+++ b/docs/std_color_matrix.md
@@ -1,0 +1,58 @@
+## Color Matrix
+
+Computes the average *R*, *G*, *B* values for each region in the RGB image denoted by the gray-scale mask and saves them in a matrix of n x 4, where n = the number of color chips represented in the mask.
+
+**plantcv.transform.get_color_matrix**(*rgb_img, mask*)
+
+**returns** headers, color_matrix
+
+- **Parameters**
+    - rgb_img - RGB image with color chips visualized
+    - mask    - a gray-scale img with unique values for each segmented space, representing unique, discrete color chips.
+
+- **Returns**
+    - color_matrix - a *n* x 4 matrix containing the average red value, average green value, and average blue value for each color chip.
+    - headers      - a list of 4 headers corresponding to the 4 columns of color_matrix respectively
+
+- **Example use:**
+    - [Color Correction Tutorial](tutorials/transform_color_correction_tutorial.md)
+
+```python
+
+from plantcv import plantcv as pcv
+
+rgb_img, imgpath, imgname = pcv.readimage(filename="target_img.png")
+mask, maskpath, maskname = pcv.readimage(filename="mask_img.png")
+
+headers, color_matrix = pcv.transform.get_color_matrix(rgb_img=rgb_img, mask=mask)
+
+print(headers)
+print(color_matrix)
+
+
+    ['chip_number', 'r_avg', 'g_avg', 'b_avg']
+    [[  10.       20.7332   33.672    92.7748]
+     [  20.      203.508    79.774    25.77  ]
+     [  30.       54.6916   34.0924   26.0352]
+     [  40.      193.2972  203.198   199.4544]
+     [  50.       40.2052   92.0536   37.222 ]
+     [  60.       36.9256   52.4976  123.6224]
+     [  70.      177.7984  103.3772   85.1672]
+     [  80.      119.4276  128.4068  126.6948]
+     [  90.      141.9036   34.0584   22.5056]
+     [ 100.      160.9764   50.3872   47.6984]
+     [ 110.       51.994    73.584   107.734 ]
+     [ 120.       65.9104   69.5172   68.482 ]
+     [ 130.      227.1652  183.1696   30.1332]
+     [ 140.       35.9472   25.4984   47.3424]
+     [ 150.       39.51     52.9624   26.3956]
+     [ 160.       32.8148   34.8512   35.5284]
+     [ 170.      146.522    55.7016   94.7452]
+     [ 180.      114.6672  155.3968   42.5688]
+     [ 190.       84.2172   88.8424  134.2356]
+     [ 200.       34.5308   90.4592  132.9108]
+     [ 210.      207.1596  128.736    28.7744]
+     [ 220.       74.632   158.8224  144.3724]]
+
+```
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/transform/color_correction.py)

--- a/docs/std_color_matrix.md
+++ b/docs/std_color_matrix.md
@@ -3,7 +3,7 @@
 Returns a color matrix with the standard *R*, *G*, *B* values compatible with the x-rite ColorCheker Classic,
 ColorChecker Mini, and ColorChecker Passport targets.
 
-Source: https://en.wikipedia.org/wiki/ColorChecker
+Source: [https://en.wikipedia.org/wiki/ColorChecker](https://en.wikipedia.org/wiki/ColorChecker)
 
 **plantcv.transform.std_color_matrix**(*pos=0*)
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1031,6 +1031,11 @@ pages for more details on the input and output variable types.
 * pre v3.0dev1: NA
 * post v3.0dev2: **plantcv.transform.save_matrix**(*matrix, filename*)
 
+#### plantcv.transform.std_color_matrix
+
+* pre v4.0: NA
+* post v4.0: **plantcv.transform.std_color_matrix**(*pos=0*)
+
 #### plantcv.triangle_auto_threshold
 
 * pre v3.0dev2: device, bin_img = **plantcv.triangle_auto_threshold**(*device, img, maxvalue, object_type, xstep=1, debug=None*)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -171,6 +171,7 @@ nav:
           - 'Quick Color Check': quick_color_check.md
           - 'Load Matrix': load_matrix.md
           - 'Save Matrix': save_matrix.md
+          - 'Standard Color Matrix': std_color_matrix.md
           - 'Gamma Correction': transform_gamma_correct.md
           - 'Nonuniform Illumination Correction': nonuniform_illumination.md
           - 'Perspective warp': transform_warp.md

--- a/plantcv/plantcv/transform/__init__.py
+++ b/plantcv/plantcv/transform/__init__.py
@@ -8,6 +8,7 @@ from plantcv.plantcv.transform.color_correction import correct_color
 from plantcv.plantcv.transform.color_correction import create_color_card_mask
 from plantcv.plantcv.transform.color_correction import quick_color_check
 from plantcv.plantcv.transform.color_correction import find_color_card
+from plantcv.plantcv.transform.color_correction import std_color_matrix
 from plantcv.plantcv.transform.rescale import rescale
 from plantcv.plantcv.transform.rotate import rotate
 from plantcv.plantcv.transform.nonuniform_illumination import nonuniform_illumination
@@ -17,5 +18,5 @@ from plantcv.plantcv.transform.gamma_correct import gamma_correct
 
 __all__ = ["get_color_matrix", "get_matrix_m", "calc_transformation_matrix", "apply_transformation_matrix",
            "save_matrix", "load_matrix", "correct_color", "create_color_card_mask", "quick_color_check",
-           "find_color_card", "rescale", "nonuniform_illumination", "resize", "resize_factor",
+           "find_color_card", "std_color_matrix", "rescale", "nonuniform_illumination", "resize", "resize_factor",
            "warp", "rotate", "warp", "warp_align", "gamma_correct"]

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -11,11 +11,18 @@ from plantcv.plantcv._debug import _debug
 
 
 def std_color_matrix(pos=0):
-    """Standard color values for the x-rite ColorCheker Classic, ColorChecker Mini,
-    and ColorChecker Passport targets.
+    """Standard color values compatible with the x-rite ColorCheker Classic,
+    ColorChecker Mini, and ColorChecker Passport targets.
+    Source: https://en.wikipedia.org/wiki/ColorChecker
 
     Inputs:
-    pos     = reference value indicating orientation of the color card
+    pos     = reference value indicating orientation of the color card. The reference
+                is based on the position of the white chip:
+
+                pos = 0: bottom-left corner
+                pos = 1: bottom-right corner
+                pos = 2: top-right corner
+                pos = 3: top-left corner
 
     Outputs:
     color_matrix    = matrix containing the standard red, green, and blue

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -10,6 +10,65 @@ from plantcv.plantcv import fatal_error
 from plantcv.plantcv._debug import _debug
 
 
+def std_color_matrix(pos=0):
+    """Standard color values for the x-rite ColorCheker Classic, ColorChecker Mini,
+    and ColorChecker Passport targets.
+
+    Inputs:
+    pos     = reference value indicating orientation of the color card
+
+    Outputs:
+    color_matrix    = matrix containing the standard red, green, and blue
+                        values for each color chip
+
+    :param pos: int
+    """
+    # list of rgb values as indicated in the color card specs. They need to be
+    # aranged depending on the orientation of the color card of reference in the
+    # image to be corrected.
+    values_list = np.array([[115,82,68], # dark skin
+            [194,150,130], # light skin
+            [98,122,157], # blue sky
+            [87,108,67], # foliage
+            [133,128,177], # blue flower
+            [103,189,170], # bluish green
+            [214,126,44], # orange
+            [80,91,166], # purplish blue
+            [193,90,99], # moderate red
+            [94,60,108], # purple
+            [157,188,64], # yellow green
+            [224,163,46], # orange yellow
+            [56,61,150], # blue
+            [70,148,73], # green
+            [175,54,60], # red
+            [231,199,31], # yellow
+            [187,86,149], # magenta
+            [8,133,161], # cyan
+            [243,243,242], # white (.05*)
+            [200,200,200], # neutral 8 (.23*)
+            [160,160,160], # neutral 6.5 (.44*)
+            [122,122,121], # neutral 5 (.7*)
+            [85,85,85], # neutral 3.5 (1.05*)
+            [52,52,52]], dtype=np.float64) # black (1.50*)
+
+    N_chips = values_list.shape[0]
+
+    # array of indices from 1 to N chips in order to match the chip numbering
+    # in the color card specs. Later when used for indexing, we substract the 1.
+    idx = np.arange(N_chips)+1
+    # indices in the shape of the color card
+    cc_indices = idx.reshape((4,6), order='C')
+    # rotate the indices depending on the specified orientation
+    cc_indices_rot = np.rot90(cc_indices, k=pos, axes=(0,1))
+    # arange color values based on the indices
+    color_matrix_wo_chip_nb = values_list[(cc_indices_rot-1).reshape(-1),:]/255.
+
+    # add chip number compatible with other PlantCV functions
+    chip_nb = np.arange(10,10*N_chips+1,10)
+    color_matrix = np.concatenate((chip_nb.reshape(N_chips,1), color_matrix_wo_chip_nb), axis=1)
+
+    return color_matrix
+
 def get_color_matrix(rgb_img, mask):
     """Calculate the average value of pixels in each color chip for each color channel.
 

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -35,29 +35,29 @@ def std_color_matrix(pos=0):
     # aranged depending on the orientation of the color card of reference in the
     # image to be corrected.
     values_list = np.array([[115, 82, 68],  # dark skin
-            [194, 150, 130],  # light skin
-            [98, 122, 157],  # blue sky
-            [87, 108, 67],  # foliage
-            [133, 128, 177],  # blue flower
-            [103, 189, 170],  # bluish green
-            [214, 126, 44],  # orange
-            [80, 91, 166],  # purplish blue
-            [193, 90, 99],  # moderate red
-            [94, 60, 108],  # purple
-            [157, 188, 64],  # yellow green
-            [224, 163, 46],  # orange yellow
-            [56, 61, 150],  # blue
-            [70, 148, 73],  # green
-            [175, 54, 60],  # red
-            [231, 199, 31],  # yellow
-            [187, 86, 149],  # magenta
-            [8, 133, 161],  # cyan
-            [243, 243, 242],  # white (.05*)
-            [200, 200, 200],  # neutral 8 (.23*)
-            [160, 160, 160],  # neutral 6.5 (.44*)
-            [122, 122, 121],  # neutral 5 (.7*)
-            [85, 85, 85],  # neutral 3.5 (1.05*)
-            [52, 52, 52]], dtype=np.float64)  # black (1.50*)
+                            [194, 150, 130],  # light skin
+                            [98, 122, 157],  # blue sky
+                            [87, 108, 67],  # foliage
+                            [133, 128, 177],  # blue flower
+                            [103, 189, 170],  # bluish green
+                            [214, 126, 44],  # orange
+                            [80, 91, 166],  # purplish blue
+                            [193, 90, 99],  # moderate red
+                            [94, 60, 108],  # purple
+                            [157, 188, 64],  # yellow green
+                            [224, 163, 46],  # orange yellow
+                            [56, 61, 150],  # blue
+                            [70, 148, 73],  # green
+                            [175, 54, 60],  # red
+                            [231, 199, 31],  # yellow
+                            [187, 86, 149],  # magenta
+                            [8, 133, 161],  # cyan
+                            [243, 243, 242],  # white (.05*)
+                            [200, 200, 200],  # neutral 8 (.23*)
+                            [160, 160, 160],  # neutral 6.5 (.44*)
+                            [122, 122, 121],  # neutral 5 (.7*)
+                            [85, 85, 85],  # neutral 3.5 (1.05*)
+                            [52, 52, 52]], dtype=np.float64)  # black (1.50*)
 
     pos = math.floor(pos)
     if (pos < 0) or (pos > 3):
@@ -69,15 +69,15 @@ def std_color_matrix(pos=0):
     # in the color card specs. Later when used for indexing, we substract the 1.
     idx = np.arange(N_chips)+1
     # indices in the shape of the color card
-    cc_indices = idx.reshape((4,6), order='C')
+    cc_indices = idx.reshape((4, 6), order='C')
     # rotate the indices depending on the specified orientation
-    cc_indices_rot = np.rot90(cc_indices, k=pos, axes=(0,1))
+    cc_indices_rot = np.rot90(cc_indices, k=pos, axes=(0, 1))
     # arange color values based on the indices
-    color_matrix_wo_chip_nb = values_list[(cc_indices_rot-1).reshape(-1),:]/255.
+    color_matrix_wo_chip_nb = values_list[(cc_indices_rot-1).reshape(-1), :]/255.
 
     # add chip number compatible with other PlantCV functions
-    chip_nb = np.arange(10,10*N_chips+1,10)
-    color_matrix = np.concatenate((chip_nb.reshape(N_chips,1), color_matrix_wo_chip_nb), axis=1)
+    chip_nb = np.arange(10, 10*N_chips+1, 10)
+    color_matrix = np.concatenate((chip_nb.reshape(N_chips, 1), color_matrix_wo_chip_nb), axis=1)
 
     return color_matrix
 

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -34,30 +34,30 @@ def std_color_matrix(pos=0):
     # list of rgb values as indicated in the color card specs. They need to be
     # aranged depending on the orientation of the color card of reference in the
     # image to be corrected.
-    values_list = np.array([[115,82,68], # dark skin
-            [194,150,130], # light skin
-            [98,122,157], # blue sky
-            [87,108,67], # foliage
-            [133,128,177], # blue flower
-            [103,189,170], # bluish green
-            [214,126,44], # orange
-            [80,91,166], # purplish blue
-            [193,90,99], # moderate red
-            [94,60,108], # purple
-            [157,188,64], # yellow green
-            [224,163,46], # orange yellow
-            [56,61,150], # blue
-            [70,148,73], # green
-            [175,54,60], # red
-            [231,199,31], # yellow
-            [187,86,149], # magenta
-            [8,133,161], # cyan
-            [243,243,242], # white (.05*)
-            [200,200,200], # neutral 8 (.23*)
-            [160,160,160], # neutral 6.5 (.44*)
-            [122,122,121], # neutral 5 (.7*)
-            [85,85,85], # neutral 3.5 (1.05*)
-            [52,52,52]], dtype=np.float64) # black (1.50*)
+    values_list = np.array([[115, 82, 68],  # dark skin
+            [194, 150, 130],  # light skin
+            [98, 122, 157],  # blue sky
+            [87, 108, 67],  # foliage
+            [133, 128, 177],  # blue flower
+            [103, 189, 170],  # bluish green
+            [214, 126, 44],  # orange
+            [80, 91, 166],  # purplish blue
+            [193, 90, 99],  # moderate red
+            [94, 60, 108],  # purple
+            [157, 188, 64],  # yellow green
+            [224, 163, 46],  # orange yellow
+            [56, 61, 150],  # blue
+            [70, 148, 73],  # green
+            [175, 54, 60],  # red
+            [231, 199, 31],  # yellow
+            [187, 86, 149],  # magenta
+            [8, 133, 161],  # cyan
+            [243, 243, 242],  # white (.05*)
+            [200, 200, 200],  # neutral 8 (.23*)
+            [160, 160, 160],  # neutral 6.5 (.44*)
+            [122, 122, 121],  # neutral 5 (.7*)
+            [85, 85, 85],  # neutral 3.5 (1.05*)
+            [52, 52, 52]], dtype=np.float64)  # black (1.50*)
 
     pos = math.floor(pos)
     if (pos < 0) or (pos > 3):
@@ -80,6 +80,7 @@ def std_color_matrix(pos=0):
     color_matrix = np.concatenate((chip_nb.reshape(N_chips,1), color_matrix_wo_chip_nb), axis=1)
 
     return color_matrix
+
 
 def get_color_matrix(rgb_img, mask):
     """Calculate the average value of pixels in each color chip for each color channel.

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -30,6 +30,7 @@ def std_color_matrix(pos=0):
                         values for each color chip
 
     :param pos: int
+    :return color_matrix: numpy.ndarray
     """
     # list of rgb values as indicated in the color card specs. They need to be
     # aranged depending on the orientation of the color card of reference in the

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -1,6 +1,7 @@
 # Color Corrections Functions
 
 import os
+import math
 import cv2
 import numpy as np
 from plantcv.plantcv import params
@@ -57,6 +58,10 @@ def std_color_matrix(pos=0):
             [122,122,121], # neutral 5 (.7*)
             [85,85,85], # neutral 3.5 (1.05*)
             [52,52,52]], dtype=np.float64) # black (1.50*)
+
+    pos = math.floor(pos)
+    if (pos < 0) or (pos > 3):
+        fatal_error("white chip position reference 'pos' must be a value among {0, 1, 2, 3}")
 
     N_chips = values_list.shape[0]
 

--- a/tests/plantcv/transform/test_color_correction.py
+++ b/tests/plantcv/transform/test_color_correction.py
@@ -9,7 +9,8 @@ from plantcv.plantcv import outputs
 
 def test_std_color_matrix():
     """Test for PlantCV"""
-    std_matrix = std_color_matrix(pos=0)
+    pos = 0
+    std_matrix = std_color_matrix(pos=pos)
 
     # indices for the color matrix where the white chip should be depending on
     # the value of pos

--- a/tests/plantcv/transform/test_color_correction.py
+++ b/tests/plantcv/transform/test_color_correction.py
@@ -7,9 +7,9 @@ from plantcv.plantcv.transform import (get_color_matrix, get_matrix_m, calc_tran
                                        find_color_card, std_color_matrix)
 from plantcv.plantcv import outputs
 
-def test_std_color_matrix():
+@pytest.mark.parametrize("pos", [0, 1, 2, 3])
+def test_std_color_matrix(pos):
     """Test for PlantCV"""
-    pos = 0
     std_matrix = std_color_matrix(pos=pos)
 
     # indices for the color matrix where the white chip should be depending on

--- a/tests/plantcv/transform/test_color_correction.py
+++ b/tests/plantcv/transform/test_color_correction.py
@@ -25,6 +25,12 @@ def test_std_color_matrix():
     # compare RGB values in the range [0-255]
     assert np.sum(255*white_val - white_rgb) < 1
 
+def test_std_color_matrix_bad_pos():
+    """Test for PlantCV"""
+    with pytest.raises(RuntimeError):
+        _ = std_color_matrix(pos=4.5)
+
+
 
 def test_get_color_matrix(transform_test_data):
     """Test for PlantCV."""

--- a/tests/plantcv/transform/test_color_correction.py
+++ b/tests/plantcv/transform/test_color_correction.py
@@ -7,6 +7,7 @@ from plantcv.plantcv.transform import (get_color_matrix, get_matrix_m, calc_tran
                                        find_color_card, std_color_matrix)
 from plantcv.plantcv import outputs
 
+
 @pytest.mark.parametrize("pos", [0, 1, 2, 3])
 def test_std_color_matrix(pos):
     """Test for PlantCV"""
@@ -18,18 +19,18 @@ def test_std_color_matrix(pos):
     white_idx_pos = white_indices[pos]
 
     # RGB values in white chip of the returned matrix in the range [0-1]
-    white_val = std_matrix[white_idx_pos,1:]
+    white_val = std_matrix[white_idx_pos, 1:]
 
     # RGB values of the white chip in the range [0-255]
     white_rgb = np.array([243., 243., 242.], dtype=np.float64)
     # compare RGB values in the range [0-255]
     assert np.sum(255*white_val - white_rgb) < 1
 
+
 def test_std_color_matrix_bad_pos():
     """Test for PlantCV"""
     with pytest.raises(RuntimeError):
         _ = std_color_matrix(pos=4.5)
-
 
 
 def test_get_color_matrix(transform_test_data):

--- a/tests/plantcv/transform/test_color_correction.py
+++ b/tests/plantcv/transform/test_color_correction.py
@@ -4,8 +4,25 @@ import cv2
 import numpy as np
 from plantcv.plantcv.transform import (get_color_matrix, get_matrix_m, calc_transformation_matrix, apply_transformation_matrix,
                                        save_matrix, load_matrix, correct_color, create_color_card_mask, quick_color_check,
-                                       find_color_card)
+                                       find_color_card, std_color_matrix)
 from plantcv.plantcv import outputs
+
+def test_std_color_matrix():
+    """Test for PlantCV"""
+    std_matrix = pcv.transform.std_color_matrix(pos=0)
+
+    # indices for the color matrix where the white chip should be depending on
+    # the value of pos
+    white_indices = [18, 23, 5, 0]
+    white_idx_pos = white_indices[pos]
+
+    # RGB values in white chip of the returned matrix in the range [0-1]
+    white_val = std_matrix[white_idx_pos,1:]
+
+    # RGB values of the white chip in the range [0-255]
+    white_rgb = np.array([243., 243., 242.], dtype=np.float64)
+    # compare RGB values in the range [0-255]
+    assert np.sum(255*white_val - white_rgb) < 1
 
 
 def test_get_color_matrix(transform_test_data):

--- a/tests/plantcv/transform/test_color_correction.py
+++ b/tests/plantcv/transform/test_color_correction.py
@@ -9,7 +9,7 @@ from plantcv.plantcv import outputs
 
 def test_std_color_matrix():
     """Test for PlantCV"""
-    std_matrix = pcv.transform.std_color_matrix(pos=0)
+    std_matrix = std_color_matrix(pos=0)
 
     # indices for the color matrix where the white chip should be depending on
     # the value of pos

--- a/tests/plantcv/transform/test_color_correction.py
+++ b/tests/plantcv/transform/test_color_correction.py
@@ -24,7 +24,7 @@ def test_std_color_matrix(pos):
     # RGB values of the white chip in the range [0-255]
     white_rgb = np.array([243., 243., 242.], dtype=np.float64)
     # compare RGB values in the range [0-255]
-    assert np.sum(255*white_val - white_rgb) < 1
+    assert np.sum(np.abs(255*white_val - white_rgb)) < 1
 
 
 def test_std_color_matrix_bad_pos():


### PR DESCRIPTION
**Describe your changes**
Add a function that helps us access the standard rgb values (hard coded) for the chips in the color cards.
This allow us to correct images with respect to the std values. 

Source: https://en.wikipedia.org/wiki/ColorChecker

**Type of update**
Is this a:
* New feature or feature enhancement
* Work in progress

**Associated issues**
Reference associated issue numbers. Does this pull request close any issues?

**Additional context**
Add any other context about the problem here.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/stable/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
