### PR TITLE
Fix ImportError in plantcv caused by change in skimage.feature function name

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.8', '3.9', '3.10']
         os: [ubuntu-latest]
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ['3.10']
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@main

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@
 # optionally, change channel name with -n {plantcv-dev}
 name: plantcv
 dependencies:
-  - python=3.9
+  - python=3.10
   - matplotlib>=1.5,<3.6
   - numpy>=1.11,<1.23
   - pandas

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pandas
   - python-dateutil
   - scipy
-  - scikit-image>=0.13
+  - scikit-image>=0.19
   - scikit-learn
   - plotnine
   - dask

--- a/plantcv/plantcv/closing.py
+++ b/plantcv/plantcv/closing.py
@@ -23,7 +23,7 @@ def closing(gray_img, kernel=None):
 
     # If image is binary use the faster method
     if len(np.unique(gray_img)) == 2:
-        bool_img = morphology.binary_closing(image=gray_img, selem=kernel)
+        bool_img = morphology.binary_closing(gray_img, kernel)
         filtered_img = np.copy(bool_img.astype(np.uint8) * 255)
     # Otherwise use method appropriate for grayscale images
     else:

--- a/plantcv/plantcv/threshold/threshold_methods.py
+++ b/plantcv/plantcv/threshold/threshold_methods.py
@@ -8,7 +8,7 @@ from matplotlib import pyplot as plt
 from plantcv.plantcv import fatal_error
 from plantcv.plantcv import params
 from plantcv.plantcv._debug import _debug
-from skimage.feature import greycomatrix, greycoprops
+from skimage.feature import graycomatrix, graycoprops
 from scipy.ndimage import generic_filter
 
 
@@ -301,9 +301,9 @@ def texture(gray_img, ksize, threshold, offset=3, texture_method='dissimilarity'
         inputs = np.reshape(a=inputs, newshape=[ksize, ksize])
         inputs = inputs.astype(np.uint8)
         # Greycomatrix takes image, distance offset, angles (in radians), symmetric, and normed
-        # http://scikit-image.org/docs/dev/api/skimage.feature.html#skimage.feature.greycomatrix
-        glcm = greycomatrix(inputs, [offset], [0], 256, symmetric=True, normed=True)
-        diss = greycoprops(glcm, texture_method)[0, 0]
+        # http://scikit-image.org/docs/dev/api/skimage.feature.html#skimage.feature.graycomatrix
+        glcm = graycomatrix(inputs, [offset], [0], 256, symmetric=True, normed=True)
+        diss = graycoprops(glcm, texture_method)[0, 0]
         return diss
 
     # Make an array the same size as the original image

--- a/plantcv/plantcv/watershed.py
+++ b/plantcv/plantcv/watershed.py
@@ -41,7 +41,9 @@ def watershed_segmentation(rgb_img, mask, distance=10, label="default"):
 
     dist_transform = cv2.distanceTransformWithLabels(mask, cv2.DIST_L2, maskSize=0)[0]
 
-    local_max = peak_local_max(dist_transform, min_distance=distance, labels=mask)
+    local_max_coordinates = peak_local_max(dist_transform, min_distance=distance, labels=mask)
+    local_max = np.zeros_like(dist_transform, dtype=bool)
+    local_max[tuple(local_max_coordinates.T)] = True
 
     markers = ndi.label(local_max, structure=np.ones((3, 3)))[0]
     dist_transform1 = -dist_transform

--- a/plantcv/plantcv/watershed.py
+++ b/plantcv/plantcv/watershed.py
@@ -41,7 +41,7 @@ def watershed_segmentation(rgb_img, mask, distance=10, label="default"):
 
     dist_transform = cv2.distanceTransformWithLabels(mask, cv2.DIST_L2, maskSize=0)[0]
 
-    local_max = peak_local_max(dist_transform, indices=False, min_distance=distance, labels=mask)
+    local_max = peak_local_max(dist_transform, min_distance=distance, labels=mask)
 
     markers = ndi.label(local_max, structure=np.ones((3, 3)))[0]
     dist_transform1 = -dist_transform

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy>=1.11,<1.23
 pandas
 python-dateutil
 scipy
-scikit-image>=0.13
+scikit-image>=0.19
 scikit-learn
 plotnine
 dask


### PR DESCRIPTION
Currently, when installing plantcv, the following error is raised: `ImportError: cannot import name 'greycomatrix' from 'skimage.feature'`
This is because skimage.feature changed their function name from greycomatrix to graycomatrix (see https://stackoverflow.com/questions/67537650/cannot-import-name-graycomatrix-from-skimage-feature ) from version 0.19. This commit changes the requirements.txt file and the function name.