### PR TITLE
Remove upper limit restriction on pandas

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.10
   - matplotlib>=1.5
   - numpy>=1.11
-  - pandas<2
+  - pandas
   - python-dateutil
   - scipy
   - scikit-image>=0.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib>=1.5
 numpy>=1.11
-pandas<2
+pandas
 python-dateutil
 scipy
 scikit-image>=0.19


### PR DESCRIPTION
**Describe your changes**
Removes limit on the maximum version of pandas supported. Fixes issue with tests for constella that used a deprecated pandas DataFrame method.

**Type of update**
Is this a: update

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
