### PR TITLE
Add helper function to centralize usage of OpenCV findContours

### DIFF
--- a/plantcv/plantcv/_helpers.py
+++ b/plantcv/plantcv/_helpers.py
@@ -1,4 +1,5 @@
 import cv2
+import numpy as np
 
 
 def _cv2_findcontours(bin_img):
@@ -14,6 +15,6 @@ def _cv2_findcontours(bin_img):
     :return contours: list
     :return hierarchy: np.array
     """
-    contours, hierarchy = cv2.findContours(bin_img, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+    contours, hierarchy = cv2.findContours(np.copy(bin_img), cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
 
     return contours, hierarchy

--- a/plantcv/plantcv/_helpers.py
+++ b/plantcv/plantcv/_helpers.py
@@ -1,0 +1,19 @@
+import cv2
+
+
+def _cv2_findcontours(bin_img):
+    """
+    Helper function for OpenCV findContours.
+
+    Reduces duplication of calls to findContours in the event the OpenCV function changes.
+
+    Keyword inputs:
+    bin_img = Binary image (np.ndarray)
+
+    :param bin_img: np.ndarray
+    :return contours: list
+    :return hierarchy: np.array
+    """
+    contours, hierarchy = cv2.findContours(bin_img, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+
+    return contours, hierarchy

--- a/plantcv/plantcv/analyze_bound_horizontal.py
+++ b/plantcv/plantcv/analyze_bound_horizontal.py
@@ -4,6 +4,7 @@ import os
 import cv2
 import numpy as np
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 from plantcv.plantcv import params
 from plantcv.plantcv import outputs
 
@@ -45,7 +46,7 @@ def analyze_bound_horizontal(img, obj, mask, line_position, label="default"):
     rec_point1 = (1, rec_corner)
     rec_point2 = (x_coor - 2, y_coor - 2)
     cv2.rectangle(background, rec_point1, rec_point2, (255), 1)
-    below_contour, below_hierarchy = cv2.findContours(background, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+    below_contour, below_hierarchy = _cv2_findcontours(bin_img=background)
 
     x, y, width, height = cv2.boundingRect(obj)
 

--- a/plantcv/plantcv/analyze_bound_vertical.py
+++ b/plantcv/plantcv/analyze_bound_vertical.py
@@ -4,6 +4,7 @@ import os
 import cv2
 import numpy as np
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 from plantcv.plantcv import params
 from plantcv.plantcv import outputs
 
@@ -44,7 +45,7 @@ def analyze_bound_vertical(img, obj, mask, line_position, label="default"):
     rec_point1 = (0, 0)
     rec_point2 = (x_coor, y_coor - 2)
     cv2.rectangle(background, rec_point1, rec_point2, (255), -1)
-    right_contour, right_hierarchy = cv2.findContours(background, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+    right_contour, right_hierarchy = _cv2_findcontours(bin_img=background)
 
     x, y, width, height = cv2.boundingRect(obj)
 

--- a/plantcv/plantcv/analyze_object.py
+++ b/plantcv/plantcv/analyze_object.py
@@ -7,6 +7,7 @@ from plantcv.plantcv import params
 from plantcv.plantcv import outputs
 from plantcv.plantcv import within_frame
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 
 
 def analyze_object(img, obj, mask, label="default"):
@@ -82,7 +83,7 @@ def analyze_object(img, obj, mask, label="default"):
         cv2.circle(background, (int(cmx), int(cmy)), 4, (255, 255, 255), -1)
         center_p = cv2.cvtColor(background, cv2.COLOR_BGR2GRAY)
         ret, centerp_binary = cv2.threshold(center_p, 0, 255, cv2.THRESH_BINARY)
-        centerpoint, cpoint_h = cv2.findContours(centerp_binary, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+        centerpoint, cpoint_h = _cv2_findcontours(bin_img=centerp_binary)
 
         dist = []
         vhull = np.vstack(hull)

--- a/plantcv/plantcv/crop_position_mask.py
+++ b/plantcv/plantcv/crop_position_mask.py
@@ -5,6 +5,7 @@ import numpy as np
 import math
 import os
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 from plantcv.plantcv import fatal_error
 from plantcv.plantcv import params
 
@@ -203,7 +204,7 @@ def crop_position_mask(img, mask, x, y, v_pos="top", h_pos="right"):
     newmask = np.array(maskv)
     _debug(visual=newmask, filename=os.path.join(params.debug_outdir, str(params.device) + "_newmask.png"), cmap='gray')
 
-    objects, hierarchy = cv2.findContours(np.copy(newmask), cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+    objects, hierarchy = _cv2_findcontours(bin_img=np.copy(newmask))
     for i, cnt in enumerate(objects):
         cv2.drawContours(ori_img, objects, i, (255, 102, 255), -1, lineType=8, hierarchy=hierarchy)
     _debug(visual=ori_img, filename=os.path.join(params.debug_outdir, str(params.device) + '_mask_overlay.png'))

--- a/plantcv/plantcv/crop_position_mask.py
+++ b/plantcv/plantcv/crop_position_mask.py
@@ -204,7 +204,7 @@ def crop_position_mask(img, mask, x, y, v_pos="top", h_pos="right"):
     newmask = np.array(maskv)
     _debug(visual=newmask, filename=os.path.join(params.debug_outdir, str(params.device) + "_newmask.png"), cmap='gray')
 
-    objects, hierarchy = _cv2_findcontours(bin_img=np.copy(newmask))
+    objects, hierarchy = _cv2_findcontours(bin_img=newmask)
     for i, cnt in enumerate(objects):
         cv2.drawContours(ori_img, objects, i, (255, 102, 255), -1, lineType=8, hierarchy=hierarchy)
     _debug(visual=ori_img, filename=os.path.join(params.debug_outdir, str(params.device) + '_mask_overlay.png'))

--- a/plantcv/plantcv/find_objects.py
+++ b/plantcv/plantcv/find_objects.py
@@ -4,6 +4,7 @@ import cv2
 import numpy as np
 import os
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 from plantcv.plantcv import params
 
 
@@ -30,7 +31,7 @@ def find_objects(img, mask):
     # If the reference image is grayscale convert it to color
     if len(np.shape(ori_img)) == 2:
         ori_img = cv2.cvtColor(ori_img, cv2.COLOR_GRAY2BGR)
-    objects, hierarchy = cv2.findContours(mask1, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+    objects, hierarchy = _cv2_findcontours(bin_img=mask1)
     # Cast tuple objects as a list
     objects = list(objects)
     for i, cnt in enumerate(objects):

--- a/plantcv/plantcv/find_objects.py
+++ b/plantcv/plantcv/find_objects.py
@@ -26,12 +26,11 @@ def find_objects(img, mask):
     :return objects: list
     :return hierarchy: numpy.ndarray
     """
-    mask1 = np.copy(mask)
     ori_img = np.copy(img)
     # If the reference image is grayscale convert it to color
     if len(np.shape(ori_img)) == 2:
         ori_img = cv2.cvtColor(ori_img, cv2.COLOR_GRAY2BGR)
-    objects, hierarchy = _cv2_findcontours(bin_img=mask1)
+    objects, hierarchy = _cv2_findcontours(bin_img=mask)
     # Cast tuple objects as a list
     objects = list(objects)
     for i, cnt in enumerate(objects):

--- a/plantcv/plantcv/morphology/_iterative_prune.py
+++ b/plantcv/plantcv/morphology/_iterative_prune.py
@@ -1,9 +1,9 @@
 import cv2
 import numpy as np
 from plantcv.plantcv import params
-from plantcv.plantcv import find_objects
 from plantcv.plantcv import image_subtract
 from plantcv.plantcv.morphology import find_tips
+from plantcv.plantcv._helpers import _cv2_findcontours
 
 
 def _iterative_prune(skel_img, size):
@@ -25,7 +25,7 @@ def _iterative_prune(skel_img, size):
     params.debug = None
 
     # Check to see if the skeleton has multiple objects
-    objects, _ = find_objects(pruned_img, pruned_img)
+    objects, _ = _cv2_findcontours(bin_img=pruned_img)
 
     # Iteratively remove endpoints (tips) from a skeleton
     for i in range(0, size):
@@ -35,8 +35,8 @@ def _iterative_prune(skel_img, size):
     # Make debugging image
     pruned_plot = np.zeros(skel_img.shape[:2], np.uint8)
     pruned_plot = cv2.cvtColor(pruned_plot, cv2.COLOR_GRAY2RGB)
-    skel_obj, skel_hierarchy = find_objects(skel_img, skel_img)
-    pruned_obj, pruned_hierarchy = find_objects(pruned_img, pruned_img)
+    skel_obj, skel_hierarchy = _cv2_findcontours(bin_img=pruned_img)
+    pruned_obj, pruned_hierarchy = _cv2_findcontours(bin_img=pruned_img)
 
     # Reset debug mode
     params.debug = debug

--- a/plantcv/plantcv/morphology/check_cycles.py
+++ b/plantcv/plantcv/morphology/check_cycles.py
@@ -7,9 +7,9 @@ from plantcv.plantcv import params
 from plantcv.plantcv import erode
 from plantcv.plantcv import dilate
 from plantcv.plantcv import outputs
-from plantcv.plantcv import find_objects
 from plantcv.plantcv import color_palette
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 
 
 def check_cycles(skel_img, label="default"):
@@ -45,7 +45,7 @@ def check_cycles(skel_img, label="default"):
     just_cycles = erode(just_cycles, 2, 1)
 
     # Use pcv.find_objects to turn plots of holes into countable contours
-    cycle_objects, cycle_hierarchies = find_objects(just_cycles, just_cycles)
+    cycle_objects, cycle_hierarchies = _cv2_findcontours(bin_img=just_cycles)
 
     # Count the number of holes
     num_cycles = len(cycle_objects)

--- a/plantcv/plantcv/morphology/find_branch_pts.py
+++ b/plantcv/plantcv/morphology/find_branch_pts.py
@@ -6,8 +6,8 @@ import numpy as np
 from plantcv.plantcv import params
 from plantcv.plantcv import dilate
 from plantcv.plantcv import outputs
-from plantcv.plantcv import find_objects
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 
 
 def find_branch_pts(skel_img, mask=None, label="default"):
@@ -79,11 +79,11 @@ def find_branch_pts(skel_img, mask=None, label="default"):
         # Make debugging image on mask
         mask_copy = mask.copy()
         branch_plot = cv2.cvtColor(mask_copy, cv2.COLOR_GRAY2RGB)
-        skel_obj, skel_hier = find_objects(skel_img, skel_img)
+        skel_obj, skel_hier = _cv2_findcontours(bin_img=skel_img)
         cv2.drawContours(branch_plot, skel_obj, -1, (150, 150, 150), params.line_thickness, lineType=8,
                          hierarchy=skel_hier)
 
-    branch_objects, _ = find_objects(branch_pts_img, branch_pts_img)
+    branch_objects, _ = _cv2_findcontours(bin_img=branch_pts_img)
 
     # Initialize list of tip data points
     branch_list = []

--- a/plantcv/plantcv/morphology/find_tips.py
+++ b/plantcv/plantcv/morphology/find_tips.py
@@ -6,8 +6,8 @@ import numpy as np
 from plantcv.plantcv import params
 from plantcv.plantcv import dilate
 from plantcv.plantcv import outputs
-from plantcv.plantcv import find_objects
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 
 
 def find_tips(skel_img, mask=None, label="default"):
@@ -51,7 +51,7 @@ def find_tips(skel_img, mask=None, label="default"):
     # Store debug
     debug = params.debug
     params.debug = None
-    tip_objects, _ = find_objects(tip_img, tip_img)
+    tip_objects, _ = _cv2_findcontours(bin_img=tip_img)
 
     if mask is None:
         # Make debugging image
@@ -62,7 +62,7 @@ def find_tips(skel_img, mask=None, label="default"):
         # Make debugging image on mask
         mask_copy = mask.copy()
         tip_plot = cv2.cvtColor(mask_copy, cv2.COLOR_GRAY2RGB)
-        skel_obj, skel_hier = find_objects(skel_img, skel_img)
+        skel_obj, skel_hier = _cv2_findcontours(bin_img=skel_img)
         cv2.drawContours(tip_plot, skel_obj, -1, (150, 150, 150), params.line_thickness,
                          lineType=8, hierarchy=skel_hier)
 

--- a/plantcv/plantcv/morphology/prune.py
+++ b/plantcv/plantcv/morphology/prune.py
@@ -4,12 +4,12 @@ import os
 import cv2
 import numpy as np
 from plantcv.plantcv import params
-from plantcv.plantcv import find_objects
 from plantcv.plantcv import image_subtract
 from plantcv.plantcv.morphology import segment_sort
 from plantcv.plantcv.morphology import segment_skeleton
 from plantcv.plantcv.morphology import _iterative_prune
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 
 
 def prune(skel_img, size=0, mask=None):
@@ -43,7 +43,7 @@ def prune(skel_img, size=0, mask=None):
     pruned_img = skel_img.copy()
 
     # Check to see if the skeleton has multiple objects
-    skel_objects, _ = find_objects(skel_img, skel_img)
+    skel_objects, _ = _cv2_findcontours(bin_img=skel_img)
 
     _, objects = segment_skeleton(skel_img)
     kept_segments = []
@@ -80,7 +80,7 @@ def prune(skel_img, size=0, mask=None):
     else:
         pruned_plot = mask.copy()
     pruned_plot = cv2.cvtColor(pruned_plot, cv2.COLOR_GRAY2RGB)
-    pruned_obj, pruned_hierarchy = find_objects(pruned_img, pruned_img)
+    pruned_obj, _ = _cv2_findcontours(bin_img=pruned_img)
     cv2.drawContours(pruned_plot, removed_segments, -1, (0, 0, 255), params.line_thickness, lineType=8)
     cv2.drawContours(pruned_plot, pruned_obj, -1, (150, 150, 150), params.line_thickness, lineType=8)
 

--- a/plantcv/plantcv/morphology/segment_curvature.py
+++ b/plantcv/plantcv/morphology/segment_curvature.py
@@ -5,12 +5,12 @@ import cv2
 import numpy as np
 from plantcv.plantcv import params
 from plantcv.plantcv import outputs
-from plantcv.plantcv import find_objects
 from plantcv.plantcv import color_palette
 from plantcv.plantcv.morphology import find_tips
 from plantcv.plantcv.morphology import segment_path_length
 from plantcv.plantcv.morphology import segment_euclidean_length
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 
 
 def segment_curvature(segmented_img, objects, label="default"):
@@ -55,7 +55,7 @@ def segment_curvature(segmented_img, objects, label="default"):
         finding_tips_img = np.zeros(segmented_img.shape[:2], np.uint8)
         cv2.drawContours(finding_tips_img, objects, i, (255, 255, 255), 1, lineType=8)
         segment_tips = find_tips(finding_tips_img)
-        tip_objects, tip_hierarchies = find_objects(segment_tips, segment_tips)
+        tip_objects, tip_hierarchies = _cv2_findcontours(bin_img=segment_tips)
         points = []
 
         for t in tip_objects:

--- a/plantcv/plantcv/morphology/segment_euclidean_length.py
+++ b/plantcv/plantcv/morphology/segment_euclidean_length.py
@@ -6,9 +6,9 @@ import numpy as np
 from plantcv.plantcv import params
 from plantcv.plantcv import outputs
 from plantcv.plantcv import fatal_error
-from plantcv.plantcv import find_objects
 from plantcv.plantcv import color_palette
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 from plantcv.plantcv.morphology import find_tips
 from scipy.spatial.distance import euclidean
 
@@ -49,7 +49,7 @@ def segment_euclidean_length(segmented_img, objects, label="default"):
         finding_tips_img = np.zeros(segmented_img.shape[:2], np.uint8)
         cv2.drawContours(finding_tips_img, objects, i, (255, 255, 255), 1, lineType=8)
         segment_tips = find_tips(finding_tips_img)
-        tip_objects, tip_hierarchies = find_objects(segment_tips, segment_tips)
+        tip_objects, _ = _cv2_findcontours(bin_img=segment_tips)
         points = []
         if not len(tip_objects) == 2:
             fatal_error("Too many tips found per segment, try pruning again")

--- a/plantcv/plantcv/morphology/segment_skeleton.py
+++ b/plantcv/plantcv/morphology/segment_skeleton.py
@@ -4,11 +4,11 @@ import os
 import cv2
 from plantcv.plantcv import dilate
 from plantcv.plantcv import params
-from plantcv.plantcv import find_objects
 from plantcv.plantcv import color_palette
 from plantcv.plantcv import image_subtract
 from plantcv.plantcv.morphology import find_branch_pts
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 
 
 def segment_skeleton(skel_img, mask=None):
@@ -39,7 +39,7 @@ def segment_skeleton(skel_img, mask=None):
     segments = image_subtract(skel_img, bp)
 
     # Gather contours of leaves
-    segment_objects, _ = find_objects(segments, segments)
+    segment_objects, _ = _cv2_findcontours(bin_img=segments)
 
     # Reset debug mode
     params.debug = debug

--- a/plantcv/plantcv/morphology/segment_tangent_angle.py
+++ b/plantcv/plantcv/morphology/segment_tangent_angle.py
@@ -6,10 +6,10 @@ import numpy as np
 import pandas as pd
 from plantcv.plantcv import params
 from plantcv.plantcv import outputs
-from plantcv.plantcv import find_objects
 from plantcv.plantcv import color_palette
 from plantcv.plantcv.morphology import _iterative_prune
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 
 
 def _slope_to_intesect_angle(m1, m2):
@@ -68,7 +68,7 @@ def segment_tangent_angle(segmented_img, objects, size, label="default"):
         cv2.drawContours(labeled_img, objects, i, rand_color[i], params.line_thickness, lineType=8)
         pruned_segment = _iterative_prune(find_tangents, size)
         segment_ends = find_tangents - pruned_segment
-        segment_end_obj, segment_end_hierarchy = find_objects(segment_ends, segment_ends)
+        segment_end_obj, _ = _cv2_findcontours(bin_img=segment_ends)
         slopes = []
         for j, obj in enumerate(segment_end_obj):
             # Find bounds for regression lines to get drawn

--- a/plantcv/plantcv/rectangle_mask.py
+++ b/plantcv/plantcv/rectangle_mask.py
@@ -5,6 +5,7 @@ import numpy as np
 import os
 from plantcv.plantcv import fatal_error
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 from plantcv.plantcv import params
 
 
@@ -47,7 +48,7 @@ def rectangle_mask(img, p1, p2, color="black"):
 
     cv2.rectangle(img=bnk, pt1=p1, pt2=p2, color=(255, 255, 255), thickness=-1)
     ret, bnk = cv2.threshold(bnk, 127, 255, 0)
-    contour, hierarchy = cv2.findContours(bnk, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+    contour, hierarchy = _cv2_findcontours(bin_img=bnk)
     # make sure entire rectangle is within (visable within) plotting region or else it will not fill with
     # thickness = -1. Note that you should only print the first contour (contour[0]) if you want to fill with
     # thickness = -1. otherwise two rectangles will be drawn and the space between them will get filled

--- a/plantcv/plantcv/report_size_marker_area.py
+++ b/plantcv/plantcv/report_size_marker_area.py
@@ -5,12 +5,12 @@ import numpy as np
 import os
 from plantcv.plantcv import fatal_error
 from plantcv.plantcv import rgb2gray_hsv
-from plantcv.plantcv import find_objects
 from plantcv.plantcv.threshold import binary as binary_threshold
 from plantcv.plantcv import roi_objects
 from plantcv.plantcv import object_composition
 from plantcv.plantcv import apply_mask
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 from plantcv.plantcv import params
 from plantcv.plantcv import outputs
 
@@ -75,7 +75,7 @@ def report_size_marker_area(img, roi_contour, roi_hierarchy, marker='define', ob
             # Threshold the HSV image
             marker_bin = binary_threshold(gray_img=marker_hsv, threshold=thresh, max_value=255, object_type=objcolor)
             # Identify contours in the masked image
-            contours, hierarchy = find_objects(img=ref_img, mask=marker_bin)
+            contours, hierarchy = _cv2_findcontours(bin_img=marker_bin)
             # Filter marker contours using the input ROI
             kept_contours, kept_hierarchy, kept_mask, obj_area = roi_objects(img=ref_img, object_contour=contours,
                                                                              obj_hierarchy=hierarchy,
@@ -92,7 +92,7 @@ def report_size_marker_area(img, roi_contour, roi_hierarchy, marker='define', ob
             fatal_error('thresh_channel and thresh must be defined in detect mode')
     elif marker.upper() == "DEFINE":
         # Identify contours in the masked image
-        contours, hierarchy = find_objects(img=ref_img, mask=roi_mask)
+        contours, hierarchy = _cv2_findcontours(bin_img=roi_mask)
         # If there are more than one contour detected, combine them into one
         # These become the marker contour and mask
         marker_contour, marker_mask = object_composition(img=ref_img, contours=contours, hierarchy=hierarchy)

--- a/plantcv/plantcv/roi/roi_methods.py
+++ b/plantcv/plantcv/roi/roi_methods.py
@@ -5,6 +5,7 @@ import cv2
 import numpy as np
 from sklearn.mixture import GaussianMixture
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 from plantcv.plantcv import fatal_error, params, Objects
 
 
@@ -30,7 +31,7 @@ def from_binary_image(img, bin_img):
     if len(np.unique(bin_img)) != 2:
         fatal_error("Input image is not binary!")
     # Use the binary image to create an ROI contour
-    roi_contour, roi_hierarchy = cv2.findContours(np.copy(bin_img), cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+    roi_contour, roi_hierarchy = _cv2_findcontours(bin_img=np.copy(bin_img))
     # Draw the ROI if requested
     _draw_roi(img=img, roi_contour=roi_contour)
 
@@ -115,7 +116,7 @@ def circle(img, x, y, r):
     cv2.circle(bin_img, (x, y), r, 255, -1)
 
     # Use the binary image to create an ROI contour
-    roi_contour, roi_hierarchy = cv2.findContours(bin_img, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+    roi_contour, roi_hierarchy = _cv2_findcontours(bin_img=bin_img)
 
     # Draw the ROI if requested
     _draw_roi(img=img, roi_contour=roi_contour)
@@ -162,7 +163,7 @@ def ellipse(img, x, y, r1, r2, angle):
     cv2.ellipse(bin_img, (x, y), (r1, r2), angle, 0, 360, 255, -1)
 
     # Use the binary image to create an ROI contour
-    roi_contour, roi_hierarchy = cv2.findContours(bin_img, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+    roi_contour, roi_hierarchy = _cv2_findcontours(bin_img=bin_img)
 
     # Draw the ROI if requested
     _draw_roi(img=img, roi_contour=roi_contour)
@@ -194,7 +195,7 @@ def _draw_roi(img, roi_contour):
 
 
 def _calculate_grid(mask, nrows, ncols):
-    contours, hierarchy = cv2.findContours(mask, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+    contours, _ = cv2.findContours(mask, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)[-2:]
     centers = []
     for c in contours:
         m = cv2.moments(c)
@@ -337,7 +338,7 @@ def auto_grid(mask, nrows, ncols, radius=None, img=None):
               "If you only see one ROI then they may overlap exactly.")
     # Draw the ROIs if requested
     # Create an array of contours and list of hierarchy for debug image
-    roi_contour1, _ = cv2.findContours(all_roi_img, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+    roi_contour1, _ = _cv2_findcontours(bin_img=all_roi_img)
     _draw_roi(img=img, roi_contour=roi_contour1)
     return roi_objects
 
@@ -382,7 +383,7 @@ def multi(img, coord, radius=None, spacing=None, nrows=None, ncols=None):
 
     # Draw the ROIs if requested
     # Create an array of contours and list of hierarchy for debug image
-    roi_contour1, _ = cv2.findContours(all_roi_img, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+    roi_contour1, _ = _cv2_findcontours(bin_img=all_roi_img)
     _draw_roi(img=img, roi_contour=roi_contour1)
     return roi_objects
 

--- a/plantcv/plantcv/roi/roi_methods.py
+++ b/plantcv/plantcv/roi/roi_methods.py
@@ -31,7 +31,7 @@ def from_binary_image(img, bin_img):
     if len(np.unique(bin_img)) != 2:
         fatal_error("Input image is not binary!")
     # Use the binary image to create an ROI contour
-    roi_contour, roi_hierarchy = _cv2_findcontours(bin_img=np.copy(bin_img))
+    roi_contour, roi_hierarchy = _cv2_findcontours(bin_img=bin_img)
     # Draw the ROI if requested
     _draw_roi(img=img, roi_contour=roi_contour)
 

--- a/plantcv/plantcv/roi_objects.py
+++ b/plantcv/plantcv/roi_objects.py
@@ -5,6 +5,7 @@ import numpy as np
 import os
 from plantcv.plantcv import logical_and
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 from plantcv.plantcv import fatal_error
 from plantcv.plantcv import params
 
@@ -69,7 +70,7 @@ def roi_objects(img, roi_contour, roi_hierarchy, object_contour, obj_hierarchy, 
                 cv2.drawContours(mask, object_contour, c, (0), -1, lineType=8, hierarchy=obj_hierarchy)
 
         # Find the kept contours and area
-        kept_cnt, kept_hierarchy = cv2.findContours(np.copy(mask), cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+        kept_cnt, kept_hierarchy = _cv2_findcontours(bin_img=np.copy(mask))
         obj_area = cv2.countNonZero(mask)
 
         # Find the largest contour if roi_type is set to 'largest'
@@ -111,7 +112,7 @@ def roi_objects(img, roi_contour, roi_hierarchy, object_contour, obj_hierarchy, 
                 cv2.drawContours(mask, largest_cnt, i, color, -1, lineType=8, hierarchy=largest_hierarchy, maxLevel=0)
 
             # Refind contours and hierarchy from new mask so they are easier to work with downstream
-            kept_cnt, kept_hierarchy = cv2.findContours(np.copy(mask), cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+            kept_cnt, kept_hierarchy = _cv2_findcontours(bin_img=np.copy(mask))
 
             # Compute object area
             obj_area = cv2.countNonZero(mask)
@@ -128,7 +129,7 @@ def roi_objects(img, roi_contour, roi_hierarchy, object_contour, obj_hierarchy, 
         cv2.fillPoly(background2, [roi_points], (255))
         mask = cv2.multiply(background1, background2)
         obj_area = cv2.countNonZero(mask)
-        kept_cnt, kept_hierarchy = cv2.findContours(np.copy(mask), cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+        kept_cnt, kept_hierarchy = _cv2_findcontours(bin_img=np.copy(mask))
         cv2.drawContours(ori_img, kept_cnt, -1, (0, 255, 0), -1, lineType=8, hierarchy=kept_hierarchy)
         cv2.drawContours(ori_img, roi_contour, -1, (255, 0, 0), params.line_thickness, lineType=8,
                          hierarchy=roi_hierarchy)

--- a/plantcv/plantcv/roi_objects.py
+++ b/plantcv/plantcv/roi_objects.py
@@ -70,7 +70,7 @@ def roi_objects(img, roi_contour, roi_hierarchy, object_contour, obj_hierarchy, 
                 cv2.drawContours(mask, object_contour, c, (0), -1, lineType=8, hierarchy=obj_hierarchy)
 
         # Find the kept contours and area
-        kept_cnt, kept_hierarchy = _cv2_findcontours(bin_img=np.copy(mask))
+        kept_cnt, kept_hierarchy = _cv2_findcontours(bin_img=mask)
         obj_area = cv2.countNonZero(mask)
 
         # Find the largest contour if roi_type is set to 'largest'
@@ -112,7 +112,7 @@ def roi_objects(img, roi_contour, roi_hierarchy, object_contour, obj_hierarchy, 
                 cv2.drawContours(mask, largest_cnt, i, color, -1, lineType=8, hierarchy=largest_hierarchy, maxLevel=0)
 
             # Refind contours and hierarchy from new mask so they are easier to work with downstream
-            kept_cnt, kept_hierarchy = _cv2_findcontours(bin_img=np.copy(mask))
+            kept_cnt, kept_hierarchy = _cv2_findcontours(bin_img=mask)
 
             # Compute object area
             obj_area = cv2.countNonZero(mask)
@@ -129,7 +129,7 @@ def roi_objects(img, roi_contour, roi_hierarchy, object_contour, obj_hierarchy, 
         cv2.fillPoly(background2, [roi_points], (255))
         mask = cv2.multiply(background1, background2)
         obj_area = cv2.countNonZero(mask)
-        kept_cnt, kept_hierarchy = _cv2_findcontours(bin_img=np.copy(mask))
+        kept_cnt, kept_hierarchy = _cv2_findcontours(bin_img=mask)
         cv2.drawContours(ori_img, kept_cnt, -1, (0, 255, 0), -1, lineType=8, hierarchy=kept_hierarchy)
         cv2.drawContours(ori_img, roi_contour, -1, (255, 0, 0), params.line_thickness, lineType=8,
                          hierarchy=roi_hierarchy)

--- a/plantcv/plantcv/visualize/obj_size_ecdf.py
+++ b/plantcv/plantcv/visualize/obj_size_ecdf.py
@@ -5,6 +5,7 @@ import cv2
 import pandas as pd
 from plantcv.plantcv import params
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _cv2_findcontours
 from statsmodels.distributions.empirical_distribution import ECDF
 from plotnine import ggplot, aes, geom_point, labels, scale_x_log10
 
@@ -24,7 +25,7 @@ def obj_size_ecdf(mask, title=None):
     :param title: str
     :return fig_ecdf: plotnine.ggplot.ggplot
     """
-    objects, _ = cv2.findContours(mask, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2:]
+    objects, _ = _cv2_findcontours(bin_img=mask)
     areas = [cv2.contourArea(cnt) for cnt in objects]
     # Remove objects with areas < 1px
     areas = [i for i in areas if i >= 1.0]


### PR DESCRIPTION
**Describe your changes**
We utilize `cv2.findContours` throughout PlantCV and use a mixture of directly using the OpenCV function or use the PlantCV wrapper `find_objects`. In most cases it's simpler to use the OpenCV function rather than using the PlantCV wrapper within the code. Additionally, if OpenCV ever changes the function signature then PlantCV has to be changed in many places. This PR adds a helper function that calls `cv2.findContours` and replaces direct usage throughout PlantCV to use the helper function. 

**Type of update**
Is this a: Code refactoring

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/stable/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
