### PR TITLE
Define type for markers in watershed

### DIFF
--- a/plantcv/plantcv/morphology/fill_segments.py
+++ b/plantcv/plantcv/morphology/fill_segments.py
@@ -27,7 +27,7 @@ def fill_segments(mask, objects, stem_objects=None, label="default"):
     :return filled_mask: numpy.ndarray
     """
     h, w = mask.shape
-    markers = np.zeros((h, w))
+    markers = np.zeros((h, w), dtype=np.int32)
 
     objects_unique = objects.copy()
     if stem_objects is not None:

--- a/plantcv/plantcv/segment_image_series.py
+++ b/plantcv/plantcv/segment_image_series.py
@@ -74,7 +74,7 @@ def segment_image_series(imgs_paths, masks_paths, rois, save_labels=True, ksize=
         # stacks init
         img_stack = np.zeros((h, w, d))
         mask_stack = np.zeros((h, w, d))
-        markers = np.zeros((h, w, d))
+        markers = np.zeros((h, w, d), dtype=np.int32)
 
         # The number of frames used is always the same but the borders are
         # treated as 'constant' or 'zero padding'


### PR DESCRIPTION
**Describe your changes**
Scikit-image stopped converting the input markers to watershed to int32 by default and we do not explicitly define the data type of markers in `pcv.segment_image_series` or `pcv.morphology.fill_segments`. Tests started failing with scikit-image v0.21.

**Type of update**
Is this a: Bug fix

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
