### PR TITLE
Fixed check for binary image

### DIFF
--- a/plantcv/plantcv/fill.py
+++ b/plantcv/plantcv/fill.py
@@ -25,7 +25,7 @@ def fill(bin_img, size):
     :return filtered_img: numpy.ndarray
     """
     # Make sure the image is binary
-    if len(np.shape(bin_img)) != 2 or len(np.unique(bin_img)) != 2:
+    if len(np.shape(bin_img)) != 2 or len(np.unique(bin_img)) > 2:
         fatal_error("Image is not binary")
 
     # Cast binary image to boolean


### PR DESCRIPTION
The check threw an error when the image was just black (only zeros) which broke workflows with images where no plant was visible.

**Describe your changes**
The check now raises an error if the number of unique values in the array is larger than 2. Before, it was checking if the number was NOT exactly two. An image with just zeros and ones can still be processed. 

**Type of update**
Is this a:
* Bug fix

**Associated issues**
None

**Additional context**
None

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/stable/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
