### PR TITLE
Fix test cache dir

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@
 name: plantcv
 dependencies:
   - python=3.9
-  - matplotlib>=1.5
+  - matplotlib>=1.5,<3.6
   - numpy>=1.11,<1.23
   - pandas
   - python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib>=1.5
+matplotlib>=1.5,<3.6
 numpy>=1.11,<1.23
 pandas
 python-dateutil

--- a/tests/plantcv/test_segment_image_series.py
+++ b/tests/plantcv/test_segment_image_series.py
@@ -3,6 +3,7 @@ import cv2
 import numpy as np
 from plantcv.plantcv import segment_image_series
 from plantcv.plantcv.roi import multi
+from plantcv.plantcv import params
 
 
 def test_plantcv_segment_image_series(tmpdir):
@@ -20,6 +21,7 @@ def test_plantcv_segment_image_series(tmpdir):
     rng = np.random.default_rng(0)
     # Create a test tmp directory
     cache_dir = tmpdir.mkdir("cache")
+    params.debug_outdir = cache_dir
     cache_img_dir = os.path.join(cache_dir, 'segment_image_series_images')
     os.mkdir(cache_img_dir)
     cache_mask_dir = os.path.join(cache_dir, 'segment_image_series_masks')

--- a/tests/plantcv/test_segment_image_series.py
+++ b/tests/plantcv/test_segment_image_series.py
@@ -11,11 +11,10 @@ def test_plantcv_segment_image_series(tmpdir):
     # parameters for the synthetic image series to generate
     H, W, C = 32, 32, 3
     FRAMES = 10
-    RGB_VAL = [50,150,50]
-    N_OBJ = 10
-    OBJ1_COORDS = [10,10]
-    SPACING = (10,10)
-    OBJ2_COORDS = [OBJ1_COORDS[0]+SPACING[0],OBJ1_COORDS[1]+SPACING[1]]
+    RGB_VAL = [50, 150, 50]
+    OBJ1_COORDS = [10, 10]
+    SPACING = (10, 10)
+    OBJ2_COORDS = [OBJ1_COORDS[0]+SPACING[0], OBJ1_COORDS[1]+SPACING[1]]
     OBJ_SIZE = 4
 
     rng = np.random.default_rng(0)
@@ -36,18 +35,18 @@ def test_plantcv_segment_image_series(tmpdir):
     obj1_init = np.array(OBJ1_COORDS)
     obj2_init = np.array(OBJ2_COORDS)
     for i in range(FRAMES):
-        img = np.zeros((H,W,C), dtype=np.uint8)
+        img = np.zeros((H, W, C), dtype=np.uint8)
 
-        obj1  = obj1_init + rng.integers(low=-1, high=1, size=2)
-        img[obj1[0]:obj1[0]+OBJ_SIZE,obj1[1]:obj1[1]+OBJ_SIZE,:] = RGB_VAL
-        obj2  = obj2_init  + rng.integers(low=-1, high=1, size=2)
-        img[obj2[0]:obj2[0]+OBJ_SIZE,obj2[1]:obj2[1]+OBJ_SIZE,:] = RGB_VAL
+        obj1 = obj1_init + rng.integers(low=-1, high=1, size=2)
+        img[obj1[0]:obj1[0]+OBJ_SIZE, obj1[1]:obj1[1]+OBJ_SIZE, :] = RGB_VAL
+        obj2 = obj2_init + rng.integers(low=-1, high=1, size=2)
+        img[obj2[0]:obj2[0]+OBJ_SIZE, obj2[1]:obj2[1]+OBJ_SIZE, :] = RGB_VAL
 
         img_path = os.path.join(cache_img_dir, f"{i}.png")
         mask_path = os.path.join(cache_mask_dir, f"{i}_mask.png")
 
         cv2.imwrite(img_path, img)
-        cv2.imwrite(mask_path, 255*(img!=0).astype(np.uint8))
+        cv2.imwrite(mask_path, 255*(img != 0).astype(np.uint8))
 
         imgs_paths.append(img_path)
         masks_paths.append(mask_path)
@@ -63,6 +62,6 @@ def test_plantcv_segment_image_series(tmpdir):
     # to the last frame
     markers = segment_image_series(imgs_paths, masks_paths, rois=valid_rois, save_labels=True, ksize=3)
 
-    nb_obj = np.unique(markers[:,:,FRAMES-1]).size - 1
+    nb_obj = np.unique(markers[:, :, FRAMES-1]).size - 1
 
     assert nb_obj == 2


### PR DESCRIPTION
**Describe your changes**
This PR sets the `pcv.params.debug_outdir` to the test cache tmp directory for the test `test_segment_image_series` to prevent test files from being saved to the source directory. Minor code format changes are also included

**Type of update**
Is this a: Bug fix

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/stable/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
