### PR TITLE
Collapse hierarchical headers for CSV files

### DIFF
--- a/plantcv/utils/converters.py
+++ b/plantcv/utils/converters.py
@@ -100,6 +100,8 @@ def json2csv(json_file, csv_prefix):
     # Pivot the dataframe to wide format
     # If duplicate indices exist, use the last set of observations are kept
     df = df.pivot_table(index=meta_vars + ["sample"], columns=["trait", "label"], values="value", aggfunc=_last_index)
+    # Collapse hierarchical column headers
+    df.columns = [f"{c[0]}_{c[1]}" for c in df.columns]
     # Save the dataframe to a CSV file
     df.to_csv(scalar_file)
 


### PR DESCRIPTION
**Describe your changes**
The `json2csv` function uses Pandas `pivot_table` to make a wide format CSV file for singe-value traits. Because we pivot on the `trait` and `label` columns, this creates a hierarchical header. In implementing this change for 4.0 we left off the code to collapse the headers into a single set of column names.

**Type of update**
Is this a: Bug fix

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
