### PR TITLE
find_color_card typo fix, move "label" param into correct function

### DIFF
--- a/docs/find_color_card.md
+++ b/docs/find_color_card.md
@@ -30,10 +30,10 @@ Automatically detects a color card's location and size. Useful in workflows wher
 
 from plantcv import plantcv as pcv
 rgb_img, path, filename = pcv.readimage("target_img.png")
-df, start, space = pcv.transform.find_color_card(rgb_img=rgb_img)
+df, start, space = pcv.transform.find_color_card(rgb_img=rgb_img, label="prefix")
 
 # Use these outputs to create a labeled color card mask
-mask = pcv.transform.create_color_card_mask(rgb_img=img, radius=10, start_coord=start, spacing=space, ncols=6, nrows=4, label="prefix")
+mask = pcv.transform.create_color_card_mask(rgb_img=img, radius=10, start_coord=start, spacing=space, ncols=6, nrows=4)
 avg_chip_size = pcv.outputs.observations['prefix']['color_chip_size']['value']
 
 ```


### PR DESCRIPTION
**Describe your changes**
Update doc page so that the `label` parameter is included while calling `find_color_card` rather than `create_color_card_mask`. 

**Type of update**
Is this a:
* typo fix

**Associated issues**

**Additional context**
Add any other context about the problem here.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
