### PR TITLE
Iterate analyze grayscale

### DIFF
--- a/docs/analyze_grayscale.md
+++ b/docs/analyze_grayscale.md
@@ -1,0 +1,51 @@
+## Analyze grayscale values
+
+This function calculates the intensity of each pixel associated with the plant and writes 
+the values out to the [Outputs class](outputs.md). Can also return/plot/print out a histogram plot of pixel intensity.
+
+**plantcv.analyze.grayscale**(*gray_img, labeled_mask, n_labels=1, bins=100, label="default"*)
+
+**returns** Histogram image
+
+- **Parameters:**
+    - gray_img - 8- or 16-bit grayscale image data.
+    - labeled_mask - Labeled mask of objects (32-bit).
+    - n_labels - Total number expected individual objects (default = 1).
+    - bins     - Number of histogram bins (default = 100)
+    - label - Optional label parameter, modifies the variable name of observations recorded. (default `label="default"`)
+- **Context:**
+    - Grayscale pixel values within a masked area of an image. 
+- **Example use:**
+    - [Use In NIR Tutorial](tutorials/nir_tutorial.md)
+- **Output data stored:** Data ('gray_frequencies', 'gray_mean', 'gray_median', 'nir_stdev') automatically gets stored to
+the [`Outputs` class](outputs.md) when this function is ran. These data can always get accessed during a workflow (example
+below). For more detail about data output see [Summary of Output Observations](output_measurements.md#summary-of-output-observations)
+
+**Original grayscale image**
+
+![Screenshot](img/documentation_images/analyze_NIR_intensity/original_image.jpg)
+
+```python
+
+from plantcv import plantcv as pcv
+
+# Set global debug behavior to None (default), "print" (to file), 
+# or "plot" (Jupyter Notebooks or X11)
+
+pcv.params.debug = "plot"
+
+# Caclulates the proportion of pixels that fall into a signal bin and writes the values to a file.
+# Also provides a histogram of this data
+analysis_image  = pcv.analyze.grayscale(gray_img=gray_img, labeled_mask=mask, n_labels=1, bins=100, label="default")
+
+# Access data stored out from analyze.grayscale
+nir_frequencies = pcv.outputs.observations['default1']['gray_frequencies']['value']
+
+```
+
+
+**Near-infrared signal histogram**
+
+![Screenshot](img/documentation_images/analyze_NIR_intensity/nir_histogram.jpg)
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/main/plantcv/plantcv/analyze/grayscale.py)

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -231,6 +231,12 @@ pages for more details on the input and output variable types.
 * post v4.0: histogram = **plantcv.analyze.color**(*rgb_img, labeled_mask, n_labels=1, colorspaces="hsv", label="default"*)
 
 
+#### plantcv.analyze.grayscale
+
+* pre v4.0: (see plantcv.analyze_nir_intensity)
+* post v4.0: histogram = **plantcv.analyze.grayscale**(*gray_img, labeled_mask, n_labels=1, bins=100, label="default"*)
+
+
 #### plantcv.analyze.size
 
 * pre v4.0: (see plantcv.analyze_object)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
     - 'PlantCV':
       - 'Analysis Methods':
         - 'Analyze Color': analyze_color2.md
+        - 'Analyze Grayscale': analyze_grayscale.md
         - 'Analyze Size and Shape': analyze_size.md
         - 'Horizontal Boundary Tool': analyze_bound_horizontal2.md
         - 'Vertical Boundary Tool': analyze_bound_vertical2.md

--- a/plantcv/plantcv/analyze/__init__.py
+++ b/plantcv/plantcv/analyze/__init__.py
@@ -2,5 +2,6 @@ from plantcv.plantcv.analyze.color import color
 from plantcv.plantcv.analyze.size import size
 from plantcv.plantcv.analyze.bound_horizontal import bound_horizontal
 from plantcv.plantcv.analyze.bound_vertical import bound_vertical
+from plantcv.plantcv.analyze.grayscale import grayscale
 
-__all__ = ["color", "bound_horizontal", "bound_vertical", "size"]
+__all__ = ["color", "bound_horizontal", "bound_vertical", "grayscale", "size"]

--- a/plantcv/plantcv/analyze/grayscale.py
+++ b/plantcv/plantcv/analyze/grayscale.py
@@ -28,7 +28,7 @@ def grayscale(gray_img, labeled_mask, n_labels=1, bins=100, label="default"):
     """
     _ = _iterate_analysis(img=gray_img, labeled_mask=labeled_mask, n_labels=n_labels, label=label, function=_analyze_grayscale,
                           **{"bins": bins})
-    gray_chart = outputs.plot_dists(variable="hue_frequencies")
+    gray_chart = outputs.plot_dists(variable="gray_frequencies")
     _debug(visual=gray_chart, filename=os.path.join(params.debug_outdir, str(params.device) + '_hue_hist.png'))
     return gray_chart
 

--- a/plantcv/plantcv/analyze/grayscale.py
+++ b/plantcv/plantcv/analyze/grayscale.py
@@ -1,0 +1,99 @@
+import os
+import numpy as np
+from plantcv.plantcv._debug import _debug
+from plantcv.plantcv import params, outputs
+from plantcv.plantcv.visualize import histogram
+from plantcv.plantcv._helpers import _iterate_analysis
+
+
+def grayscale(gray_img, labeled_mask, n_labels=1, bins=100, label="default"):
+    """Analyzes the grayscale values of a masked region of an image.
+
+    Inputs:
+    gray_img     = 8- or 16-bit grayscale image data.
+    labeled_mask = Labeled mask of objects (32-bit).
+    n_labels     = Total number expected individual objects (default = 1).
+    bins         = Number of histogram bins.
+    label        = optional label parameter, modifies the variable name of observations recorded (default = "default")
+
+    Returns:
+    analysis_image = Grayscale histogram image
+
+    :param gray_img: numpy.ndarray
+    :param labeled_mask: numpy.ndarray
+    :param n_labels: int
+    :param bins: int
+    :param label: str
+    :return analysis_image: altair.vegalite.v5.api.FacetChart
+    """
+    _ = _iterate_analysis(img=gray_img, labeled_mask=labeled_mask, n_labels=n_labels, label=label, function=_analyze_grayscale,
+                          **{"bins": bins})
+    gray_chart = outputs.plot_dists(variable="hue_frequencies")
+    _debug(visual=gray_chart, filename=os.path.join(params.debug_outdir, str(params.device) + '_hue_hist.png'))
+    return gray_chart
+
+
+def _analyze_grayscale(img, mask, bins=100, label="default"):
+    """Analyzes the grayscale values of a masked region of an image.
+
+    Inputs:
+    img          = 8- or 16-bit grayscale image data.
+    mask         = Labeled mask of objects (32-bit).
+    bins         = Number of histogram bins.
+    label        = optional label parameter, modifies the variable name of observations recorded (default = "default")
+
+    Returns:
+    img          = Input image
+
+    :param gray_img: numpy.ndarray
+    :param mask: numpy.ndarray
+    :param bins: int
+    :param label: str
+    :return img: numpy.ndarray
+    """
+    # Save user debug setting
+    debug = params.debug
+    params.debug = None
+
+    # Initialize output measurements
+    hist_gray = [0] * bins
+    bin_labels = list(range(0, bins))
+    masked_gray_mean = 0
+    masked_gray_median = 0
+    masked_gray_std = 0
+
+    # Skip empty masks
+    if np.count_nonzero(mask) != 0:
+        # calculate histogram
+        if img.dtype == 'uint16':
+            maxval = 65536
+        else:
+            maxval = 256
+
+        masked_array = img[np.where(mask > 0)]
+        masked_gray_mean = np.average(masked_array)
+        masked_gray_median = np.median(masked_array)
+        masked_gray_std = np.std(masked_array)
+
+        # Calculate histogram
+        fig_hist, hist_data = histogram(img, mask=mask, bins=bins, lower_bound=0, upper_bound=maxval, title=None,
+                                        hist_data=True)
+
+        bin_labels, hist_gray = hist_data["pixel intensity"].tolist(), hist_data['hist_count'].tolist()
+
+        outputs.add_observation(sample=label, variable='gray_frequencies', trait='grayscale frequencies',
+                                method='plantcv.plantcv.analyze.grayscale', scale='frequency', datatype=list,
+                                value=hist_gray, label=bin_labels)
+        outputs.add_observation(sample=label, variable='gray_mean', trait='grayscale mean',
+                                method='plantcv.plantcv.analyze.grayscale', scale='none', datatype=float,
+                                value=masked_gray_mean, label='none')
+        outputs.add_observation(sample=label, variable='nir_median', trait='grayscale median',
+                                method='plantcv.plantcv.analyze.grayscale', scale='none', datatype=float,
+                                value=masked_gray_median, label='none')
+        outputs.add_observation(sample=label, variable='nir_stdev', trait='grayscale standard deviation',
+                                method='plantcv.plantcv.analyze.grayscale', scale='none', datatype=float,
+                                value=masked_gray_std, label='none')
+    # Restore user debug setting
+    params.debug = debug
+
+    return img

--- a/plantcv/plantcv/analyze/grayscale.py
+++ b/plantcv/plantcv/analyze/grayscale.py
@@ -87,10 +87,10 @@ def _analyze_grayscale(img, mask, bins=100, label="default"):
         outputs.add_observation(sample=label, variable='gray_mean', trait='grayscale mean',
                                 method='plantcv.plantcv.analyze.grayscale', scale='none', datatype=float,
                                 value=masked_gray_mean, label='none')
-        outputs.add_observation(sample=label, variable='nir_median', trait='grayscale median',
+        outputs.add_observation(sample=label, variable='gray_median', trait='grayscale median',
                                 method='plantcv.plantcv.analyze.grayscale', scale='none', datatype=float,
                                 value=masked_gray_median, label='none')
-        outputs.add_observation(sample=label, variable='nir_stdev', trait='grayscale standard deviation',
+        outputs.add_observation(sample=label, variable='gray_stdev', trait='grayscale standard deviation',
                                 method='plantcv.plantcv.analyze.grayscale', scale='none', datatype=float,
                                 value=masked_gray_std, label='none')
     # Restore user debug setting

--- a/tests/plantcv/analyze/test_grayscale.py
+++ b/tests/plantcv/analyze/test_grayscale.py
@@ -1,0 +1,28 @@
+import cv2
+import numpy as np
+from plantcv.plantcv import outputs
+from plantcv.plantcv.analyze import grayscale as analyze_grayscale
+
+
+def test_grayscale(test_data):
+    """Test for PlantCV."""
+    # Clear previous outputs
+    outputs.clear()
+    # Read in test data
+    img = cv2.imread(test_data.small_gray_img, -1)
+    mask = cv2.imread(test_data.small_bin_img, -1)
+
+    _ = analyze_grayscale(gray_img=img, labeled_mask=mask, n_labels=1, bins=256)
+    assert int(outputs.observations['default1']['gray_median']['value']) == 117
+
+
+def test_grayscale_16bit(test_data):
+    """Test for PlantCV."""
+    # Clear previous outputs
+    outputs.clear()
+    # Read in test data
+    img = cv2.imread(test_data.small_gray_img, -1)
+    mask = cv2.imread(test_data.small_bin_img, -1)
+
+    _ = analyze_grayscale(gray_img=np.uint16(img), labeled_mask=mask, n_labels=1, bins=256)
+    assert int(outputs.observations['default1']['gray_median']['value']) == 117


### PR DESCRIPTION
**Describe your changes**
Create a new function to analyze grayscale pixel values, `pcv.analyze.grayscale`, that utilizes labeled masks. Ultimately replaces `pcv.analyze_nir_intensity`.

**Type of update**
Is this a: New feature or feature enhancement

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
