### PR TITLE
remove max_val param from threshold.gaussian()

### DIFF
--- a/docs/gaussian_threshold.md
+++ b/docs/gaussian_threshold.md
@@ -8,7 +8,7 @@ This local threshold depends on the local average, computed in a squared portion
 
 In the Gaussian adaptive threshold, the local average is a weighted average of the pixel values in the block, where the weights are a 2D Gaussian centered in the middle.
 
-**plantcv.threshold.gaussian**(*gray_img, block_size, offset, object_type="light", max_value=255*)
+**plantcv.threshold.gaussian**(*gray_img, block_size, offset, object_type="light"*)
 
 **returns** thresholded/binary image
 
@@ -19,10 +19,9 @@ In the Gaussian adaptive threshold, the local average is a weighted average of t
     A negative offset sets the local threshold above the local average.
     - object_type - "light" or "dark" (default: "light").
       - "light" for objects brighter than the background, sets the pixels above
-      the local threshold to max_value and the pixels below to 0.
+      the local threshold to 255 and the pixels below to 0.
       - "dark" for objects darker than the background, sets the pixels below the
-      local threshold to max_value and the pixels above to 0.
-    - max_value - Value to apply above threshold (default: 255 = white).
+      local threshold to 255 and the pixels above to 0.
 - **Context:**
     - Useful for unevenly illuminated images.
 
@@ -42,13 +41,13 @@ pcv.params.debug = "plot"
 
 # Adaptive threshold with different parameters
 bin_gauss1 = pcv.threshold.gaussian(gray_img=gray_img, block_size=250, offset=15,
-                                    object_type='dark', max_value=255)
+                                    object_type='dark')
 
 bin_gauss1 = pcv.threshold.gaussian(gray_img=gray_img, block_size=25, offset=5,
-                                    object_type='dark', max_value=255)
+                                    object_type='dark')
                                     
 bin_gauss1 = pcv.threshold.gaussian(gray_img=gray_img, block_size=2000, offset=15,
-                                    object_type='dark', max_value=255)
+                                    object_type='dark')
 
 ```
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1041,7 +1041,7 @@ pages for more details on the input and output variable types.
 
 * pre v3.0dev2: NA
 * post v3.0dev2: bin_img = **plantcv.threshold.gaussian**(*gray_img, max_value, object_type="light"*)
-* post v4.0: bin_img = **plantcv.threshold.gaussian**(*gray_img, block_size, offset, object_type="light", max_value=255*)
+* post v4.0: bin_img = **plantcv.threshold.gaussian**(*gray_img, block_size, offset, object_type="light"*)
 
 #### plantcv.threshold.mean
 

--- a/plantcv/plantcv/threshold/threshold_methods.py
+++ b/plantcv/plantcv/threshold/threshold_methods.py
@@ -54,7 +54,7 @@ def binary(gray_img, threshold, max_value, object_type="light"):
 
 
 # Gaussian adaptive threshold
-def gaussian(gray_img, block_size, offset, object_type="light", max_value=255):
+def gaussian(gray_img, block_size, offset, object_type="light"):
     """Creates a binary image from a grayscale image based on the Gaussian adaptive threshold method.
 
     Adaptive thresholds use a threshold value that varies across the image.
@@ -71,10 +71,9 @@ def gaussian(gray_img, block_size, offset, object_type="light", max_value=255):
                     A negative offset sets the local threshold above the local average.
     object_type  = "light" or "dark" (default: "light")
                    - "light" (for objects brighter than the background) sets the pixels above
-                        the local threshold to max_value and the pixels below to 0.
+                        the local threshold to 255 and the pixels below to 0.
                    - "dark" (for objects darker than the background) sets the pixels below the
-                        local threshold to max_value and the pixels above to 0.
-    max_value    = value to apply above local threshold (default: 255 = white)
+                        local threshold to 255 and the pixels above to 0.
 
     Returns:
     bin_img      = Thresholded, binary image
@@ -83,7 +82,6 @@ def gaussian(gray_img, block_size, offset, object_type="light", max_value=255):
     :param block_size: int
     :param offset: float
     :param object_type: str
-    :param max_value: int
     :return bin_img: numpy.ndarray
     """
     # Set the threshold method
@@ -97,7 +95,7 @@ def gaussian(gray_img, block_size, offset, object_type="light", max_value=255):
 
     params.device += 1
 
-    bin_img = _call_adaptive_threshold(gray_img, block_size, offset, max_value, cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
+    bin_img = _call_adaptive_threshold(gray_img, block_size, offset, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
                                        threshold_method, "_gaussian_threshold_")
 
     return bin_img

--- a/tests/plantcv/threshold/test_threshold_methods.py
+++ b/tests/plantcv/threshold/test_threshold_methods.py
@@ -29,7 +29,7 @@ def test_gaussian(objtype, threshold_test_data):
     """Test for PlantCV."""
     # Read in test data
     gray_img = cv2.imread(threshold_test_data.small_gray_img, -1)
-    binary_img = gaussian(gray_img=gray_img, block_size=11, offset=2, object_type=objtype, max_value=255,)
+    binary_img = gaussian(gray_img=gray_img, block_size=11, offset=2, object_type=objtype)
     # Assert that the output image has the dimensions of the input image and is binary
     assert gray_img.shape == binary_img.shape and np.array_equal(np.unique(binary_img), np.array([0, 255]))
 
@@ -39,7 +39,7 @@ def test_gaussian_incorrect_object_type(threshold_test_data):
     # Read in test data
     gray_img = cv2.imread(threshold_test_data.small_gray_img, -1)
     with pytest.raises(RuntimeError):
-        _ = gaussian(gray_img=gray_img, block_size=11, offset=2, object_type="lite", max_value=255)
+        _ = gaussian(gray_img=gray_img, block_size=11, offset=2, object_type="lite")
 
 
 @pytest.mark.parametrize("objtype, size", [["dark", 11], ["light", 10]])


### PR DESCRIPTION
**Describe your changes**

* Removes max_val param from the threshold.gaussian method
* updates function documentation
* updates updating.md
* fixes tests broken by change

**Type of update**
feature enhancement

**Associated issues**
completes one task from this ticket: https://github.com/danforthcenter/plantcv/issues/1194

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
