### PR TITLE
Add all-contributors table and badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ![Conda](https://img.shields.io/conda/v/conda-forge/plantcv)
 [![license](https://img.shields.io/github/license/danforthcenter/plantcv.svg)](https://github.com/danforthcenter/plantcv/blob/main/LICENSE)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](docs/CODE_OF_CONDUCT.md)
+[![All Contributors](https://img.shields.io/github/all-contributors/danforthcenter/plantcv?color=ee8449&style=flat-square)](#contributors)
 
 # PlantCV: Plant phenotyping using computer vision
 
@@ -58,3 +59,14 @@ Please file any PlantCV suggestions/issues/bugs via our
 issues have already been filed.
 
 ***
+
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->


### PR DESCRIPTION
**Describe your changes**
Adds a template to `README.md` for a contributors table, populated by a bot action: https://allcontributors.org/docs/en/bot/usage. The purpose is to broaden recognition of both code and non-code contributors.

**Type of update**
Is this a: New feature or feature enhancement

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
