### PR TITLE
Update matplotlib supported versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@
 name: plantcv
 dependencies:
   - python=3.10
-  - matplotlib>=1.5,<3.6
+  - matplotlib>=1.5
   - numpy>=1.11
   - pandas<2
   - python-dateutil

--- a/plantcv/plantcv/classes.py
+++ b/plantcv/plantcv/classes.py
@@ -330,8 +330,7 @@ class Points(object):
             idx_remove, _ = _find_closest_pt((event.xdata, event.ydata), self.points)
             # remove the closest point to the user right clicked one
             self.points.pop(idx_remove)
-            ax0plots = self.ax.lines
-            self.ax.lines.remove(ax0plots[idx_remove])
+            self.ax.lines[idx_remove].remove()
         self.fig.canvas.draw()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib>=1.5,<3.6
+matplotlib>=1.5
 numpy>=1.11
 pandas<2
 python-dateutil


### PR DESCRIPTION
**Describe your changes**
Removes upper limit on matplotlib versions and fixes one issue in `Points` related to changes to the `matplotlib` API. The change is backwards compatible with older versions of matplotlib.

**Type of update**
Is this a: update

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
