### PR TITLE
Set num_labels to num ROIs

### DIFF
--- a/plantcv/plantcv/create_labels.py
+++ b/plantcv/plantcv/create_labels.py
@@ -45,6 +45,7 @@ def create_labels(mask, rois=None, roi_type="partial"):
     else:
         contours, hierarchy = _cv2_findcontours(mask)
         labeled_mask = np.zeros(mask.shape[:2], dtype=np.int32)
+        num_labels = len(rois.contours)
         for i, roi in enumerate(rois):
             kept_cnt, kept_hierarchy, mask = _roi_filter(img=mask, roi=roi,
                                                          obj=contours,
@@ -53,7 +54,6 @@ def create_labels(mask, rois=None, roi_type="partial"):
 
             # Pixel intensity of (i+1) such that the first object has value
             cv2.drawContours(labeled_mask, kept_cnt, -1, (i+1), -1)
-            num_labels = np.unique(labeled_mask).size - 1
 
     # Restore debug parameter
     params.debug = debug


### PR DESCRIPTION
**Describe your changes**
`pcv.create_labels` was incorrectly setting the number of labels to the number of unique labels in the labeled mask. When plants are missing and ROIs are supplied, this can under count the number of labels. Instead we changed the number of labels to the number of input ROIs, when relevant.

**Type of update**
Is this a: Bug fix

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
