### PR TITLE
Rename job_extra to job_extra_directives

### DIFF
--- a/docs/parallel_config.md
+++ b/docs/parallel_config.md
@@ -174,7 +174,7 @@ environmental variable.
 **local_directory**: (str, optional, default = `None`): dask working directory location. Can be set to a path or 
 environmental variable.
 
-**job_extra**: (dict, optional, default = `None`): extra parameters sent to the scheduler. Specified as a dictionary 
+**job_extra_directives**: (dict, optional, default = `None`): extra parameters sent to the scheduler. Specified as a dictionary 
 of key-value pairs (e.g. `{"getenv": "true"}`).
 
 !!! note

--- a/docs/pipeline_parallel.md
+++ b/docs/pipeline_parallel.md
@@ -120,7 +120,7 @@ Sample image filename: `cam1_16-08-06-16:45_el1100s1_p19.jpg`
         "disk": "1GB",
         "log_directory": null,
         "local_directory": null,
-        "job_extra": null
+        "job_extra_directives": null
     },
     "metadata_terms": {
     ...
@@ -196,7 +196,7 @@ in a list to the `filename_metadata` parameter.
         "disk": "1GB",
         "log_directory": null,
         "local_directory": null,
-        "job_extra": null
+        "job_extra_directives": null
     },
     "metadata_terms": {
     ...
@@ -248,7 +248,7 @@ To identify each image within our workflow, we will name them based on the `imgt
         "disk": "1GB",
         "log_directory": null,
         "local_directory": null,
-        "job_extra": null
+        "job_extra_directives": null
     },
     "metadata_terms": {
     ...

--- a/plantcv/parallel/__init__.py
+++ b/plantcv/parallel/__init__.py
@@ -42,7 +42,7 @@ class WorkflowConfig:
             "disk": "1GB",
             "log_directory": None,
             "local_directory": None,
-            "job_extra": None
+            "job_extra_directives": None
         }
         self.metadata_terms = {
                 # Camera settings

--- a/tests/testdata/workflowconfig_template.json
+++ b/tests/testdata/workflowconfig_template.json
@@ -26,7 +26,7 @@
         "disk": "1GB",
         "log_directory": null,
         "local_directory": null,
-        "job_extra": null
+        "job_extra_directives": null
     },
     "metadata_terms": {
         "camera": {


### PR DESCRIPTION
**Describe your changes**
Fixes warning from Dask Jobqueue:

>FutureWarning: job_extra has been renamed to job_extra_directives. You are still using it (even if only set to []; please also check config files). If you did not set job_extra_directives yet, job_extra will be respected for now, but it will be removed in a future release. If you already set job_extra_directives, job_extra is ignored and you can remove it.

**Type of update**
Is this a: update

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
