### PR TITLE
Update PSII dataset names

### DIFF
--- a/docs/analyze_npq.md
+++ b/docs/analyze_npq.md
@@ -37,7 +37,7 @@ from plantcv import plantcv as pcv
 pcv.params.debug = "plot"
 
 # Analyze NPQ   
-npq, npq_hist = pcv.analyze.npq(ps_da_light=ps.lightadapted, ps_da_dark=ps.darkadapted, labeled_mask=kept_mask, label="plant")
+npq, npq_hist = pcv.analyze.npq(ps_da_light=ps.ojip_light, ps_da_dark=ps.ojip_dark, labeled_mask=kept_mask, label="plant")
 
 # Access the NPQ median value
 # the default measurement label for cropreporter data is t1

--- a/docs/analyze_yii.md
+++ b/docs/analyze_yii.md
@@ -8,7 +8,7 @@ The photosynthesis subpackage is dependent on a PSII_Data instance file structur
 **returns** YII DataArray, YII histograms
 
 - **Parameters:**
-    - ps_da - Photosynthesis xarray DataArray (either darkadapted or lightadapted). Can either have a pair of frames F0,Fm or pair(s) of Fp,Fmp.
+    - ps_da - Photosynthesis xarray DataArray (either ojip_dark or ojip_light). Can either have a pair of frames F0,Fm or pair(s) of Fp,Fmp.
     - labeled_mask - Labeled mask of objects (32-bit).
     - n_labels - Total number expected individual objects (default = 1).
     - auto_fm - Automatically calculate the frame with maximum fluorescence per label, otherwise use a fixed frame for all labels (default = False).
@@ -39,11 +39,11 @@ from plantcv import plantcv as pcv
 # or "plot" (Jupyter Notebooks or X11)
 pcv.params.debug = "plot"
 
-# photosynthesis read functions will read fluroescence data into predefined data format that includes at least attribute 'darkadapted'
+# photosynthesis read functions will read fluroescence data into predefined data format that includes at least attribute 'ojip_dark'
 ps = pcv.photosynthesis.read_cropreporter(filename="mydata.inf")
 
 # Analyze Fv/Fm    
-fvfm, fvfm_hist = pcv.analyze.yii(ps_da=ps.darkadapted, labeled_mask=kept_mask, label="plant")
+fvfm, fvfm_hist = pcv.analyze.yii(ps_da=ps.ojip_dark, labeled_mask=kept_mask, label="plant")
 
 # Access Fv/Fm median value
 fvfm_median = pcv.outputs.observations['plant1']['yii_median_t0']['value']
@@ -73,7 +73,7 @@ from plantcv import plantcv as pcv
 pcv.params.debug = "plot"
 
 # Analyze Fq'/Fm'    
-fqfm, fqfm_hist = pcv.analyze.yii(ps=ps.lightadapted, labeled_mask=kept_mask, label="plant")
+fqfm, fqfm_hist = pcv.analyze.yii(ps=ps.ojip_light, labeled_mask=kept_mask, label="plant")
 
 # Access Fq'/Fm' median value
 fqfm_median = pcv.outputs.observations['plant1']["yii_median_t1"]['value']

--- a/docs/photosynthesis_read_cropreporter.md
+++ b/docs/photosynthesis_read_cropreporter.md
@@ -14,9 +14,9 @@ with labeled frames.
 - **Context:**
     - Reads in binary image files to be processed and does so using the metadata contained within a corresponding .INF
       file.
-    - Measurements from dark-adapted plant state are stored in the attribute `darkadapted`. Frames F0 and Fm are
+    - Measurements from dark-adapted plant state are stored in the attribute `ojip_dark`. Frames F0 and Fm are
       labeled according to the metadata in .INF. The default measurement label is 't0'.
-    - Measurements from light-adapted plant state are stored in the attribute `lightadapted`. Frames Fp and Fmp are
+    - Measurements from light-adapted plant state are stored in the attribute `ojip_light`. Frames Fp and Fmp are
       labeled according to the metadata in .INF. The default measurement label is 't1'.
     - Measurements from chlorophyll fluorescence are stored in the attribute `chlorophyll` and include a dark frame
       (Fdark) and chlorophyll fluorescence frame (Chl).
@@ -44,15 +44,15 @@ ps = pcv.photosynthesis.read_cropreporter(filename="PSII_HDR_020321_WT_TOP_1.INF
 ps
 
 # to see the frames you imported use xarray plot methods e.g.
-ps.darkadapted.plot(col='frame_label', col_wrap=4)
+ps.ojip_dark.plot(col='frame_label', col_wrap=4)
 
 ```
 
-**Dark-adapted fluorescence measurements**
+**OJIP Dark-adapted fluorescence measurements**
 
 ![Screenshot](img/documentation_images/photosynthesis_read_cropreporter/0_PSD-frames.png)
 
-**Light-adapted fluorescence measurements**
+**OJIP Light-adapted fluorescence measurements**
 
 ![Screenshot](img/documentation_images/photosynthesis_read_cropreporter/1_PSL-frames.png)
 

--- a/docs/photosynthesis_reassign_frame_labels.md
+++ b/docs/photosynthesis_reassign_frame_labels.md
@@ -29,7 +29,7 @@ from plantcv import plantcv as pcv
 # or "plot" (Jupyter Notebooks or X11)
 pcv.params.debug = "plot"
 
-psd = pcv.photosynthesis.reassign_frame_labels(ps_da=ps.darkadapted, mask=mask)
+psd = pcv.photosynthesis.reassign_frame_labels(ps_da=ps.ojip_dark, mask=mask)
 
 ```
 
@@ -42,7 +42,7 @@ from plantcv import plantcv as pcv
 # or "plot" (Jupyter Notebooks or X11)
 pcv.params.debug = "plot"
 
-psl = pcv.photosynthesis.reassign_frame_labels(ps_da=ps.lightadapted, mask=mask)
+psl = pcv.photosynthesis.reassign_frame_labels(ps_da=ps.ojip_light, mask=mask)
 
 ```
 

--- a/docs/tutorials/psII_tutorial.md
+++ b/docs/tutorials/psII_tutorial.md
@@ -121,7 +121,7 @@ near-infrared (800nm) frames.
 
 `ps` is an instance of the `PSII_data` class in PlantCV. The class stores each available dataset as attributes. The
 class stores two dataset attributes (`datapath` and `filename`) and stores each of the datasets with the following
-variable names: `darkadapted`, `lightadapted`, `chlorophyll`, `spectral`. The darkadapted, lightadapted, and 
+variable names: `ojip_dark`, `ojip_light`, `chlorophyll`, `spectral`. The ojip_dark, ojip_light, and 
 chlorophyll datasets are stored as xarray DataArrays. The spectral dataset is stored as a PlantCV
 [Spectral_data](../Spectral_data.md) class instance.
 
@@ -176,7 +176,7 @@ are set at a reasonable place or whether we want to adjust them in a later step.
 # Returns:
 # chart            = Plot of the chlorophyll fluorescence induction curve for each object
 
-dark_fig = pcv.visualize.chlorophyll_fluorescence(ps_da=ps.darkadapted, labeled_mask=mask)
+dark_fig = pcv.visualize.chlorophyll_fluorescence(ps_da=ps.ojip_dark, labeled_mask=mask)
 
 ```
 
@@ -203,7 +203,7 @@ curve.
 # Returns:
 # chart            = Plot of the chlorophyll fluorescence induction curve for each object
 
-light_fig = pcv.photosynthesis.reassign_frame_labels(ps_da=ps.lightadapted, labeled_mask=mask)
+light_fig = pcv.photosynthesis.reassign_frame_labels(ps_da=ps.ojip_light, labeled_mask=mask)
 
 ```
 
@@ -223,7 +223,7 @@ fluorescence for each masked region.
 # Analyze Fv/Fm
 
 # Inputs:
-# ps_da               = Photosynthesis xarray DataArray (either darkadapted or lightadapted)
+# ps_da               = Photosynthesis xarray DataArray (either ojip_dark or ojip_light)
 # labeled_mask        = Labeled mask of objects (32-bit).
 # n_labels            = Total number expected individual objects (default = 1).
 # auto_fm             = Automatically calculate the frame with maximum fluorescence per label, otherwise
@@ -235,7 +235,7 @@ fluorescence for each masked region.
 # yii_global          = DataArray of efficiency estimate values
 # yii_chart           = Histograms of efficiency estimate
 
-fvfm, fvfm_hist = pcv.analyze.yii(ps_da=ps.darkadapted, labeled_mask=mask, auto_fm=True,
+fvfm, fvfm_hist = pcv.analyze.yii(ps_da=ps.ojip_dark, labeled_mask=mask, auto_fm=True,
                                     measurement_labels=["Fv/Fm"], label="plant")
 
 ```
@@ -248,7 +248,7 @@ fvfm, fvfm_hist = pcv.analyze.yii(ps_da=ps.darkadapted, labeled_mask=mask, auto_
 # Analyze Fq'/Fm'
 
 # Inputs:
-# ps_da               = Photosynthesis xarray DataArray (either darkadapted or lightadapted)
+# ps_da               = Photosynthesis xarray DataArray (either ojip_dark or ojip_light)
 # labeled_mask        = Labeled mask of objects (32-bit).
 # n_labels            = Total number expected individual objects (default = 1).
 # auto_fm             = Automatically calculate the frame with maximum fluorescence per label, otherwise
@@ -260,7 +260,7 @@ fvfm, fvfm_hist = pcv.analyze.yii(ps_da=ps.darkadapted, labeled_mask=mask, auto_
 # yii_global          = DataArray of efficiency estimate values
 # yii_chart           = Histograms of efficiency estimate
 
-fqfm, fqfm_hist = pcv.analyze.yii(ps_da=ps.lightadapted, labeled_mask=mask, auto_fm=True,
+fqfm, fqfm_hist = pcv.analyze.yii(ps_da=ps.ojip_light, labeled_mask=mask, auto_fm=True,
                                     measurement_labels=["Fq'/Fm'"], label="plant")
 
 ```
@@ -277,8 +277,8 @@ Nonphotochemical quanching (NPQ) can be estimated using the [analyze.npq](../ana
 # Analyze NPQ
 
 # Inputs:
-# ps_da_light        = Photosynthesis xarray DataArray that contains frame_label `Fmp` (lightadapted)
-# ps_da_dark         = Photosynthesis xarray DataArray that contains frame_label `Fm` (darkadapted)
+# ps_da_light        = Photosynthesis xarray DataArray that contains frame_label `Fmp` (ojip_light)
+# ps_da_dark         = Photosynthesis xarray DataArray that contains frame_label `Fm` (ojip_dark)
 # labeled_mask       = Labeled mask of objects (32-bit).
 # n_labels           = Total number expected individual objects (default = 1).
 # auto_fm            = Automatically calculate the frame with maximum fluorescence per label, otherwise
@@ -292,7 +292,7 @@ Nonphotochemical quanching (NPQ) can be estimated using the [analyze.npq](../ana
 # npq_global         = DataArray of NPQ values
 # npq_chart          = Histograms of NPQ estimates
 
-npq, npq_hist = pcv.analyze.npq(ps_da_light=ps.lightadapted, ps_da_dark=ps.darkadapted, labeled_mask=mask,
+npq, npq_hist = pcv.analyze.npq(ps_da_light=ps.ojip_light, ps_da_dark=ps.ojip_dark, labeled_mask=mask,
                                 auto_fm=True, measurement_labels=["NPQ"], label="plant")
 
 ```

--- a/docs/visualize_chlorophyll_fluorescence.md
+++ b/docs/visualize_chlorophyll_fluorescence.md
@@ -10,7 +10,7 @@ to decide whether to use `auto_fm` in [pcv.analyze.yii](analyze_yii.md) and [pcv
 **returns** chlorophyll fluorescence induction curve chart
 
 - **Parameters:**
-    - ps_da - photosynthesis xarray DataArray ("lightadapted" or "darkadapted")
+    - ps_da - photosynthesis xarray DataArray ("ojip_light" or "ojip_dark")
     - labeled_mask - Labeled mask of objects (32-bit).
     - n_labels - Total number expected individual objects (default = 1).
     - label - optional label parameter, modifies the prefix of the group plotting label
@@ -30,7 +30,7 @@ from plantcv import plantcv as pcv
 # or "plot" (Jupyter Notebooks or X11)
 pcv.params.debug = "plot"
 
-chart = pcv.visualize.chlorophyll_fluorescence(ps_da=ps.darkadapted, labeled_mask=labeled_mask, n_labels=3, label="object")
+chart = pcv.visualize.chlorophyll_fluorescence(ps_da=ps.ojip_dark, labeled_mask=labeled_mask, n_labels=3, label="object")
 
 ```
 

--- a/environment.yml
+++ b/environment.yml
@@ -25,6 +25,7 @@ dependencies:
   - nodejs
   - jupyterlab<4
   - altair
+  - vl-convert-python
 
 channels:
   - conda-forge

--- a/plantcv/plantcv/analyze/npq.py
+++ b/plantcv/plantcv/analyze/npq.py
@@ -16,8 +16,8 @@ def npq(ps_da_light, ps_da_dark, labeled_mask, n_labels=1, auto_fm=False, min_bi
     Calculate and analyze non-photochemical quenching estimates from fluorescence image data.
 
     Inputs:
-    ps_da_light        = Photosynthesis xarray DataArray that contains frame_label `Fmp` (lightadapted)
-    ps_da_dark         = Photosynthesis xarray DataArray that contains frame_label `Fm` (darkadapted)
+    ps_da_light        = Photosynthesis xarray DataArray that contains frame_label `Fmp` (ojip_light)
+    ps_da_dark         = Photosynthesis xarray DataArray that contains frame_label `Fm` (ojip_dark)
     labeled_mask       = Labeled mask of objects (32-bit).
     n_labels           = Total number expected individual objects (default = 1).
     auto_fm            = Automatically calculate the frame with maximum fluorescence per label, otherwise
@@ -49,8 +49,8 @@ def npq(ps_da_light, ps_da_dark, labeled_mask, n_labels=1, auto_fm=False, min_bi
     if (measurement_labels is not None) and (len(measurement_labels) != ps_da_light.coords['measurement'].shape[0]):
         fatal_error('measurement_labels must be the same length as the number of measurements in `ps_da_light`')
 
-    if ps_da_light.name.lower() != 'lightadapted' or ps_da_dark.name.lower() != 'darkadapted':
-        fatal_error(f"ps_da_light and ps_da_dark must be DataArrays with names 'lightadapted' and 'darkadapted', "
+    if ps_da_light.name.lower() != 'ojip_light' or ps_da_dark.name.lower() != 'ojip_dark':
+        fatal_error(f"ps_da_light and ps_da_dark must be DataArrays with names 'ojip_light' and 'ojip_dark', "
                     f"respectively. Instead the inputs are: "
                     f"ps_da_light: {ps_da_light.name}, ps_da_dark: {ps_da_dark.name}"
                     )

--- a/plantcv/plantcv/analyze/yii.py
+++ b/plantcv/plantcv/analyze/yii.py
@@ -14,7 +14,7 @@ def yii(ps_da, labeled_mask, n_labels=1, auto_fm=False, measurement_labels=None,
     Calculate and analyze PSII efficiency estimates from fluorescence image data.
 
     Inputs:
-    ps_da               = Photosynthesis xarray DataArray (either darkadapted or lightadapted)
+    ps_da               = Photosynthesis xarray DataArray (either ojip_dark or ojip_light)
     labeled_mask        = Labeled mask of objects (32-bit).
     n_labels            = Total number expected individual objects (default = 1).
     auto_fm             = Automatically calculate the frame with maximum fluorescence per label, otherwise
@@ -47,7 +47,7 @@ def yii(ps_da, labeled_mask, n_labels=1, auto_fm=False, measurement_labels=None,
     var = ps_da.name.lower()
 
     # Validate that var is a supported type
-    if var not in ['darkadapted', 'lightadapted']:
+    if var not in ['ojip_dark', 'ojip_light']:
         fatal_error(f"Unsupported DataArray type: {var}")
 
     # Make an zeroed array of the same shape as the input DataArray
@@ -78,12 +78,12 @@ def yii(ps_da, labeled_mask, n_labels=1, auto_fm=False, measurement_labels=None,
         yii_masked = ps_da.astype('float').where(submask > 0, other=np.nan)
 
         # Dark-adapted datasets (Fv/Fm)
-        if var == 'darkadapted':
+        if var == 'ojip_dark':
             # Calculate Fv/Fm
             yii_lbl = (yii_masked.sel(frame_label='Fm') - yii_masked.sel(frame_label='F0')) / yii_masked.sel(frame_label='Fm')
 
         # Light-adapted datasets (Fq'/Fm')
-        if var == 'lightadapted':
+        if var == 'ojip_light':
             # Calculate Fq'/Fm'
             yii_lbl = yii_masked.groupby('measurement', squeeze=False).map(_calc_yii)
 

--- a/plantcv/plantcv/classes.py
+++ b/plantcv/plantcv/classes.py
@@ -268,8 +268,10 @@ class PSII_data:
     """PSII data class"""
 
     def __init__(self):
-        self.darkadapted = None
-        self.lightadapted = None
+        self.ojip_dark = None
+        self.ojip_light = None
+        self.pam_dark = None
+        self.pam_light = None
         self.spectral = None
         self.chlorophyll = None
         self.datapath = None

--- a/plantcv/plantcv/photosynthesis/read_cropreporter.py
+++ b/plantcv/plantcv/photosynthesis/read_cropreporter.py
@@ -93,15 +93,15 @@ def _process_psd_data(ps, metadata):
             coords={'frame_label': frame_labels,
                     'frame_num': ('frame_label', frame_nums),
                     'measurement': ['t0']},
-            name='darkadapted'
+            name='ojip_dark'
         )
-        psd.attrs["long_name"] = "dark-adapted measurements"
+        psd.attrs["long_name"] = "OJIP dark-adapted measurements"
         ps.add_data(psd)
 
-        _debug(visual=ps.darkadapted.squeeze('measurement', drop=True),
+        _debug(visual=ps.ojip_dark.squeeze('measurement', drop=True),
                filename=os.path.join(params.debug_outdir, f"{str(params.device)}_PSD-frames.png"),
                col='frame_label',
-               col_wrap=int(np.ceil(ps.darkadapted.frame_label.size / 4)))
+               col_wrap=int(np.ceil(ps.ojip_dark.frame_label.size / 4)))
 
 
 def _process_psl_data(ps, metadata):
@@ -142,15 +142,15 @@ def _process_psl_data(ps, metadata):
             coords={'frame_label': frame_labels,
                     'frame_num': ('frame_label', frame_nums),
                     'measurement': ['t1']},
-            name='lightadapted'
+            name='ojip_light'
         )
-        psl.attrs["long_name"] = "light-adapted measurements"
+        psl.attrs["long_name"] = "OJIP light-adapted measurements"
         ps.add_data(psl)
 
-        _debug(visual=ps.lightadapted.squeeze('measurement', drop=True),
+        _debug(visual=ps.ojip_light.squeeze('measurement', drop=True),
                filename=os.path.join(params.debug_outdir, f"{str(params.device)}_PSL-frames.png"),
                col='frame_label',
-               col_wrap=int(np.ceil(ps.lightadapted.frame_label.size / 4)))
+               col_wrap=int(np.ceil(ps.ojip_light.frame_label.size / 4)))
 
 
 def _process_chl_data(ps, metadata):

--- a/plantcv/plantcv/photosynthesis/reassign_frame_labels.py
+++ b/plantcv/plantcv/photosynthesis/reassign_frame_labels.py
@@ -29,25 +29,25 @@ def reassign_frame_labels(ps_da, mask):
     params.device += 1
 
     try:
-        if ps_da.name != "lightadapted" and ps_da.name != "darkadapted":
-            fatal_error("You must provide a xarray DataArray with name lightadapted or darkadapted")
+        if ps_da.name != "ojip_light" and ps_da.name != "ojip_dark":
+            fatal_error("You must provide a xarray DataArray with name ojip_light or ojip_dark")
     except AttributeError:
         if isinstance(ps_da, PSII_data):
-            fatal_error("You need to provide the `darkadapted` or `lightadapted` dataarray")
+            fatal_error("You need to provide the `ojip_dark` or `ojip_light` dataarray")
         else:
-            fatal_error("You must provide a xarray DataArray with name lightadapted or darkadapted")
+            fatal_error("You must provide a xarray DataArray with name ojip_light or ojip_dark")
 
     if mask.shape != ps_da.shape[:2] or len(np.unique(mask)) > 2:
         fatal_error(f"Mask needs to be binary and have shape {ps_da.shape[:2]}")
 
     # Prime is empty for Fv/Fm (dark- and light-adapted) and p for Fq'/Fm'
     datasets = {
-        "lightadapted": {
+        "ojip_light": {
             "prime": "p",
             "label": "PSL",
             "F": "Fp"
         },
-        "darkadapted": {
+        "ojip_dark": {
             "prime": "",
             "label": "PSD",
             "F": "F0"

--- a/plantcv/plantcv/visualize/chlorophyll_fluorescence.py
+++ b/plantcv/plantcv/visualize/chlorophyll_fluorescence.py
@@ -29,21 +29,21 @@ def chlorophyll_fluorescence(ps_da, labeled_mask, n_labels=1, label="object"):
 
     # Check that the dataarray is valid
     try:
-        if ps_da.name != "lightadapted" and ps_da.name != "darkadapted":
-            fatal_error("You must provide a xarray DataArray with name lightadapted or darkadapted")
+        if ps_da.name != "ojip_light" and ps_da.name != "ojip_dark":
+            fatal_error("You must provide a xarray DataArray with name ojip_light or ojip_dark")
     except AttributeError:
         if isinstance(ps_da, PSII_data):
-            fatal_error("You need to provide the `darkadapted` or `lightadapted` dataarray")
+            fatal_error("You need to provide the `ojip_dark` or `ojip_light` dataarray")
         else:
-            fatal_error("You must provide a xarray DataArray with name lightadapted or darkadapted")
+            fatal_error("You must provide a xarray DataArray with name ojip_light or ojip_dark")
 
     # Prime is empty for Fv/Fm (dark- and light-adapted) and p for Fq'/Fm'
     datasets = {
-        "lightadapted": {
+        "ojip_light": {
             "prime": "p",
             "label": "PSL"
         },
-        "darkadapted": {
+        "ojip_dark": {
             "prime": "",
             "label": "PSD"
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ opencv-python
 xarray>=2022.11.0
 statsmodels
 altair
+vl-convert-python

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,10 +121,10 @@ class TestData:
         f3[5, 5] = 8
 
         # set specific labels for xarray for dark and light adapted
-        if var == 'darkadapted':
+        if var == 'ojip_dark':
             frame_labels = ['Fdark', 'F0', 'Fm', '3']
             measurements = ['t0']
-        elif var == 'lightadapted':
+        elif var == 'ojip_light':
             frame_labels = ['Fdark', 'Fp', '2', 'Fmp']
             measurements = ['t1']
 
@@ -139,7 +139,7 @@ class TestData:
     def psii_walz(var):
         """Create and return synthetic psii dataarrays from walz"""
         # create darkadapted
-        if var == 'darkadapted':
+        if var == 'ojip_dark':
             i = 0
             fmin = np.ones((10, 10), dtype='uint8') * ((i+15)*2)
             fmax = np.ones((10, 10), dtype='uint8') * (200-i*15)
@@ -153,11 +153,11 @@ class TestData:
                 coords={'frame_label': indf,
                         'frame_num': ('frame_label', frame_nums),
                         'measurement': ['t0']},
-                name='darkadapted'
+                name='ojip_dark'
             )
 
         # create lightadapted
-        elif var == 'lightadapted':
+        elif var == 'ojip_light':
             da_list = []
             measurement = []
 
@@ -179,7 +179,7 @@ class TestData:
 
             prop_idx = pd.Index(measurement)
             ps_da = xr.concat(da_list, 'measurement')
-            ps_da.name = 'lightadapted'
+            ps_da.name = 'ojip_light'
             ps_da.coords['measurement'] = prop_idx
 
         return ps_da

--- a/tests/plantcv/analyze/test_npq.py
+++ b/tests/plantcv/analyze/test_npq.py
@@ -8,8 +8,8 @@ def test_npq_cropreporter(test_data):
     """Test for PlantCV."""
     # Clear results
     outputs.clear()
-    da_dark = test_data.psii_cropreporter('darkadapted')
-    da_light = test_data.psii_cropreporter('lightadapted')
+    da_dark = test_data.psii_cropreporter('ojip_dark')
+    da_light = test_data.psii_cropreporter('ojip_light')
     _ = analyze_npq(ps_da_light=da_light, ps_da_dark=da_dark, labeled_mask=test_data.create_ps_mask(),
                     auto_fm=False,
                     measurement_labels=["Fq/Fm"], label="prefix", min_bin="auto", max_bin="auto")
@@ -20,8 +20,8 @@ def test_npq_waltz(test_data):
     """Test for PlantCV."""
     # Clear results
     outputs.clear()
-    da_dark = test_data.psii_walz('darkadapted')
-    da_light = test_data.psii_walz('lightadapted')
+    da_dark = test_data.psii_walz('ojip_dark')
+    da_light = test_data.psii_walz('ojip_light')
     _ = analyze_npq(ps_da_light=da_light, ps_da_dark=da_dark, labeled_mask=test_data.create_ps_mask(), auto_fm=True,
                     measurement_labels=None, label="prefix", min_bin="auto", max_bin="auto")
     assert np.isclose(outputs.observations["prefix1"]["npq_median_t40"]["value"], float((200 / 185) - 1))
@@ -36,15 +36,15 @@ def test_npq_fatalerror(mlabels, tmask, test_data):
     """Test for PlantCV."""
     tmask[0, 0] = 255
     with pytest.raises(RuntimeError):
-        _ = analyze_npq(ps_da_dark=test_data.psii_cropreporter('darkadapted'),
-                        ps_da_light=test_data.psii_cropreporter('lightadapted'), labeled_mask=tmask,
+        _ = analyze_npq(ps_da_dark=test_data.psii_cropreporter('ojip_dark'),
+                        ps_da_light=test_data.psii_cropreporter('ojip_light'), labeled_mask=tmask,
                         measurement_labels=mlabels, label="default")
 
 
 def test_npq_bad_var(test_data):
     """Test for PlantCV."""
     with pytest.raises(RuntimeError):
-        _ = analyze_npq(ps_da_dark=test_data.psii_cropreporter('lightadapted'),
-                        ps_da_light=test_data.psii_cropreporter('darkadapted'),
+        _ = analyze_npq(ps_da_dark=test_data.psii_cropreporter('ojip_light'),
+                        ps_da_light=test_data.psii_cropreporter('ojip_dark'),
                         labeled_mask=test_data.create_ps_mask(),
                         measurement_labels=None, label="default")

--- a/tests/plantcv/analyze/test_yii.py
+++ b/tests/plantcv/analyze/test_yii.py
@@ -5,7 +5,7 @@ from plantcv.plantcv.analyze import yii as analyze_yii
 
 
 @pytest.mark.parametrize("prot,mlabels,exp", [
-    # test darkadapted control seq
+    # test ojip_dark control seq
     ["ojip_dark", None, 0.8],
     # test lightadapted control seq and measurement_labels arg
     ["ojip_light", ["Fq/Fm"], 0.8]])
@@ -22,7 +22,7 @@ def test_yii_cropreporter(prot, mlabels, exp, test_data):
 
 
 @pytest.mark.parametrize("prot,mlabels,exp", [
-    # test darkadapted control seq
+    # test ojip_dark control seq
     ["ojip_dark", ["Fv/Fm"], float(np.around((200 - 30) / 200, decimals=4))],
     # test lightadapted control seq and measurement_labels arg
     ["ojip_light", [f't{i*40}' for i in np.arange(1, 3)], float((185 - 32) / 185)]])

--- a/tests/plantcv/analyze/test_yii.py
+++ b/tests/plantcv/analyze/test_yii.py
@@ -6,9 +6,9 @@ from plantcv.plantcv.analyze import yii as analyze_yii
 
 @pytest.mark.parametrize("prot,mlabels,exp", [
     # test darkadapted control seq
-    ["darkadapted", None, 0.8],
+    ["ojip_dark", None, 0.8],
     # test lightadapted control seq and measurement_labels arg
-    ["lightadapted", ["Fq/Fm"], 0.8]])
+    ["ojip_light", ["Fq/Fm"], 0.8]])
 def test_yii_cropreporter(prot, mlabels, exp, test_data):
     """Test for PlantCV."""
     # Clear results
@@ -23,9 +23,9 @@ def test_yii_cropreporter(prot, mlabels, exp, test_data):
 
 @pytest.mark.parametrize("prot,mlabels,exp", [
     # test darkadapted control seq
-    ["darkadapted", ["Fv/Fm"], float(np.around((200 - 30) / 200, decimals=4))],
+    ["ojip_dark", ["Fv/Fm"], float(np.around((200 - 30) / 200, decimals=4))],
     # test lightadapted control seq and measurement_labels arg
-    ["lightadapted", [f't{i*40}' for i in np.arange(1, 3)], float((185 - 32) / 185)]])
+    ["ojip_light", [f't{i*40}' for i in np.arange(1, 3)], float((185 - 32) / 185)]])
 def test_yii_waltz(prot, mlabels, exp, test_data):
     """Test for PlantCV."""
     # Clear results
@@ -47,13 +47,13 @@ def test_yii_fatalerror(mlabels, tmask, test_data):
     """Test for PlantCV."""
     tmask[0, 0] = 255
     with pytest.raises(RuntimeError):
-        _ = analyze_yii(ps_da=test_data.psii_cropreporter('darkadapted'), labeled_mask=tmask,
+        _ = analyze_yii(ps_da=test_data.psii_cropreporter('ojip_dark'), labeled_mask=tmask,
                         measurement_labels=mlabels, label="default")
 
 
 def test_yii_bad_var(test_data):
     """Test for PlantCV."""
-    da = test_data.psii_cropreporter('darkadapted')
+    da = test_data.psii_cropreporter('ojip_dark')
     da.name = 'bad'
     with pytest.raises(RuntimeError):
         _ = analyze_yii(ps_da=da, labeled_mask=test_data.create_ps_mask(),

--- a/tests/plantcv/photosynthesis/conftest.py
+++ b/tests/plantcv/photosynthesis/conftest.py
@@ -24,7 +24,7 @@ class PhotosynthesisTestData:
     @staticmethod
     def psii_walz(var):
         """Create and return synthetic psii dataarrays from walz"""
-        # create darkadapted
+        # create ojip_dark
         if var == 'ojip_dark':
             i = 0
             fmin = np.ones((10, 10), dtype='uint8') * ((i+15)*2)

--- a/tests/plantcv/photosynthesis/conftest.py
+++ b/tests/plantcv/photosynthesis/conftest.py
@@ -25,7 +25,7 @@ class PhotosynthesisTestData:
     def psii_walz(var):
         """Create and return synthetic psii dataarrays from walz"""
         # create darkadapted
-        if var == 'darkadapted':
+        if var == 'ojip_dark':
             i = 0
             fmin = np.ones((10, 10), dtype='uint8') * ((i+15)*2)
             fmax = np.ones((10, 10), dtype='uint8') * (200-i*15)
@@ -39,11 +39,11 @@ class PhotosynthesisTestData:
                 coords={'frame_label': indf,
                         'frame_num': ('frame_label', frame_nums),
                         'measurement': ['t0']},
-                name='darkadapted'
+                name='ojip_dark'
             )
 
         # create lightadapted
-        elif var == 'lightadapted':
+        elif var == 'ojip_light':
             da_list = []
             measurement = []
 
@@ -65,7 +65,7 @@ class PhotosynthesisTestData:
 
             prop_idx = pd.Index(measurement)
             ps_da = xr.concat(da_list, 'measurement')
-            ps_da.name = 'lightadapted'
+            ps_da.name = 'ojip_light'
             ps_da.coords['measurement'] = prop_idx
 
         return(ps_da)
@@ -90,10 +90,10 @@ class PhotosynthesisTestData:
         f3[5, 5] = 8
 
         # set specific labels for xarray for dark and light adapted
-        if var == 'darkadapted':
+        if var == 'ojip_dark':
             frame_labels = ['Fdark', 'F0', 'Fm', '3']
             measurements = ['t0']
-        elif var == 'lightadapted':
+        elif var == 'ojip_light':
             frame_labels = ['Fdark', 'Fp', '2', 'Fmp']
             measurements = ['t1']
 

--- a/tests/plantcv/photosynthesis/test_psii_data.py
+++ b/tests/plantcv/photosynthesis/test_psii_data.py
@@ -4,5 +4,5 @@ from plantcv.plantcv import PSII_data
 def test_psii_data(photosynthesis_test_data):
     """Test for PlantCV."""
     psii = PSII_data()
-    psii.add_data(photosynthesis_test_data.psii_cropreporter('darkadapted'))
-    assert repr(psii) == "PSII variables defined:\ndarkadapted"
+    psii.add_data(photosynthesis_test_data.psii_cropreporter('ojip_dark'))
+    assert repr(psii) == "PSII variables defined:\nojip_dark"

--- a/tests/plantcv/photosynthesis/test_read_cropreporter.py
+++ b/tests/plantcv/photosynthesis/test_read_cropreporter.py
@@ -7,14 +7,14 @@ from plantcv.plantcv.photosynthesis import read_cropreporter
 def test_read_cropreporter(photosynthesis_test_data, tmpdir):
     """Test for PlantCV."""
     ps = read_cropreporter(filename=photosynthesis_test_data.cropreporter)
-    assert isinstance(ps, PSII_data) and ps.darkadapted.shape == (966, 1296, 21, 1)
+    assert isinstance(ps, PSII_data) and ps.ojip_dark.shape == (966, 1296, 21, 1)
 
     # Check with different naming conventioned of phenovation
     ps = read_cropreporter(filename=photosynthesis_test_data.cropreporter_v653_ojip)
-    assert isinstance(ps, PSII_data) and ps.darkadapted.shape == (1500, 2048, 7, 1)
+    assert isinstance(ps, PSII_data) and ps.ojip_dark.shape == (1500, 2048, 7, 1)
     # check labels
     true_labels = ['Fdark', 'F0', 'PSD2', 'PSD3', 'Fm', 'PSD5', 'PSD6']
-    assert all([a == b for a, b in zip(ps.darkadapted.coords['frame_label'].to_dict()['data'], true_labels)])
+    assert all([a == b for a, b in zip(ps.ojip_dark.coords['frame_label'].to_dict()['data'], true_labels)])
 
     # Create dataset with only 3 frames
     cache_dir = os.path.join(tmpdir, "sub")
@@ -38,9 +38,9 @@ def test_read_cropreporter(photosynthesis_test_data, tmpdir):
     ps = read_cropreporter(filename=inffilename)
     # check labels
     true_dark_labels = ['Fdark', 'F0', 'Fm', 'PSD3', 'PSD4', 'PSD5', 'PSD6']
-    assert all([a == b for a, b in zip(ps.darkadapted.coords['frame_label'].to_dict()['data'], true_dark_labels)])
+    assert all([a == b for a, b in zip(ps.ojip_dark.coords['frame_label'].to_dict()['data'], true_dark_labels)])
     true_light_labels = ['Flight', 'Fp', 'Fmp', 'PSL3', 'PSL4', 'PSL5', 'PSL6']
-    assert all([a == b for a, b in zip(ps.lightadapted.coords['frame_label'].to_dict()['data'], true_light_labels)])
+    assert all([a == b for a, b in zip(ps.ojip_light.coords['frame_label'].to_dict()['data'], true_light_labels)])
 
 
 def test_read_cropreporter_spc_only(photosynthesis_test_data, tmpdir):

--- a/tests/plantcv/photosynthesis/test_reassign_frame_labels.py
+++ b/tests/plantcv/photosynthesis/test_reassign_frame_labels.py
@@ -4,7 +4,7 @@ from plantcv.plantcv import PSII_data
 from plantcv.plantcv.photosynthesis import reassign_frame_labels
 
 
-@pytest.mark.parametrize("prot,frame", [["darkadapted", "Fm"], ["lightadapted", "Fmp"]])
+@pytest.mark.parametrize("prot,frame", [["ojip_dark", "Fm"], ["ojip_light", "Fmp"]])
 def test_reassign_frame_labels(prot, frame, photosynthesis_test_data):
     """Test for PlantCV."""
     da = reassign_frame_labels(ps_da=photosynthesis_test_data.psii_cropreporter(prot),
@@ -14,9 +14,9 @@ def test_reassign_frame_labels(prot, frame, photosynthesis_test_data):
 
 @pytest.mark.parametrize("prot,tmask", [
     # test mask shape
-    ["darkadapted", np.ones((2, 2))],
+    ["ojip_dark", np.ones((2, 2))],
     # test mask is binary
-    ["lightadapted", np.random.random((10, 10))]])
+    ["ojip_light", np.random.random((10, 10))]])
 def test_reassign_frame_labels_fatalerror(prot, tmask, photosynthesis_test_data):
     """Test for PlantCV."""
     da = photosynthesis_test_data.psii_cropreporter(prot)
@@ -32,7 +32,7 @@ def test_reassign_frame_labels_invalid_array(photosynthesis_test_data):
 
 def test_reassign_frame_labels_invalid_name(photosynthesis_test_data):
     """Test for PlantCV."""
-    da = photosynthesis_test_data.psii_cropreporter('darkadapted').rename('test')
+    da = photosynthesis_test_data.psii_cropreporter('ojip_dark').rename('test')
     with pytest.raises(RuntimeError):
         _ = reassign_frame_labels(ps_da=da, mask=photosynthesis_test_data.create_ps_mask())
 

--- a/tests/plantcv/test_plot_image.py
+++ b/tests/plantcv/test_plot_image.py
@@ -52,6 +52,6 @@ def test_plot_image_psiidata():
 
 def test_plantcv_plot_image_dataarray(test_data):
     """Test for PlantCV."""
-    plot_image(test_data.psii_cropreporter('darkadapted').squeeze('measurement', drop=True), col='frame_label')
+    plot_image(test_data.psii_cropreporter('ojip_dark').squeeze('measurement', drop=True), col='frame_label')
     # Assert that the image was plotted without error
     assert True

--- a/tests/plantcv/test_print_image.py
+++ b/tests/plantcv/test_print_image.py
@@ -57,7 +57,7 @@ def test_print_image_dataarray(test_data, tmpdir):
     """Test for PlantCV."""
     # Create a test tmp directory
     cache_dir = tmpdir.mkdir("cache")
-    da = test_data.psii_cropreporter('darkadapted').squeeze('measurement', drop=True)
+    da = test_data.psii_cropreporter('ojip_dark').squeeze('measurement', drop=True)
     filename = os.path.join(cache_dir, 'plantcv_print_image.png')
     print_image(img=da, col='frame_label', filename=filename)
     # Assert that the file was created

--- a/tests/plantcv/test_show_dataarray.py
+++ b/tests/plantcv/test_show_dataarray.py
@@ -4,7 +4,7 @@ from plantcv.plantcv._show_dataarray import _show_dataarray
 
 def test_show_dataarray(test_data):
     """Test for PlantCV."""
-    _show_dataarray(test_data.psii_cropreporter('darkadapted').squeeze('measurement', drop=True), col='frame_label')
+    _show_dataarray(test_data.psii_cropreporter('ojip_dark').squeeze('measurement', drop=True), col='frame_label')
     # Assert that the image was plotted without error
     assert True
 
@@ -12,13 +12,13 @@ def test_show_dataarray(test_data):
 def test_show_dataarray_bad_kwarg(test_data):
     """Test for PlantCV."""
     with pytest.raises(RuntimeError):
-        _show_dataarray(test_data.psii_cropreporter('darkadapted').squeeze('measurement', drop=True), col=None)
+        _show_dataarray(test_data.psii_cropreporter('ojip_dark').squeeze('measurement', drop=True), col=None)
 
 
 def test_show_dataarray_missing_dim(test_data):
     """Test for PlantCV."""
     with pytest.raises(RuntimeError):
-        _show_dataarray(test_data.psii_cropreporter('darkadapted').squeeze('measurement', drop=True)[0, :, :],
+        _show_dataarray(test_data.psii_cropreporter('ojip_dark').squeeze('measurement', drop=True)[0, :, :],
                         col="frame_label")
 
 
@@ -26,11 +26,11 @@ def test_show_dataarray_too_many_dims(test_data):
     """Test for PlantCV."""
     # pcolormesh() fails with ValueError if ndim != 2 in addition to row and/or col
     with pytest.raises(ValueError):
-        _show_dataarray(img=test_data.psii_cropreporter('darkadapted'), col_wrap=4, row='frame_label')
+        _show_dataarray(img=test_data.psii_cropreporter('ojip_dark'), col_wrap=4, row='frame_label')
 
 
 def test_show_dataarray_too_few_dims(test_data):
     """Test for PlantCV."""
     # pcolormesh() fails with ValueError if ndim != 2 in addition to row and/or col
     with pytest.raises(ValueError):
-        _show_dataarray(img=test_data.psii_cropreporter('darkadapted')[:, :, 0, 0], col_wrap=4, row='frame_label')
+        _show_dataarray(img=test_data.psii_cropreporter('ojip_dark')[:, :, 0, 0], col_wrap=4, row='frame_label')

--- a/tests/plantcv/visualize/test_chlorophyll_fluorescence.py
+++ b/tests/plantcv/visualize/test_chlorophyll_fluorescence.py
@@ -6,7 +6,7 @@ from altair.vegalite.v5.api import LayerChart
 
 def test_chlorophyll_fluorescence(test_data):
     """Test for PlantCV."""
-    da = test_data.psii_cropreporter('darkadapted')
+    da = test_data.psii_cropreporter('ojip_dark')
     mask = test_data.create_ps_mask()
     chart = chlorophyll_fluorescence(ps_da=da, labeled_mask=mask)
     assert isinstance(chart, LayerChart)
@@ -14,7 +14,7 @@ def test_chlorophyll_fluorescence(test_data):
 
 def test_chlorophyll_fluorescence_bad_var(test_data):
     """Test for PlantCV."""
-    da = test_data.psii_cropreporter('darkadapted')
+    da = test_data.psii_cropreporter('ojip_dark')
     da.name = 'bad'
     mask = test_data.create_ps_mask()
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
**Describe your changes**
Renames `PSII_data` dataset attributes from `darkadapted` and `lightadapted` to `ojip_dark` and `ojip_light`, based on the name of the method, OJIP. This will allow future addition of PAM measurements.

**Type of update**
Is this a: update

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
