### PR TITLE
Pin matplotlib to < 3.6

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@
 name: plantcv
 dependencies:
   - python=3.9
-  - matplotlib>=1.5
+  - matplotlib>=1.5,<3.6
   - numpy>=1.11,<1.23
   - pandas
   - python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib>=1.5
+matplotlib>=1.5,<3.6
 numpy>=1.11,<1.23
 pandas
 python-dateutil


### PR DESCRIPTION
**Describe your changes**
Temporarily pin matplotlib to < v3.6 due to issues with plotnine. After merging, sync changes with the 4.x and release-4.0 branches.

**Type of update**
Is this a: Bug fix

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/stable/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
