### PR TITLE
Fixed typo in visualize_colorspace.md

### DIFF
--- a/docs/visualize_colorspace.md
+++ b/docs/visualize_colorspace.md
@@ -2,7 +2,7 @@
 
 This is a plotting method used to examine all potential colorspaces from available PlantCV functions.
 
-**plantcv.visualize.colorspaces**(*rgb_img, originial_img=True*)
+**plantcv.visualize.colorspaces**(*rgb_img, original_img=True*)
 
 **returns** plotting_img
 


### PR DESCRIPTION
**Describe your changes**
Changed "plantcv.visualize.colorspaces(rgb_img, **originial**_img=True)" to plantcv.visualize.colorspaces(rgb_img, **original**_img=True)."

**Type of update**
Update to documentation

**Associated issues**
Issue #999 

**Additional context**
N/A

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/stable/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
