### PR TITLE
Simplify histogram code and fix bug in minimum value calculation

### DIFF
--- a/plantcv/plantcv/analyze_nir_intensity.py
+++ b/plantcv/plantcv/analyze_nir_intensity.py
@@ -66,7 +66,6 @@ def analyze_nir_intensity(gray_img, mask, bins=256, histplot=None, label="defaul
     # Print or plot masked image
     _debug(visual=masked1, filename=os.path.join(params.debug_outdir, str(params.device) + "_masked_nir_plant.png"))
 
-
     fig_hist = fig_hist + labs(x="Grayscale pixel intensity (0-{})".format(maxval), y="Proportion of pixels (%)")
 
     # Print or plot histogram

--- a/plantcv/plantcv/visualize/histogram.py
+++ b/plantcv/plantcv/visualize/histogram.py
@@ -2,7 +2,6 @@
 
 import os
 import numpy as np
-from plantcv.plantcv.threshold import binary as binary_threshold
 from plantcv.plantcv import params
 from plantcv.plantcv import fatal_error
 from plantcv.plantcv._debug import _debug
@@ -35,23 +34,13 @@ def _hist_gray(gray_img, bins, lower_bound, upper_bound, mask=None):
     :return hist_gray_data: numpy.ndarray
     """
     params.device += 1
-    debug = params.debug
+    # Create a dummy mask if none was supplied
+    if mask is None:
+        mask = np.ones(gray_img.shape, dtype=np.uint8)
 
-    # Apply mask if one is supplied
-    if mask is not None:
-        min_val = np.min(gray_img)
-        pixels = len(np.where(mask > 0)[0])
-        # apply plant shaped mask to image
-        params.debug = None
-        mask1 = binary_threshold(mask, 0, 255, 'light')
-        mask1 = (mask1 / 255)
-        masked = np.where(mask1 != 0, gray_img, min_val - 5000)
-
-    else:
-        pixels = gray_img.shape[0] * gray_img.shape[1]
-        masked = gray_img
-
-    params.debug = debug
+    # Apply mask
+    pixels = len(np.where(mask > 0)[0])
+    masked = gray_img[np.where(mask > 0)]
 
     # Store histogram data
     hist_gray_data, hist_bins = np.histogram(masked, bins, (lower_bound, upper_bound))


### PR DESCRIPTION
**Describe your changes**
The helper function `_hist_gray` ignores the `lower_bound` input when calculating the minimum image value. It uses a hard-coded value of 5000 the set masked values to a negative number, but for some images the minimum observed value is > 5000, causing a false peak in the grayscale histogram. This PR reduces the complexity of the function and fixes the bug.

**Type of update**
Is this a: Bug fix

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [ ] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
