### PR TITLE
Add gif to gitattributes to treat as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,4 @@ plantcv/plantcv/_version.py export-subst
 *.pkl binary
 *.npz binary
 *.DAT binary
+*.gif binary


### PR DESCRIPTION
**Describe your changes**
To avoid conversion of line endings between Windows, macOS, and Linux systems when cloning the git repository, we specify in `.gitattributes` that some file types should be treated as binary and remain unmodified. This PR adds .gif file types to that list.

**Type of update**
Is this a: Bug fix

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/stable/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
