### PR TITLE
remove max_val param from threshold.dual_channels()

### DIFF
--- a/docs/threshold_dual_channels.md
+++ b/docs/threshold_dual_channels.md
@@ -4,7 +4,7 @@ Creates a binary image from an RGB image based on the pixels values in two chann
 The x and y channels define a 2D plane and the two input points define a straight line.
 Pixels in the plane above and below the straight line are assigned two different values.
 
-**plantcv.threshold.dual_channels**(*rgb_img, x_channel, y_channel, points, above=True, max_value=255*)
+**plantcv.threshold.dual_channels**(*rgb_img, x_channel, y_channel, points, above=True*)
 
 **returns** thresholded/binary image
 
@@ -15,8 +15,7 @@ Pixels in the plane above and below the straight line are assigned two different
     - y_channel - Channel to use for the vertical coordinate.
       Options:  'R', 'G', 'B', 'l', 'a', 'b', 'h', 's', 'v', 'gray', and 'index'
     - points - List containing two points as tuples defining the segmenting straight line
-    - above - Whether the pixels above the line are given the value of 0 or max_value
-    - max_value - Value to apply above threshold (255 = white)
+    - above - Whether the pixels above the line are given the value of 0 or 255
 
 - **Context:**
     - Used to help differentiate plant and background
@@ -41,7 +40,7 @@ pcv.params.debug = "plot"
 pts = [(159, 128), (132, 110)]
 # Create binary image from a RGB image based on two color channels and a straight
 # line defined by two points
-mask = pcv.threshold.dual_channels(rgb_img=img, x_channel='b', y_channel='a', points=pts, above=True, max_value=255)
+mask = pcv.threshold.dual_channels(rgb_img=img, x_channel='b', y_channel='a', points=pts, above=True)
 
 ```
 
@@ -53,7 +52,7 @@ mask = pcv.threshold.dual_channels(rgb_img=img, x_channel='b', y_channel='a', po
 
 # Create binary image from a RGB image based on two color channels and a straight
 # line defined by two points
-mask = pcv.threshold.threshold_2_channels(rgb_img=img, x_channel='b', y_channel='a', points=pts, above=False, max_value=255)
+mask = pcv.threshold.threshold_2_channels(rgb_img=img, x_channel='b', y_channel='a', points=pts, above=False)
 ```
 
 **Thresholded image (inverse)**

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1022,7 +1022,7 @@ pages for more details on the input and output variable types.
 #### plantcv.threshold.dual_channels
 
 * pre v4.0: NA
-* post v4.0: bin_img = **plantcv.threshold.dual_channels**(*rgb_img, x_channel, y_channel, points, above=True, max_value=255*)
+* post v4.0: bin_img = **plantcv.threshold.dual_channels**(*rgb_img, x_channel, y_channel, points, above=True*)
 
 #### plantcv.threshold.binary
 

--- a/plantcv/plantcv/threshold/threshold_methods.py
+++ b/plantcv/plantcv/threshold/threshold_methods.py
@@ -784,7 +784,7 @@ def _not_valid(*args):
     return fatal_error("channel not valid, use R, G, B, l, a, b, h, s, v, gray, or index")
 
 
-def dual_channels(rgb_img, x_channel, y_channel, points, above=True, max_value=255):
+def dual_channels(rgb_img, x_channel, y_channel, points, above=True):
     """Create a binary image from an RGB image based on the pixels values in two channels.
     The x and y channels define a 2D plane and the two input points define a straight line.
     Pixels in the plane above and below the straight line are assigned two different values.
@@ -796,7 +796,6 @@ def dual_channels(rgb_img, x_channel, y_channel, points, above=True, max_value=2
                 Options:  'R', 'G', 'B', 'l', 'a', 'b', 'h', 's', 'v', 'gray', and 'index'
     points    = List containing two points as tuples defining the segmenting straight line
     above     = Whether the pixels above the line are given the value of 0 or max_value
-    max_value = Value to apply above threshold (usually 255 = white)
 
     Returns:
     bin_img      = Thresholded, binary image
@@ -805,7 +804,6 @@ def dual_channels(rgb_img, x_channel, y_channel, points, above=True, max_value=2
     :param y_channel: str
     :param points: list of two tuples
     :param above: bool
-    :param max_value: int
     :return bin_img: numpy.ndarray
     """
 
@@ -840,9 +838,6 @@ def dual_channels(rgb_img, x_channel, y_channel, points, above=True, max_value=2
         # Print warning statement
         warn("only the first two points are used in this function")
 
-    # avoid overflow when casting as uint8 if max_value > 255
-    max_value = min(max_value, 255)
-
     x0, y0 = points[0]
     x1, y1 = points[1]
 
@@ -851,6 +846,7 @@ def dual_channels(rgb_img, x_channel, y_channel, points, above=True, max_value=2
 
     y_line = m*img_x_ch + b
 
+    max_value = 255
     if above:
         bin_img = max_value*(img_y_ch > y_line)
     else:

--- a/tests/plantcv/threshold/test_threshold_methods.py
+++ b/tests/plantcv/threshold/test_threshold_methods.py
@@ -228,7 +228,7 @@ def test_dual_channels(y_ch, abv, expected):
     # last two points are ignored ut trigger the warning
     pts = [(0, 0), (255, 255), (0, 1), (2, 3)]
     x_ch = 'B'
-    mask = dual_channels(img, x_channel=x_ch, y_channel=y_ch, points=pts, above=abv, max_value=255)
+    mask = dual_channels(img, x_channel=x_ch, y_channel=y_ch, points=pts, above=abv)
     assert mask[0, 0] == expected
 
 
@@ -240,7 +240,7 @@ def test_dual_channels_bad_points():
     x_ch = 'B'
     y_ch = 'R'
     with pytest.raises(RuntimeError):
-        _ = dual_channels(img, x_channel=x_ch, y_channel=y_ch, points=pts, above=True, max_value=255)
+        _ = dual_channels(img, x_channel=x_ch, y_channel=y_ch, points=pts, above=True)
 
 
 def test_dual_channels_bad_channel():
@@ -249,4 +249,4 @@ def test_dual_channels_bad_channel():
     # only one point given
     pts = [(0, 0), (255, 255)]
     with pytest.raises(RuntimeError):
-        _ = dual_channels(img, x_channel='wrong_ch', y_channel='index', points=pts, above=True, max_value=255)
+        _ = dual_channels(img, x_channel='wrong_ch', y_channel='index', points=pts, above=True)


### PR DESCRIPTION
**Describe your changes**

* Removes max_val param from the threshold.dual_channels method
* updates function documentation
* updates updating.md
* fixes tests broken by change

**Type of update**
feature enhancement

**Associated issues**
completes one task from this ticket: https://github.com/danforthcenter/plantcv/issues/1194

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
