### PR TITLE
Scipy ndimage namespace fix 

### DIFF
--- a/plantcv/plantcv/fill_holes.py
+++ b/plantcv/plantcv/fill_holes.py
@@ -5,7 +5,7 @@ import os
 from plantcv.plantcv._debug import _debug
 from plantcv.plantcv import fatal_error
 from plantcv.plantcv import params
-from scipy.ndimage.morphology import binary_fill_holes
+from scipy.ndimage import binary_fill_holes
 
 
 def fill_holes(bin_img):

--- a/plantcv/plantcv/median_blur.py
+++ b/plantcv/plantcv/median_blur.py
@@ -4,7 +4,7 @@ import os
 from plantcv.plantcv._debug import _debug
 from plantcv.plantcv import params
 from plantcv.plantcv import fatal_error
-from scipy.ndimage.filters import median_filter
+from scipy.ndimage import median_filter
 
 
 def median_blur(gray_img, ksize):


### PR DESCRIPTION
**Describe your changes**
Changed the namespace for two functions being imported ( `scipy.ndimage.morphology` ->  `scipy.ndimage` , and `scipy.ndimage.filters` -> `scipy.ndimage`) in `fill_holes.py` and `median_blur.py`.

**Type of update**
Is this a:
* Bug fix (fixing a deprecation warning)

**Associated issues**
See comments in #999

**Additional context**
None

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/stable/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
