### PR TITLE
Add extra table of contents links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,12 @@ nav:
   - 'Exporting Data': db-exporter.md
   - 'PlantCV Namespace':
     - 'PlantCV':
+      - 'Inputs and Outputs':
+        - 'Print Image': print_image.md
+        - 'Print Results': print_results.md
+        - 'Plot Image': plot_image.md
+        - 'Read Image': read_image.md
+        - 'Read Bayer Raw Image': read_bayer.md
       - 'Analysis Methods':
         - 'Analyze Color': analyze_color2.md
         - 'Analyze Grayscale': analyze_grayscale.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,9 @@ nav:
       - 'Photosynthesis Functions':
           - 'Read CropReporter Data': photosynthesis_read_cropreporter.md
           - 'Reassign Frame Labels': photosynthesis_reassign_frame_labels.md
+          - 'Analyze YII': analyze_yii.md
+          - 'Analyze NPQ': analyze_npq.md
+          - 'Chlorophyll Fluorescence': visualize_chlorophyll_fluorescence.md
       - 'Params (Debugging)': params.md
       - 'Print Image': print_image.md
       - 'Print Results': print_results.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,12 +68,14 @@ nav:
       - 'Histogram Normalization': HistEqualization.md
       - 'Hyperspectral Data':
           - 'Analyze Spectral Reflectance': analyze_spectral_reflectance.md
-          - 'Calibrate': calibrate.md
+          - 'Analyze Spectral Index': analyze_spectral_index.md
+          - 'Calibrate HSI': calibrate.md
+          - 'Crop HSI': crop.md
           - 'Spectral Index': spectral_index.md
           - 'Extract wavelength': extract_wavelength.md
-          - 'Rotate Hyperspectral Datacubes ': hyperspectral_rot90.md
+          - 'Rotate HSI': hyperspectral_rot90.md
           - 'Spectral data objects': Spectral_data.md
-          - 'Write data': write_data.md
+          - 'Write HSI data': write_data.md
       - 'Image Add': image_add.md
       - 'Image Subtract': image_subtract.md
       - 'Image Fusion': image_fusion.md
@@ -124,7 +126,7 @@ nav:
           - 'Reassign Frame Labels': photosynthesis_reassign_frame_labels.md
           - 'Analyze YII': analyze_yii.md
           - 'Analyze NPQ': analyze_npq.md
-          - 'Chlorophyll Fluorescence': visualize_chlorophyll_fluorescence.md
+          - 'Visualize chlorophyll Fluorescence': visualize_chlorophyll_fluorescence.md
       - 'Params (Debugging)': params.md
       - 'Print Image': print_image.md
       - 'Print Results': print_results.md


### PR DESCRIPTION
**Describe your changes**
Functions are organized by common purpose or data type. For example, all analysis functions are organized in `plantcv.analyze`. The documentation TOC follows this logic, but in some cases it is useful to also link to a function based on a shared set of functionality, such as all functions related to Hyperspectral image analysis.

This PR adds duplicate links to the TOC of the documents so that functions can be found both in their actual submodule but also in relevant groupings based on function. In particular, duplicate links are added to the `hyperspectral` and `photosynthesis` sections, and a new `Inputs and Outputs` section is added at the top to make the basic data handling functions easier to find.

**Type of update**
Is this a: Update to documentation

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
