### PR TITLE
Update PULL_REQUEST_TEMPLATE.md changed PR template link from stable branch to latest branch.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@ Reference associated issue numbers. Does this pull request close any issues?
 Add any other context about the problem here.
 
 **For the reviewer**
-See [this page](https://plantcv.readthedocs.io/en/stable/pr_review_process/) for instructions on how to review the pull request.
+See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
 - [ ] PR functionality reviewed in a Jupyter Notebook
 - [ ] All tests pass
 - [ ] Test coverage remains 100%


### PR DESCRIPTION
PR template link was based on `stable` doc URL. Changed PR template link to `latest` branch.

**Describe your changes**
Updated PR template link so doc URL is based off `latest` branch.

**Type of update**
Is this a:
* Bug fix
* Update to documentation

**Associated issues**
Issue #918 

**Additional context**
Add any other context about the problem here.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/stable/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
