### PR TITLE
removed an 'else: pass' from analyze_object

### DIFF
--- a/plantcv/plantcv/analyze_object.py
+++ b/plantcv/plantcv/analyze_object.py
@@ -152,9 +152,6 @@ def analyze_object(img, obj, mask, label="default"):
 
         analysis_images.append(mask)
 
-    else:
-        pass
-
     outputs.add_observation(sample=label, variable='area', trait='area',
                             method='plantcv.plantcv.analyze_object', scale='pixels', datatype=int,
                             value=area, label='pixels')


### PR DESCRIPTION
**Describe your changes**
Removed an `else: pass` section after an `if area:` which was suspected to be a problem line for code coverage checks.

**Type of update**
Is this a:
* housekeeping

**Associated issues**
See #999 

**Additional context**
None

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/stable/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
