### PR TITLE
changes for deepsource expecting 2 blank lines

### DIFF
--- a/plantcv/plantcv/hyperspectral/write_data.py
+++ b/plantcv/plantcv/hyperspectral/write_data.py
@@ -5,6 +5,7 @@ from plantcv.plantcv import _version
 
 __version__ = _version.get_versions()['version']
 
+
 def write_data(filename, spectral_data):
     """Write hyperspectral image data to a file.
     Inputs:

--- a/plantcv/plantcv/visualize/pixel_scatter_vis.py
+++ b/plantcv/plantcv/visualize/pixel_scatter_vis.py
@@ -33,6 +33,7 @@ def _get_gray(rgb_img, _):
     """ Get the gray scale transformation of a RGB image """
     return pcv.rgb2gray(rgb_img=rgb_img)
 
+
 def _get_index(rgb_img, _):
     """ Get a vector with linear indices of the pixels in an image """
     h,w,_ = rgb_img.shape


### PR DESCRIPTION
**Describe your changes**
Changed two places where one blank line was between classes and functions per deepsource recommendation

**Type of update**
Is this a deepsource fix.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
