### PR TITLE
Updated link and debug print to plot in texture_threshold.md

### DIFF
--- a/docs/texture_threshold.md
+++ b/docs/texture_threshold.md
@@ -15,8 +15,7 @@ texture calculation for thresholding.
     - offset - Distance offsets (default offset=3)
     - texture_method - Feature of a grey level co-occurrence matrix, either
                       ‘contrast’, ‘dissimilarity’ (default), ‘homogeneity’, ‘ASM’, ‘energy’,
-                      or ‘correlation’. For equations of different features see
-                      http://scikit-image.org/docs/dev/api/skimage.feature.html#greycoprops
+                      or ‘correlation’. For equations of different features see [this link](http://scikit-image.org/docs/dev/api/skimage.feature.html#greycoprops)
     - borders - How the array borders are handled, either ‘reflect’, ‘constant’, ‘nearest’ (default), ‘mirror’, or ‘wrap’
     - max_value - Value to apply above threshold (usually 255 = white)
 - **Context:**
@@ -37,7 +36,7 @@ from plantcv import plantcv as pcv
 # Set global debug behavior to None (default), "print" (to file), 
 # or "plot" (Jupyter Notebooks or X11)
 
-pcv.params.debug = "print"
+pcv.params.debug = "plot"
 
 # Create binary image from a gray image based on texture values.
 texture_img = pcv.threshold.texture(gray_img, ksize=6, threshold=7, offset=3, 


### PR DESCRIPTION
**Describe your changes**
"print" was changed to "plot" as a debug
Link was updated from a text link to a hyperlink

**Type of update**
Is this a:
* Update to documentation

**Associated issues**
Issue #999

**Additional context**
None

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/stable/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
