### PR TITLE
remove max_val param from threshold.texture()

### DIFF
--- a/docs/texture_threshold.md
+++ b/docs/texture_threshold.md
@@ -4,7 +4,7 @@ Creates a binary image from a grayscale image using [skimage](http://scikit-imag
 texture calculation for thresholding.
 
 
-**plantcv.threshold.texture**(*gray_img, ksize, threshold, offset=3, texture_method='dissimilarity', borders='nearest', max_value=255*)
+**plantcv.threshold.texture**(*gray_img, ksize, threshold, offset=3, texture_method='dissimilarity', borders='nearest'*)
 
 **returns** thresholded/binary image
 
@@ -17,7 +17,6 @@ texture calculation for thresholding.
                       ‘contrast’, ‘dissimilarity’ (default), ‘homogeneity’, ‘ASM’, ‘energy’,
                       or ‘correlation’. For equations of different features see [this link](http://scikit-image.org/docs/dev/api/skimage.feature.html#greycoprops)
     - borders - How the array borders are handled, either ‘reflect’, ‘constant’, ‘nearest’ (default), ‘mirror’, or ‘wrap’
-    - max_value - Value to apply above threshold (usually 255 = white)
 - **Context:**
     - Used to threshold based on texture
 - **Note:**
@@ -40,8 +39,7 @@ pcv.params.debug = "plot"
 
 # Create binary image from a gray image based on texture values.
 texture_img = pcv.threshold.texture(gray_img, ksize=6, threshold=7, offset=3, 
-                                    texture_method='dissimilarity', borders='nearest', 
-                                    max_value=255)
+                                    texture_method='dissimilarity', borders='nearest')
                                     
 ```
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1057,12 +1057,13 @@ pages for more details on the input and output variable types.
 #### plantcv.threshold.saturation
 
 * pre v3.8: NA
-* post v3.8: bin_img = **plantcv.threshold.saturation**(*rgb_img, threshold=255, channel="any")
+* post v3.8: bin_img = **plantcv.threshold.saturation**(*rgb_img, threshold=255, channel="any"*)
 
-#### plantcv.threshold.texture_filter
+#### plantcv.threshold.texture
 
 * pre v3.0: NA
-* post v3.0: bin_img = **plantcv.threshold.texture_filter**(*gray_img, ksize, threshold, offset=3, texture_method='dissimilarity', borders='nearest', max_value=255*)
+* post v3.0: bin_img = **plantcv.threshold.texture**(*gray_img, ksize, threshold, offset=3, texture_method='dissimilarity', borders='nearest', max_value=255*)
+* post v4.0: bin_img = **plantcv.threshold.texture**(*gray_img, ksize, threshold, offset=3, texture_method='dissimilarity', borders='nearest'*)
 
 #### plantcv.threshold.triangle
 

--- a/plantcv/plantcv/threshold/threshold_methods.py
+++ b/plantcv/plantcv/threshold/threshold_methods.py
@@ -286,8 +286,7 @@ def triangle(gray_img, object_type="light", xstep=1):
     return bin_img
 
 
-def texture(gray_img, ksize, threshold, offset=3, texture_method='dissimilarity', borders='nearest',
-            max_value=255):
+def texture(gray_img, ksize, threshold, offset=3, texture_method='dissimilarity', borders='nearest'):
     """Creates a binary image from a grayscale image using skimage texture calculation for thresholding.
     This function is quite slow.
 
@@ -302,7 +301,6 @@ def texture(gray_img, ksize, threshold, offset=3, texture_method='dissimilarity'
                      scikit-image.
     borders        = How the array borders are handled, either 'reflect',
                      'constant', 'nearest', 'mirror', or 'wrap'
-    max_value      = Value to apply above threshold (usually 255 = white)
 
     Returns:
     bin_img        = Thresholded, binary image
@@ -313,7 +311,6 @@ def texture(gray_img, ksize, threshold, offset=3, texture_method='dissimilarity'
     :param offset: int
     :param texture_method: str
     :param borders: str
-    :param max_value: int
     :return bin_img: numpy.ndarray
     """
     # Function that calculates the texture of a kernel

--- a/tests/plantcv/threshold/test_threshold_methods.py
+++ b/tests/plantcv/threshold/test_threshold_methods.py
@@ -176,8 +176,7 @@ def test_texture(threshold_test_data):
     gray_img = cv2.imread(threshold_test_data.small_gray_img, -1)
     # Subset input data
     gray_img = gray_img[150:200, 200:250]
-    binary_img = texture(gray_img, ksize=6, threshold=7, offset=3, texture_method='dissimilarity', borders='nearest',
-                         max_value=255)
+    binary_img = texture(gray_img, ksize=6, threshold=7, offset=3, texture_method='dissimilarity', borders='nearest')
     # Assert that the output image has the dimensions of the input image and is binary
     assert gray_img.shape == binary_img.shape and np.array_equal(np.unique(binary_img), np.array([0, 255]))
 


### PR DESCRIPTION
This PR Builds on: https://github.com/danforthcenter/plantcv/pull/1218

**Describe your changes**

* Removes max_val param from the threshold.texture method
* updates function documentation
* updates updating.md
* fixes tests broken by change

**Type of update**
feature enhancement

**Associated issues**
completes one task from this ticket: https://github.com/danforthcenter/plantcv/issues/1194

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
