### PR TITLE
Update spectral wavelengths for CropReporter datasets

### DIFF
--- a/docs/photosynthesis_read_cropreporter.md
+++ b/docs/photosynthesis_read_cropreporter.md
@@ -21,8 +21,8 @@ with labeled frames.
     - Measurements from chlorophyll fluorescence are stored in the attribute `chlorophyll` and include a dark frame
       (Fdark) and chlorophyll fluorescence frame (Chl).
     - Spectral measurements are stored as a PlantCV [Spectral_data](Spectral_data.md) object in the attribute
-      `spectral`. Frames are stored by reflectance wavelength and can include: blue (460nm), green (500nm), red (670nm),
-      green2 (550nm), far-red (700nm), and near-infrared (800nm).
+      `spectral`. Frames are stored by reflectance wavelength and can include: blue (475nm), green (550nm), red (640nm),
+      green2 (540nm), far-red (710nm), and near-infrared (770nm).
 - **Example use:**
     - [Use In PSII Tutorial](tutorials/psII_tutorial.md)
 

--- a/plantcv/plantcv/photosynthesis/read_cropreporter.py
+++ b/plantcv/plantcv/photosynthesis/read_cropreporter.py
@@ -279,14 +279,14 @@ def _process_spc_data(ps, metadata):
                                         height=int(metadata["ImageRows"]),
                                         width=int(metadata["ImageCols"]))
         img_cubes.append(rgb_cube)
-        wavelengths += [670, 500, 460]
+        wavelengths += [640, 550, 475]
         rgb = img_as_ubyte(rgb_cube[:, :, [2, 1, 0]])
     if os.path.exists(spc_filepath):
         spc_cube, _, _ = _read_dat_file(dataset="SPC", filename=spc_filepath,
                                         height=int(metadata["ImageRows"]),
                                         width=int(metadata["ImageCols"]))
         img_cubes.append(spc_cube)
-        wavelengths += [550, 700, 800]
+        wavelengths += [540, 710, 770]
         if rgb is None:
             rgb = img_as_ubyte(spc_cube)
 


### PR DESCRIPTION
**Describe your changes**
Updates the wavelengths assigned to spectral frames in CropReporter datasets to:

* 640, 550, 475nm are Red, Green, Blue
* 540, 710, 770nm are Anthocyanin, red-Edge, NIR

The existing wavelengths could cause some spectral indices to be computed with the incorrect frame: see #1373.

**Type of update**
Is this a: Bug fix

**Associated issues**
Closes #1373

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
