### PR TITLE
Skip CSV output for x-y points

### DIFF
--- a/plantcv/utils/converters.py
+++ b/plantcv/utils/converters.py
@@ -70,8 +70,9 @@ def json2csv(json_file, csv_file):
                     if var in obs:
                         if obs[var]["label"] != "none":
                             for i in range(0, len(obs[var]["value"])):
-                                row = [sample, var, obs[var]["value"][i], obs[var]["label"][i]]
-                                csv.write(",".join(map(str, meta_row + row)) + "\n")
+                                if not isinstance(obs[var]["value"][i], (list, tuple)):
+                                    row = [sample, var, obs[var]["value"][i], obs[var]["label"][i]]
+                                    csv.write(",".join(map(str, meta_row + row)) + "\n")
                     else:
                         csv.write(",".join(map(str, meta_row + [sample, var, "NA", "NA"])) + "\n")
         csv.close()


### PR DESCRIPTION
**Describe your changes**
`json2csv` checks for `list` and `tuple` data types and unpacks them into a long-format CSV output file. But when the value is a list of tuples, for storing coordinates, it was outputting the comma-delimited coordinates into the CSV output, which caused the table to be parsed with an uneven number of columns.

This PR checks the type of the data contained in the enclosing list or tuple and skips it if it is also a list or tuple.

**Type of update**
Is this a: Bug fix

**Associated issues**
#1191

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
