### PR TITLE
Add wavelength means Observation to analyze_spectral function

### DIFF
--- a/docs/analyze_spectral.md
+++ b/docs/analyze_spectral.md
@@ -14,7 +14,8 @@ the values out as observations to get saved out. Can also print out a histogram 
     - label         - Optional label parameter, modifies the variable name of observations recorded. (default `label="default"`)
 - **Example use:**
     - Below 
-- **Output data stored:** Data ('max_reflectance', 'min_reflectance', 'median_reflectance', 'spectral_std', 'spectral_frequencies', 'global_mean_reflectance', 'global_median_reflectance', 'global_spectral_std') automatically gets stored to the 
+- **Output data stored:** Data ('global_mean_reflectance', 'global_median_reflectance', 'global_spectral_std', 'wavelength_means', 'max_reflectance', 
+    'min_reflectance', 'spectral_std', 'spectral_frequencies') automatically gets stored to the 
     [`Outputs` class](outputs.md) when this function is ran. 
     These data can always get accessed during a workflow (example below). For more detail about data output see [Summary of Output Observations](output_measurements.md#summary-of-output-observations)
 

--- a/plantcv/plantcv/hyperspectral/analyze_spectral.py
+++ b/plantcv/plantcv/hyperspectral/analyze_spectral.py
@@ -58,7 +58,7 @@ def analyze_spectral(array, mask, histplot=None, label="default"):
 
     for i, wavelength in enumerate(array.wavelength_dict):
         new_wavelengths.append(wavelength)
-        new_freq.append((wavelength_freq[i]).astype(float))
+        new_freq.append((wavelength_means[i]).astype(float))
         new_std_per_band.append(std_per_band[i].astype(float))
         new_max_per_band.append(max_per_band[i].astype(float))
         new_min_per_band.append(min_per_band[i].astype(float))

--- a/plantcv/plantcv/hyperspectral/analyze_spectral.py
+++ b/plantcv/plantcv/hyperspectral/analyze_spectral.py
@@ -83,9 +83,9 @@ def analyze_spectral(array, mask, histplot=None, label="default"):
                             trait='pixel-wise standard deviation per band',
                             method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='None', datatype=float,
                             value=float(std_reflectance), label='reflectance')
-    outputs.add_observation(sample=label, variable='wavelength_means', trait='pixel-wise standard deviation ',
+    outputs.add_observation(sample=label, variable='wavelength_means', trait='mean reflectance per band',
                             method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='reflectance', datatype=list,
-                            value=wavelength_means, label=wavelength_labels)
+                            value=wavelength_means.tolist(), label=wavelength_labels)
     outputs.add_observation(sample=label, variable='max_reflectance', trait='maximum reflectance per band',
                             method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='reflectance', datatype=list,
                             value=new_max_per_band, label=wavelength_labels)

--- a/plantcv/plantcv/hyperspectral/analyze_spectral.py
+++ b/plantcv/plantcv/hyperspectral/analyze_spectral.py
@@ -84,7 +84,7 @@ def analyze_spectral(array, mask, histplot=None, label="default"):
                             method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='None', datatype=float,
                             value=float(std_reflectance), label='reflectance')
     outputs.add_observation(sample=label, variable='wavelength_means', trait='pixel-wise standard deviation ',
-                            method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='None', datatype=list,
+                            method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='reflectance', datatype=list,
                             value=wavelength_means, label=wavelength_labels)
     outputs.add_observation(sample=label, variable='max_reflectance', trait='maximum reflectance per band',
                             method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='reflectance', datatype=list,

--- a/plantcv/plantcv/hyperspectral/analyze_spectral.py
+++ b/plantcv/plantcv/hyperspectral/analyze_spectral.py
@@ -51,14 +51,14 @@ def analyze_spectral(array, mask, histplot=None, label="default"):
     # Create lists with wavelengths in float format rather than as strings
     # and make a list of the frequencies since they are in an array
     new_wavelengths = []
-    new_freq = []
+    band_averages = []
     new_std_per_band = []
     new_max_per_band = []
     new_min_per_band = []
 
     for i, wavelength in enumerate(array.wavelength_dict):
         new_wavelengths.append(wavelength)
-        new_freq.append((wavelength_means[i]).astype(float))
+        band_averages.append((wavelength_means[i]).astype(float))
         new_std_per_band.append(std_per_band[i].astype(float))
         new_max_per_band.append(max_per_band[i].astype(float))
         new_min_per_band.append(min_per_band[i].astype(float))
@@ -85,7 +85,7 @@ def analyze_spectral(array, mask, histplot=None, label="default"):
                             value=float(std_reflectance), label='reflectance')
     outputs.add_observation(sample=label, variable='wavelength_means', trait='mean reflectance per band',
                             method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='reflectance', datatype=list,
-                            value=wavelength_means.tolist(), label=wavelength_labels)
+                            value=band_averages, label=wavelength_labels)
     outputs.add_observation(sample=label, variable='max_reflectance', trait='maximum reflectance per band',
                             method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='reflectance', datatype=list,
                             value=new_max_per_band, label=wavelength_labels)
@@ -95,9 +95,6 @@ def analyze_spectral(array, mask, histplot=None, label="default"):
     outputs.add_observation(sample=label, variable='spectral_std', trait='pixel-wise standard deviation per band',
                             method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='None', datatype=list,
                             value=new_std_per_band, label=wavelength_labels)
-    outputs.add_observation(sample=label, variable='spectral_frequencies', trait='spectral frequencies',
-                            method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='frequency', datatype=list,
-                            value=new_freq, label=wavelength_labels)
 
     dataset = pd.DataFrame({'Wavelength (' + array.wavelength_units + ')': new_wavelengths,
                             'Reflectance': wavelength_means})

--- a/plantcv/plantcv/hyperspectral/analyze_spectral.py
+++ b/plantcv/plantcv/hyperspectral/analyze_spectral.py
@@ -39,7 +39,7 @@ def analyze_spectral(array, mask, histplot=None, label="default"):
     wavelength_data = array_data[np.where(mask > 0)]
 
     # Calculate mean reflectance across wavelengths
-    wavelength_freq = wavelength_data.mean(axis=0)
+    wavelength_means = wavelength_data.mean(axis=0)
     max_per_band = wavelength_data.max(axis=0)
     min_per_band = wavelength_data.min(axis=0)
     std_per_band = wavelength_data.std(axis=0)
@@ -83,9 +83,9 @@ def analyze_spectral(array, mask, histplot=None, label="default"):
                             trait='pixel-wise standard deviation per band',
                             method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='None', datatype=float,
                             value=float(std_reflectance), label='reflectance')
-    outputs.add_observation(sample=label, variable='global_spectral_std', trait='pixel-wise standard deviation ',
-                            method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='None', datatype=float,
-                            value=float(std_reflectance), label='reflectance')
+    outputs.add_observation(sample=label, variable='wavelength_means', trait='pixel-wise standard deviation ',
+                            method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='None', datatype=list,
+                            value=wavelength_means, label=wavelength_labels)
     outputs.add_observation(sample=label, variable='max_reflectance', trait='maximum reflectance per band',
                             method='plantcv.plantcv.hyperspectral.analyze_spectral', scale='reflectance', datatype=list,
                             value=new_max_per_band, label=wavelength_labels)
@@ -100,7 +100,7 @@ def analyze_spectral(array, mask, histplot=None, label="default"):
                             value=new_freq, label=wavelength_labels)
 
     dataset = pd.DataFrame({'Wavelength (' + array.wavelength_units + ')': new_wavelengths,
-                            'Reflectance': wavelength_freq})
+                            'Reflectance': wavelength_means})
     mean_spectra = (ggplot(data=dataset,
                     mapping=aes(x='Wavelength (' + array.wavelength_units + ')', y='Reflectance'))
                     + geom_line(color='purple')

--- a/tests/plantcv/hyperspectral/test_analyze_spectral.py
+++ b/tests/plantcv/hyperspectral/test_analyze_spectral.py
@@ -10,4 +10,4 @@ def test_analyze_spectral(hyperspectral_test_data):
     mask = cv2.imread(hyperspectral_test_data.hsi_mask_file, -1)
     _ = analyze_spectral(array=hyperspectral_test_data.load_hsi(hyperspectral_test_data.hsi_file), mask=mask,
                          histplot=True, label="prefix")
-    assert len(outputs.observations['prefix']['spectral_frequencies']['value']) == 978
+    assert len(outputs.observations['prefix']['wavelength_means']['value']) == 978


### PR DESCRIPTION
**Describe your changes**
There was duplicate observations of global standard deviation within the `pcv.hyperspectral.analyze_spectral` function when we probably intended to include the wavelength averages calculated earlier in the function and then plotted out. This PR resolves these bugs and renamed the variable to be more accurate throughout the function. 

**Type of update**
Is this a:
* Bug fix
* New feature or feature enhancement


**Associated issues**
- Closes #962 

**Additional context**
Add any other context about the problem here.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/stable/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
