### PR TITLE
Reconfigure dask futures and client management

### DIFF
--- a/plantcv/parallel/multiprocess.py
+++ b/plantcv/parallel/multiprocess.py
@@ -60,13 +60,7 @@ def multiprocess(jobs, client):
     :param client: distributed.client.Client
     """
     # Keep a list of job futures
-    processed = []
-    # Submit the jobs to the scheduler
-    for job in jobs:
-        # Submit individual job
-        processed.append(client.submit(_process_images_multiproc, job))
+    futures = client.map(_process_images_multiproc, jobs)
     # Watch job progress and print a progress bar
-    progress(processed)
-    # Each job outputs results to disk so we do not need to gather results here
-    client.shutdown()
+    progress(futures)
 ###########################################

--- a/tests/parallel/test_multiprocess.py
+++ b/tests/parallel/test_multiprocess.py
@@ -3,6 +3,7 @@ import os
 import dask
 from dask.distributed import Client
 from plantcv.parallel import create_dask_cluster, multiprocess
+from plantcv.parallel.multiprocess import _process_images_multiproc
 
 
 def test_create_dask_cluster_local(tmpdir):
@@ -33,7 +34,7 @@ def test_create_dask_cluster_invalid_cluster():
         _ = create_dask_cluster(cluster="Skynet", cluster_config={})
 
 
-def test_plantcv_parallel_multiprocess(parallel_test_data, tmpdir):
+def test_multiprocess(parallel_test_data, tmpdir):
     """Test for PlantCV."""
     # Create tmp directory
     tmp_dir = tmpdir.mkdir("sub")
@@ -47,3 +48,9 @@ def test_plantcv_parallel_multiprocess(parallel_test_data, tmpdir):
     client = Client(n_workers=1)
     multiprocess(jobs, client=client)
     assert os.path.exists(result_file)
+
+
+def test_process_images_multiproc():
+    """Test for PlantCV."""
+    result = _process_images_multiproc(['python', '-c', 'print("Hello World!")'])
+    assert result is None

--- a/tests/parallel/test_multiprocess.py
+++ b/tests/parallel/test_multiprocess.py
@@ -13,7 +13,6 @@ def test_create_dask_cluster_local(tmpdir):
     dask.config.set(temporary_directory=tmp_dir)
     client = create_dask_cluster(cluster="LocalCluster", cluster_config={})
     status = client.status
-    client.shutdown()
     assert status == "running"
 
 
@@ -25,7 +24,6 @@ def test_create_dask_cluster(tmpdir):
     dask.config.set(temporary_directory=tmp_dir)
     client = create_dask_cluster(cluster="HTCondorCluster", cluster_config={"cores": 1, "memory": "1GB", "disk": "1GB"})
     status = client.status
-    client.shutdown()
     assert status == "running"
 
 


### PR DESCRIPTION
**Describe your changes**
This PR simplifies the `pcv.parallel.multiprocess` function to use the Dask client map function to submit jobs to the cluster. Map creates a futures object that can then be monitored with `progress`. The aim here is to properly populate the client cluster and shut it down upon completion to eliminate client errors that have been oberved.

**Type of update**
Is this a: update

**Associated issues**
#922

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/stable/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
