### PR TITLE
Enable multi label input

### DIFF
--- a/docs/analyze_bound_horizontal2.md
+++ b/docs/analyze_bound_horizontal2.md
@@ -13,7 +13,7 @@ best if the pot size/position of the plant remains relatively constant.
     - labeled_mask - Labeled mask of objects (32-bit).
     - line_position - position of boundary line (a value of 0 would draw the line through the top of the image)
     - n_labels - Total number expected individual objects (default = 1).
-    - label - Optional label parameter, modifies the variable name of observations recorded. (default = `pcv.params.sample_label`)
+    - label - Optional label parameter, modifies the variable name of observations recorded. Can be a prefix or list (default = pcv.params.sample_label).
 - **Context:**
     - Used to define a boundary line for the image, to find the height above and below as well as area above and below a
     boundary line.

--- a/docs/analyze_bound_horizontal2.md
+++ b/docs/analyze_bound_horizontal2.md
@@ -39,7 +39,7 @@ pcv.params.sample_label = "plant"
 boundary_image = pcv.analyze.bound_horizontal(img=img, labeled_mask=bin_mask, line_position=300, n_labels=1)
 
 # Access data stored out from analyze_bound_horizontal
-percent_area_below_reference = pcv.outputs.observations['plant1']['percent_area_below_reference']['value']
+percent_area_below_reference = pcv.outputs.observations['plant_1']['percent_area_below_reference']['value']
 
 ```
 

--- a/docs/analyze_bound_vertical2.md
+++ b/docs/analyze_bound_vertical2.md
@@ -13,7 +13,7 @@ best if the pot size/position of the plant remains relatively constant.
     - labeled_mask - Labeled mask of objects (32-bit).
     - line_position - position of boundary line (a value of 0 would draw the line through the left of the image)
     - n_labels - Total number expected individual objects (default = 1).
-    - label - Optional label parameter, modifies the variable name of observations recorded. (default = `pcv.params.sample_label`)
+    - label - Optional label parameter, modifies the variable name of observations recorded. Can be a prefix or list (default = pcv.params.sample_label).
 - **Context:**
     - Used to define a boundary line for the image, to find the width to the right and to the left as well as area to the
     right and to the left of a boundary line.
@@ -39,7 +39,7 @@ pcv.params.sample_label = "plant"
 boundary_image = pcv.analyze.bound_vertical(img=img, labeled_mask=bin_mask, line_position=1000, n_labels=1)
 
 # Access data stored out from analyze_bound_vertical
-area_right_reference = pcv.outputs.observations['plant1']['area_right_reference']['value']
+area_right_reference = pcv.outputs.observations['plant_1']['area_right_reference']['value']
 
 ```
 

--- a/docs/analyze_color2.md
+++ b/docs/analyze_color2.md
@@ -12,7 +12,7 @@ HSV (Hue, Saturation, Value) and LAB (Lightness, Green-Magenta, Blue Yellow) cha
     - labeled_mask - Labeled mask of objects (32-bit, output from [`pcv.create_labels`](create_labels.md) or [`pcv.roi.filter`](roi_filter.md)).
     - n_labels - Total number expected individual objects (default = 1).
     - colorspaces - 'all', 'rgb', 'lab', or 'hsv'. This can limit the data saved out (default = 'hsv'). 
-    - label - Optional label parameter, modifies the variable name of observations recorded. (default = `pcv.params.sample_label`)
+    - label - Optional label parameter, modifies the variable name of observations recorded. Can be a prefix or list (default = pcv.params.sample_label).
 - **Context:**
     - Used to extract color data from RGB, LAB, and HSV color channels.
     - Generates histogram of color channel data. 
@@ -42,7 +42,7 @@ pcv.params.sample_label = "plant"
 analysis_image = pcv.analyze.color(rgb_img=rgb_img, labeled_mask=mask, n_labels=1, colorspaces='hsv')
 
 # Access data stored out from analyze_color
-hue_circular_mean = pcv.outputs.observations['plant1']['hue_circular_mean']['value']
+hue_circular_mean = pcv.outputs.observations['plant_1']['hue_circular_mean']['value']
 
 ```
 

--- a/docs/analyze_grayscale.md
+++ b/docs/analyze_grayscale.md
@@ -12,7 +12,7 @@ the values out to the [Outputs class](outputs.md). Can also return/plot/print ou
     - labeled_mask - Labeled mask of objects (32-bit).
     - n_labels - Total number expected individual objects (default = 1).
     - bins     - Number of histogram bins (default = 100)
-    - label - Optional label parameter, modifies the variable name of observations recorded. (default = `pcv.params.sample_label`)
+    - label - Optional label parameter, modifies the variable name of observations recorded. Can be a prefix or list (default = pcv.params.sample_label).
 - **Context:**
     - Grayscale pixel values within a masked area of an image. 
 - **Example use:**
@@ -42,7 +42,7 @@ pcv.params.sample_label = "plant"
 analysis_image  = pcv.analyze.grayscale(gray_img=gray_img, labeled_mask=mask, n_labels=1, bins=100)
 
 # Access data stored out from analyze.grayscale
-nir_frequencies = pcv.outputs.observations['plant1']['gray_frequencies']['value']
+nir_frequencies = pcv.outputs.observations['plant_1']['gray_frequencies']['value']
 
 ```
 

--- a/docs/analyze_npq.md
+++ b/docs/analyze_npq.md
@@ -18,7 +18,7 @@ measurement_labels=None, label=None*)
     - min_bin - minimum bin value ("auto" or user input minimum value - must be an integer). (default `min_bin=0`)
     - max_bin - maximum bin value ("auto" or user input maximum value - must be an integer). (default `max_bin="auto"`)
     - measurement_labels - list of label(s) for each measurement in `ps_da_light`, modifies the variable name of observations recorded
-    - label - Optional label parameter, modifies the entity name of observations recorded. (default = `pcv.params.sample_label`)
+    - label - Optional label parameter, modifies the variable name of observations recorded. Can be a prefix or list (default = pcv.params.sample_label).
 - **Context:**
     - Used to extract NPQ per identified plant pixel.
     - Generates histogram of NPQ values.
@@ -43,7 +43,7 @@ npq, npq_hist = pcv.analyze.npq(ps_da_light=ps.ojip_light, ps_da_dark=ps.ojip_da
 
 # Access the NPQ median value
 # the default measurement label for cropreporter data is t1
-npq_median = pcv.outputs.observations['plant1']['npq_median_t1']['value']
+npq_median = pcv.outputs.observations['plant_1']['npq_median_t1']['value']
 
 # Pseudocolor the NPQ image
 pseudo_img = pcv.visualize.pseudocolor(gray_img=npq, mask=kept_mask, min_value=0, max_value=1, title="NPQ")

--- a/docs/analyze_size.md
+++ b/docs/analyze_size.md
@@ -10,7 +10,7 @@ Size and shape analysis outputs numeric properties for individual plants, seeds,
     - img - RGB or grayscale image data for plotting.
     - labeled_mask - Labeled mask of objects (32-bit, output from [`pcv.create_labels`](create_labels.md) or [`pcv.roi.filter`](roi_filter.md)).
     - n_labels - Total number expected individual objects (default = 1).
-    - label - Optional label parameter, modifies the variable name of observations recorded. (default = `pcv.params.sample_label`)
+    - label - Optional label parameter, modifies the variable name of observations recorded. Can be a prefix or list (default = pcv.params.sample_label).
 - **Context:**
     - Used to output size and shape characteristics of individual objects (labeled regions). 
 - **Example use:**
@@ -44,7 +44,7 @@ shape_image = pcv.analyze.size(img=img, labeled_mask=mask, n_labels=1)
 pcv.print_image(shape_image, '/home/malia/setaria_shape_img.png')
 
 # Access data stored out from analyze.size
-plant_solidity = pcv.outputs.observations['plant1']['solidity']['value']
+plant_solidity = pcv.outputs.observations['plant_1']['solidity']['value']
 
 ```
 

--- a/docs/analyze_spectral_index.md
+++ b/docs/analyze_spectral_index.md
@@ -15,7 +15,7 @@ This function calculates the spectral index statistics and writes the values as 
     - min_bin       - Optional, minimum bin label. Default of 0 will be used for the smallest bin label while calculating pixel frequency data unless otherwise defined. 
                       `min_bin="auto"` will set minimum bin to the smallest observed pixel value within the masked index provided.
     - max_bin       - Optional, maximum bin label. Default of 1 will be used for the maximum bin label unless otherwise defined. `max_bin="auto"` will set maximum bin to the largest observed pixel value within the masked index provided.
-    - label         - Optional label parameter, modifies the variable name of observations recorded. (default = `pcv.params.sample_label`)
+    - label - Optional label parameter, modifies the variable name of observations recorded. Can be a prefix or list (default = pcv.params.sample_label).
 
 - **Context:**
     - Calculates data about mean, median, and standard deviation of an input index within a masked region. 

--- a/docs/analyze_spectral_reflectance.md
+++ b/docs/analyze_spectral_reflectance.md
@@ -10,7 +10,7 @@ This function analyzes the reflectance values across the wavelengths measured by
     - hsi           - A hyperspectral datacube object, an instance of the `Spectral_data` class (read in with [pcv.readimage](read_image.md) with `mode='envi'`)
     - labeled_mask  - Labeled mask of objects (32-bit).
     - n_labels      - Total number expected individual objects (default = 1).
-    - label         - Optional label parameter, modifies the variable name of observations recorded. (default = `pcv.params.sample_label`)
+    - label - Optional label parameter, modifies the variable name of observations recorded. Can be a prefix or list (default = pcv.params.sample_label).
 - **Example use:**
     - Below 
 - **Output data stored:** Data ('global_mean_reflectance', 'global_median_reflectance', 'global_spectral_std', 'wavelength_means', 'max_reflectance', 

--- a/docs/analyze_thermal.md
+++ b/docs/analyze_thermal.md
@@ -40,7 +40,7 @@ pcv.params.sample_label = "plant"
 thermal_hist  = pcv.analyze.thermal(thermal_img=thermal_img, labeled_mask=mask)
 
 # Access data stored out from analyze.thermal
-temp_range = pcv.outputs.observations['plant_1']['max_temp']['value'] - pcv.outputs.observations['plant1']['min_temp']['value']
+temp_range = pcv.outputs.observations['plant_1']['max_temp']['value'] - pcv.outputs.observations['plant_1']['min_temp']['value']
 
 ```
 

--- a/docs/analyze_thermal.md
+++ b/docs/analyze_thermal.md
@@ -11,7 +11,7 @@ This function calculates the temperature of each pixel and stores summary statis
     - labeled_mask - Labeled mask of objects (32-bit, output from [`pcv.create_labels`](create_labels.md) or [`pcv.roi.filter`](roi_filter.md)).
     - n_labels - Total number expected individual objects (default = 1).
     - bins     - Number of histogram bins (default = 100)
-    - label - Optional label parameter, modifies the variable name of observations recorded. (default = `pcv.params.sample_label`)
+    - label - Optional label parameter, modifies the variable name of observations recorded. Can be a prefix or list (default = pcv.params.sample_label).
 - **Context:**
     - Data about image temperature within a masked region. 
 - **Example use:**
@@ -40,7 +40,7 @@ pcv.params.sample_label = "plant"
 thermal_hist  = pcv.analyze.thermal(thermal_img=thermal_img, labeled_mask=mask)
 
 # Access data stored out from analyze.thermal
-temp_range = pcv.outputs.observations['plant1']['max_temp']['value'] - pcv.outputs.observations['plant1']['min_temp']['value']
+temp_range = pcv.outputs.observations['plant_1']['max_temp']['value'] - pcv.outputs.observations['plant1']['min_temp']['value']
 
 ```
 

--- a/docs/analyze_yii.md
+++ b/docs/analyze_yii.md
@@ -14,7 +14,7 @@ The photosynthesis subpackage is dependent on a PSII_Data instance file structur
     - n_labels - Total number expected individual objects (default = 1).
     - auto_fm - Automatically calculate the frame with maximum fluorescence per label, otherwise use a fixed frame for all labels (default = False).
     - measurement_labels - list of label(s) for each measurement, modifies the default variable names of observations. must have same length as number of measurements in ps_da
-    - label - Optional label parameter, modifies the variable name of observations recorded. (default = `pcv.params.sample_label`)
+    - label - Optional label parameter, modifies the variable name of observations recorded. Can be a prefix or list (default = pcv.params.sample_label).
 - **Context:**
     - Used to extract Fv/Fm, Fv'/Fm' or Fq'/Fm' per identified plant pixel.
     - Generates histograms of Fv/Fm, Fv'/Fm' or Fq'/Fm' data.
@@ -81,7 +81,7 @@ pcv.params.sample_label = "plant"
 fqfm, fqfm_hist = pcv.analyze.yii(ps=ps.ojip_light, labeled_mask=kept_mask)
 
 # Access Fq'/Fm' median value
-fqfm_median = pcv.outputs.observations['plant1']["yii_median_t1"]['value']
+fqfm_median = pcv.outputs.observations['plant_1']["yii_median_t1"]['value']
 
 fqfm_cmap = pcv.visualize.pseudocolor(gray_img=fqfm, mask=kept_mask, min_value=0, max_value=1, title="Fq'/Fm'")
 

--- a/docs/analyze_yii.md
+++ b/docs/analyze_yii.md
@@ -49,7 +49,7 @@ ps = pcv.photosynthesis.read_cropreporter(filename="mydata.inf")
 fvfm, fvfm_hist = pcv.analyze.yii(ps_da=ps.ojip_dark, labeled_mask=kept_mask)
 
 # Access Fv/Fm median value
-fvfm_median = pcv.outputs.observations['plant1']['yii_median_t0']['value']
+fvfm_median = pcv.outputs.observations['plant_1']['yii_median_t0']['value']
 
 # Pseudocolor the Fv/Fm image
 fvfm_cmap = pcv.visualize.pseudocolor(gray_img=fvfm, mask=kept_mask, min_value=0, max_value=1, title="Fv/Fm")

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -90,7 +90,7 @@ pcv.params.sample_label = "plant"
 shape_img = pcv.analyze.size(img=img, labeled_mask=mask, n_labels=1)
 
 # Look at object area data without writing to a file 
-plant_area = pcv.outputs.observations['plant1']['pixel_area']['value']
+plant_area = pcv.outputs.observations['plant_1']['pixel_area']['value']
 
 ######## More workflow steps here ########
 

--- a/plantcv/plantcv/_helpers.py
+++ b/plantcv/plantcv/_helpers.py
@@ -175,7 +175,7 @@ def _iterate_analysis(img, labeled_mask, n_labels, label, function, **kwargs):
         mask_copy = np.where(mask_copy == 255, 1, 0).astype(np.uint8)
     for i in range(1, n_labels + 1):
         submask = np.where(mask_copy == i, 255, 0).astype(np.uint8)
-        img = function(img=img, mask=submask, label=f"{labels[i - 1]}{i}", **kwargs)
+        img = function(img=img, mask=submask, label=f"{labels[i - 1]}_{i}", **kwargs)
     return img
 
 

--- a/plantcv/plantcv/_helpers.py
+++ b/plantcv/plantcv/_helpers.py
@@ -162,12 +162,20 @@ def _iterate_analysis(img, labeled_mask, n_labels, label, function, **kwargs):
     :param function: function
     :param kwargs: dict
     """
+    # Set labels to label
+    labels = label
+    # If label is a string, make a list of labels
+    if isinstance(label, str):
+        labels = [label] * n_labels
+    # If the length of the labels list is not equal to the number of labels, raise an error
+    if len(labels) != n_labels:
+        fatal_error(f"Number of labels ({len(labels)}) does not match number of objects ({n_labels})")
     mask_copy = np.copy(labeled_mask)
     if len(np.unique(mask_copy)) == 2 and np.max(mask_copy) == 255:
         mask_copy = np.where(mask_copy == 255, 1, 0).astype(np.uint8)
     for i in range(1, n_labels + 1):
         submask = np.where(mask_copy == i, 255, 0).astype(np.uint8)
-        img = function(img=img, mask=submask, label=f"{label}{i}", **kwargs)
+        img = function(img=img, mask=submask, label=f"{labels[i - 1]}{i}", **kwargs)
     return img
 
 

--- a/plantcv/plantcv/analyze/npq.py
+++ b/plantcv/plantcv/analyze/npq.py
@@ -46,6 +46,11 @@ def npq(ps_da_light, ps_da_dark, labeled_mask, n_labels=1, auto_fm=False, min_bi
     # Set lable to params.sample_label if None
     if label is None:
         label = params.sample_label
+    # Set labels to label
+    labels = label
+    # If label is a string, make a list of labels
+    if isinstance(label, str):
+        labels = [label] * n_labels
 
     if labeled_mask.shape != ps_da_light.shape[:2] or labeled_mask.shape != ps_da_dark.shape[:2]:
         fatal_error(f"Mask needs to have shape {ps_da_dark.shape[:2]}")
@@ -95,7 +100,7 @@ def npq(ps_da_light, ps_da_dark, labeled_mask, n_labels=1, auto_fm=False, min_bi
 
         # Record observations for each labeled region
         _add_observations(npq_da=npq_lbl, measurements=ps_da_light.measurement.values,
-                          measurement_labels=measurement_labels, label=f"{label}{i}",
+                          measurement_labels=measurement_labels, label=f"{labels[i - 1]}_{i}",
                           max_bin=max_bin, min_bin=min_bin)
 
     # Convert the labeled mask to a binary mask

--- a/plantcv/plantcv/analyze/npq.py
+++ b/plantcv/plantcv/analyze/npq.py
@@ -43,17 +43,8 @@ def npq(ps_da_light, ps_da_dark, labeled_mask, n_labels=1, auto_fm=False, min_bi
     :return npq_global: xarray.core.dataarray.DataArray
     :return npq_chart: altair.vegalite.v4.api.FacetChart
     """
-    # Set lable to params.sample_label if None
-    if label is None:
-        label = params.sample_label
-    # Set labels to label
-    labels = label
-    # If label is a string, make a list of labels
-    if isinstance(label, str):
-        labels = [label] * n_labels
-    # If the length of the labels list is not equal to the number of labels, raise an error
-    if len(labels) != n_labels:
-        fatal_error(f"Number of labels ({len(labels)}) does not match number of objects ({n_labels})")
+    # Set labels
+    labels = _set_labels(label, n_labels)
 
     if labeled_mask.shape != ps_da_light.shape[:2] or labeled_mask.shape != ps_da_dark.shape[:2]:
         fatal_error(f"Mask needs to have shape {ps_da_dark.shape[:2]}")
@@ -132,6 +123,22 @@ def npq(ps_da_light, ps_da_dark, labeled_mask, n_labels=1, auto_fm=False, min_bi
     # this only returns the last histogram..... xarray does not seem to support panels of histograms
     # but does support matplotlib subplots....
     return npq_global.squeeze(), npq_chart
+
+
+def _set_labels(label, n_labels):
+    """Create list of labels."""
+    # Set lable to params.sample_label if None
+    if label is None:
+        label = params.sample_label
+    # Set labels to label
+    labels = label
+    # If label is a string, make a list of labels
+    if isinstance(label, str):
+        labels = [label] * n_labels
+    # If the length of the labels list is not equal to the number of labels, raise an error
+    if len(labels) != n_labels:
+        fatal_error(f"Number of labels ({len(labels)}) does not match number of objects ({n_labels})")
+    return labels
 
 
 def _calc_npq(fmp, fm):

--- a/plantcv/plantcv/analyze/npq.py
+++ b/plantcv/plantcv/analyze/npq.py
@@ -51,6 +51,9 @@ def npq(ps_da_light, ps_da_dark, labeled_mask, n_labels=1, auto_fm=False, min_bi
     # If label is a string, make a list of labels
     if isinstance(label, str):
         labels = [label] * n_labels
+    # If the length of the labels list is not equal to the number of labels, raise an error
+    if len(labels) != n_labels:
+        fatal_error(f"Number of labels ({len(labels)}) does not match number of objects ({n_labels})")
 
     if labeled_mask.shape != ps_da_light.shape[:2] or labeled_mask.shape != ps_da_dark.shape[:2]:
         fatal_error(f"Mask needs to have shape {ps_da_dark.shape[:2]}")

--- a/plantcv/plantcv/analyze/yii.py
+++ b/plantcv/plantcv/analyze/yii.py
@@ -34,17 +34,8 @@ def yii(ps_da, labeled_mask, n_labels=1, auto_fm=False, measurement_labels=None,
     :return yii_global: xarray.core.dataarray.DataArray
     :return yii_chart: altair.vegalite.v4.api.FacetChart
     """
-    # Set lable to params.sample_label if None
-    if label is None:
-        label = params.sample_label
-    # Set labels to label
-    labels = label
-    # If label is a string, make a list of labels
-    if isinstance(label, str):
-        labels = [label] * n_labels
-    # If the length of the labels list is not equal to the number of labels, raise an error
-    if len(labels) != n_labels:
-        fatal_error(f"Number of labels ({len(labels)}) does not match number of objects ({n_labels})")
+    # Set labels
+    labels = _set_labels(label, n_labels)
 
     # Validate that the input mask has the same 2D shape as the input DataArray
     if labeled_mask.shape != ps_da.shape[:2]:
@@ -134,6 +125,22 @@ def yii(ps_da, labeled_mask, n_labels=1, auto_fm=False, measurement_labels=None,
            vmin=0, vmax=1)
 
     return yii_global.squeeze(), yii_chart
+
+
+def _set_labels(label, n_labels):
+    """Create list of labels."""
+    # Set lable to params.sample_label if None
+    if label is None:
+        label = params.sample_label
+    # Set labels to label
+    labels = label
+    # If label is a string, make a list of labels
+    if isinstance(label, str):
+        labels = [label] * n_labels
+    # If the length of the labels list is not equal to the number of labels, raise an error
+    if len(labels) != n_labels:
+        fatal_error(f"Number of labels ({len(labels)}) does not match number of objects ({n_labels})")
+    return labels
 
 
 def _create_histogram(yii_img, mlabel):

--- a/plantcv/plantcv/analyze/yii.py
+++ b/plantcv/plantcv/analyze/yii.py
@@ -42,6 +42,9 @@ def yii(ps_da, labeled_mask, n_labels=1, auto_fm=False, measurement_labels=None,
     # If label is a string, make a list of labels
     if isinstance(label, str):
         labels = [label] * n_labels
+    # If the length of the labels list is not equal to the number of labels, raise an error
+    if len(labels) != n_labels:
+        fatal_error(f"Number of labels ({len(labels)}) does not match number of objects ({n_labels})")
 
     # Validate that the input mask has the same 2D shape as the input DataArray
     if labeled_mask.shape != ps_da.shape[:2]:

--- a/plantcv/plantcv/analyze/yii.py
+++ b/plantcv/plantcv/analyze/yii.py
@@ -37,6 +37,11 @@ def yii(ps_da, labeled_mask, n_labels=1, auto_fm=False, measurement_labels=None,
     # Set lable to params.sample_label if None
     if label is None:
         label = params.sample_label
+    # Set labels to label
+    labels = label
+    # If label is a string, make a list of labels
+    if isinstance(label, str):
+        labels = [label] * n_labels
 
     # Validate that the input mask has the same 2D shape as the input DataArray
     if labeled_mask.shape != ps_da.shape[:2]:
@@ -98,7 +103,7 @@ def yii(ps_da, labeled_mask, n_labels=1, auto_fm=False, measurement_labels=None,
         yii_global = yii_global + yii_lbl
 
         # Record observations for each labeled region
-        _add_observations(yii_da=yii_lbl, measurements=ps_da.measurement.values, label=f"{label}{i}",
+        _add_observations(yii_da=yii_lbl, measurements=ps_da.measurement.values, label=f"{labels[i - 1]}_{i}",
                           measurement_labels=measurement_labels)
 
     # Convert the labeled mask to a binary mask

--- a/tests/plantcv/analyze/test_bound_horizontal.py
+++ b/tests/plantcv/analyze/test_bound_horizontal.py
@@ -13,7 +13,7 @@ def test_analyze_bound_horizontal(pos, exp, test_data):
     img = cv2.imread(test_data.small_rgb_img)
     mask = cv2.imread(test_data.small_bin_img, -1)
     _ = analyze_bound_horizontal(img=img, labeled_mask=mask, n_labels=1, line_position=pos)
-    assert outputs.observations["default1"]["height_above_reference"]["value"] == exp
+    assert outputs.observations["default_1"]["height_above_reference"]["value"] == exp
 
 
 def test_analyze_bound_horizontal_grayscale_image(test_data):

--- a/tests/plantcv/analyze/test_bound_vertical.py
+++ b/tests/plantcv/analyze/test_bound_vertical.py
@@ -13,7 +13,7 @@ def test_bound_vertical(pos, exp, test_data):
     img = cv2.imread(test_data.small_rgb_img)
     mask = cv2.imread(test_data.small_bin_img, -1)
     _ = analyze_bound_vertical(img=img, labeled_mask=mask, n_labels=1, line_position=pos)
-    assert outputs.observations['default1']['width_left_reference']['value'] == exp
+    assert outputs.observations['default_1']['width_left_reference']['value'] == exp
 
 
 def test_bound_vertical_grayscale_image(test_data):
@@ -24,4 +24,4 @@ def test_bound_vertical_grayscale_image(test_data):
     img = cv2.imread(test_data.small_gray_img, -1)
     mask = cv2.imread(test_data.small_bin_img, -1)
     _ = analyze_bound_vertical(img=img, labeled_mask=mask, n_labels=1, line_position=225)
-    assert outputs.observations['default1']['width_left_reference']['value'] == 16
+    assert outputs.observations['default_1']['width_left_reference']['value'] == 16

--- a/tests/plantcv/analyze/test_color.py
+++ b/tests/plantcv/analyze/test_color.py
@@ -13,7 +13,7 @@ def test_color(colorspace, test_data):
     img = cv2.imread(test_data.small_rgb_img)
     mask = cv2.imread(test_data.small_bin_img, -1)
     _ = analyze_color(rgb_img=img, labeled_mask=mask, n_labels=1, colorspaces=colorspace)
-    assert outputs.observations['default1']['hue_median']['value'] == 80.0
+    assert outputs.observations['default_1']['hue_median']['value'] == 80.0
 
 
 def test_color_bad_imgtype(test_data):

--- a/tests/plantcv/analyze/test_grayscale.py
+++ b/tests/plantcv/analyze/test_grayscale.py
@@ -13,7 +13,7 @@ def test_grayscale(test_data):
     mask = cv2.imread(test_data.small_bin_img, -1)
 
     _ = analyze_grayscale(gray_img=img, labeled_mask=mask, n_labels=1, bins=256)
-    assert int(outputs.observations['default1']['gray_median']['value']) == 117
+    assert int(outputs.observations['default_1']['gray_median']['value']) == 117
 
 
 def test_grayscale_16bit(test_data):
@@ -25,4 +25,4 @@ def test_grayscale_16bit(test_data):
     mask = cv2.imread(test_data.small_bin_img, -1)
 
     _ = analyze_grayscale(gray_img=np.uint16(img), labeled_mask=mask, n_labels=1, bins=256)
-    assert int(outputs.observations['default1']['gray_median']['value']) == 117
+    assert int(outputs.observations['default_1']['gray_median']['value']) == 117

--- a/tests/plantcv/analyze/test_npq.py
+++ b/tests/plantcv/analyze/test_npq.py
@@ -14,7 +14,7 @@ def test_npq_cropreporter(test_data):
     _ = analyze_npq(ps_da_light=da_light, ps_da_dark=da_dark, labeled_mask=test_data.create_ps_mask(),
                     auto_fm=False,
                     measurement_labels=["Fq/Fm"], label="prefix", min_bin="auto", max_bin="auto")
-    assert np.isclose(outputs.observations["prefix1"]["npq_median_Fq/Fm"]["value"], 0.25)
+    assert np.isclose(outputs.observations["prefix_1"]["npq_median_Fq/Fm"]["value"], 0.25)
 
 
 def test_npq_waltz(test_data):
@@ -25,7 +25,7 @@ def test_npq_waltz(test_data):
     da_light = test_data.psii_walz('ojip_light')
     _ = analyze_npq(ps_da_light=da_light, ps_da_dark=da_dark, labeled_mask=test_data.create_ps_mask(), auto_fm=True,
                     measurement_labels=None, label="prefix", min_bin="auto", max_bin="auto")
-    assert np.isclose(outputs.observations["prefix1"]["npq_median_t40"]["value"], float((200 / 185) - 1))
+    assert np.isclose(outputs.observations["prefix_1"]["npq_median_t40"]["value"], float((200 / 185) - 1))
 
 
 @pytest.mark.parametrize("mlabels, tmask",

--- a/tests/plantcv/analyze/test_npq.py
+++ b/tests/plantcv/analyze/test_npq.py
@@ -49,3 +49,12 @@ def test_npq_bad_var(test_data):
                         ps_da_light=test_data.psii_cropreporter('ojip_dark'),
                         labeled_mask=test_data.create_ps_mask(),
                         measurement_labels=None)
+
+
+def test_npq_wrong_num_labels(test_data):
+    """Test for PlantCV."""
+    with pytest.raises(RuntimeError):
+        _ = analyze_npq(ps_da_dark=test_data.psii_cropreporter('ojip_dark'),
+                        ps_da_light=test_data.psii_cropreporter('ojip_light'),
+                        labeled_mask=test_data.create_ps_mask(),
+                        measurement_labels=None, label=["prefix", "prefix"])

--- a/tests/plantcv/analyze/test_size.py
+++ b/tests/plantcv/analyze/test_size.py
@@ -12,7 +12,7 @@ def test_size(test_data):
     img = cv2.imread(test_data.small_rgb_img)
     mask = cv2.imread(test_data.small_bin_img, -1)
     _ = analyze_size(img=img, labeled_mask=mask, n_labels=1)
-    assert int(outputs.observations["default1"]["area"]["value"]) == 221
+    assert int(outputs.observations["default_1"]["area"]["value"]) == 221
 
 
 def test_size_zero_slope():
@@ -33,7 +33,7 @@ def test_size_zero_slope():
                             [[12, 10]], [[11, 10]]], dtype=np.int32)
     mask = cv2.drawContours(mask, obj_contour, -1, (255), thickness=-1)
     _ = analyze_size(img=img, labeled_mask=mask, n_labels=1)
-    assert outputs.observations["default1"]["longest_path"]["value"] == 30
+    assert outputs.observations["default_1"]["longest_path"]["value"] == 30
 
 
 def test_size_longest_axis_2d():
@@ -49,7 +49,7 @@ def test_size_longest_axis_2d():
                             [[4, 1]], [[3, 1]], [[2, 1]]], dtype=np.int32)
     mask = cv2.drawContours(mask, obj_contour, -1, (255), thickness=-1)
     _ = analyze_size(img=img, labeled_mask=mask, n_labels=1)
-    assert outputs.observations["default1"]["longest_path"]["value"] == 186
+    assert outputs.observations["default_1"]["longest_path"]["value"] == 186
 
 
 def test_size_longest_axis_2e():
@@ -71,7 +71,7 @@ def test_size_longest_axis_2e():
                             [[13, 10]], [[12, 10]], [[11, 10]]], dtype=np.int32)
     mask = cv2.drawContours(mask, obj_contour, -1, (255), thickness=-1)
     _ = analyze_size(img=img, labeled_mask=mask, n_labels=1)
-    assert outputs.observations["default1"]["longest_path"]["value"] == 141
+    assert outputs.observations["default_1"]["longest_path"]["value"] == 141
 
 
 def test_size_small_contour(test_data):

--- a/tests/plantcv/analyze/test_spectral_index.py
+++ b/tests/plantcv/analyze/test_spectral_index.py
@@ -13,7 +13,7 @@ def test_spectral_index(test_data):
     mask_img = np.ones(np.shape(index_array.array_data), dtype=np.uint8)
     _ = spectral_index(index_img=index_array, labeled_mask=mask_img)
 
-    assert outputs.observations['default1']['mean_index_savi']['value'] > 0
+    assert outputs.observations['default_1']['mean_index_savi']['value'] > 0
 
 
 def test_spectral_index_set_range(test_data):
@@ -23,7 +23,7 @@ def test_spectral_index_set_range(test_data):
     index_array = test_data.load_hsi(test_data.savi_file)
     mask = np.ones(np.shape(index_array.array_data), dtype=np.uint8)
     _ = spectral_index(index_img=index_array, labeled_mask=mask, min_bin=0, max_bin=1)
-    assert outputs.observations['default1']['mean_index_savi']['value'] > 0
+    assert outputs.observations['default_1']['mean_index_savi']['value'] > 0
 
 
 def test_spectral_index_auto_range(test_data):
@@ -33,7 +33,7 @@ def test_spectral_index_auto_range(test_data):
     index_array = test_data.load_hsi(test_data.savi_file)
     mask = np.ones(np.shape(index_array.array_data), dtype=np.uint8)
     _ = spectral_index(index_img=index_array, labeled_mask=mask, min_bin="auto", max_bin="auto")
-    assert outputs.observations['default1']['mean_index_savi']['value'] > 0
+    assert outputs.observations['default_1']['mean_index_savi']['value'] > 0
 
 
 def test_spectral_index_outside_range_warning(test_data):

--- a/tests/plantcv/analyze/test_spectral_reflectance.py
+++ b/tests/plantcv/analyze/test_spectral_reflectance.py
@@ -9,4 +9,4 @@ def test_spectral_reflectance(test_data):
     outputs.clear()
     mask = cv2.imread(test_data.hsi_mask_file, -1)
     _ = spectral_reflectance(hsi=test_data.load_hsi(test_data.hsi_file), labeled_mask=mask)
-    assert len(outputs.observations['default1']['wavelength_means']['value']) == 978
+    assert len(outputs.observations['default_1']['wavelength_means']['value']) == 978

--- a/tests/plantcv/analyze/test_thermal.py
+++ b/tests/plantcv/analyze/test_thermal.py
@@ -11,4 +11,4 @@ def test_thermal(test_data):
     mask = cv2.imread(test_data.thermal_mask, -1)
     img = test_data.load_npz(test_data.thermal_obj_file)
     _ = analyze_thermal(thermal_img=img, labeled_mask=mask)
-    assert outputs.observations['default1']['median_temp']['value'] == 33.20922
+    assert outputs.observations['default_1']['median_temp']['value'] == 33.20922

--- a/tests/plantcv/analyze/test_yii.py
+++ b/tests/plantcv/analyze/test_yii.py
@@ -19,7 +19,7 @@ def test_yii_cropreporter(prot, mlabels, exp, test_data):
                     n_labels=1, auto_fm=True,
                     measurement_labels=mlabels)
     label = "t0" if mlabels is None else mlabels[0]
-    assert np.isclose(outputs.observations["default1"][f"yii_median_{label}"]["value"], exp)
+    assert np.isclose(outputs.observations["default_1"][f"yii_median_{label}"]["value"], exp)
 
 
 @pytest.mark.parametrize("prot,mlabels,exp", [
@@ -36,7 +36,7 @@ def test_yii_waltz(prot, mlabels, exp, test_data):
                     n_labels=1, auto_fm=False,
                     measurement_labels=mlabels, label="default")
     label = "t0" if mlabels is None else mlabels[0]
-    assert np.isclose(outputs.observations["default1"][f"yii_median_{label}"]["value"], exp)
+    assert np.isclose(outputs.observations["default_1"][f"yii_median_{label}"]["value"], exp)
 
 
 @pytest.mark.parametrize("mlabels, tmask",

--- a/tests/plantcv/analyze/test_yii.py
+++ b/tests/plantcv/analyze/test_yii.py
@@ -59,3 +59,11 @@ def test_yii_bad_var(test_data):
     with pytest.raises(RuntimeError):
         _ = analyze_yii(ps_da=da, labeled_mask=test_data.create_ps_mask(),
                         measurement_labels=None, label="default")
+
+
+def test_yii_wrong_num_labels(test_data):
+    """Test for PlantCV."""
+    with pytest.raises(RuntimeError):
+        _ = analyze_yii(ps_da=test_data.psii_cropreporter('ojip_dark'),
+                        labeled_mask=test_data.create_ps_mask(),
+                        measurement_labels=None, label=["prefix", "prefix"])

--- a/tests/plantcv/test_helper_iterate_analysis.py
+++ b/tests/plantcv/test_helper_iterate_analysis.py
@@ -1,4 +1,5 @@
 import cv2
+import pytest
 from plantcv.plantcv._helpers import _iterate_analysis
 
 
@@ -7,6 +8,13 @@ def test_iterate_analysis(test_data):
     mask = cv2.imread(test_data.small_bin_img, -1)
     img = _iterate_analysis(img=mask, labeled_mask=mask, n_labels=1, label="test", function=analysis_test_func)
     assert img.shape == mask.shape
+
+
+def test_iterate_analysis_wrong_num_labels(test_data):
+    """Test for PlantCV."""
+    mask = cv2.imread(test_data.small_bin_img, -1)
+    with pytest.raises(RuntimeError):
+        _ = _iterate_analysis(img=mask, labeled_mask=mask, n_labels=1, label=["test", "test"], function=analysis_test_func)
 
 
 def analysis_test_func(img, mask, label):


### PR DESCRIPTION
**Describe your changes**
Modifies the helper function `_iterate_analysis` to accept either a string label or a list of labels equal to the length of `n_labels`. If a string is input, a list of length `n_labels` is made by repeating the input string. The iterator uses the list of labels to label each object label. If the length of labels is not equal to `n_labels` a fatal error is triggered.

We might need to update all analysis doc pages to indicate that a list of labels can be input.

**Type of update**
Is this a:
* New feature or feature enhancement

**Associated issues**
#1360 

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [ ] PR approved
