### PR TITLE
Enable actions release4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,10 +6,10 @@ name: builds
 on:
   push:
     # Run when main is updated
-    branches: [ main, 4.x ]
+    branches: [ main, 4.x, release-4.0 ]
   pull_request:
     # Run on pull requests against main
-    branches: [ main, 4.x ]
+    branches: [ main, 4.x, release-4.0 ]
 
 jobs:
   build:


### PR DESCRIPTION
**Describe your changes**
Updates the GitHub Actions workflow to run CI workflow on the `release-4.0` branch. Branch settings were also updated to protect the branch and require PRs to update and reviews before merging.

**Type of update**
Is this a: Update

**Additional context**
The branch `release-4.0` will be used to collect the remaining breaking changes mapped out for the v4.0 release.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/stable/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [ ] PR approved
