### PR TITLE
Add type to markers

### DIFF
--- a/plantcv/plantcv/morphology/fill_segments.py
+++ b/plantcv/plantcv/morphology/fill_segments.py
@@ -27,7 +27,7 @@ def fill_segments(mask, objects, stem_objects=None, label="default"):
     :return filled_mask: numpy.ndarray
     """
     h, w = mask.shape
-    markers = np.zeros((h, w))
+    markers = np.zeros((h, w), dtype=np.int32)
 
     objects_unique = objects.copy()
     if stem_objects is not None:


### PR DESCRIPTION
**Describe your changes**
Fixes an issue where newer versions of scikit-image do not coerce markers in watershed to int32

**Type of update**
Is this a: Bug fix

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
