### PR TITLE
too many leading '#' for block comment

### DIFF
--- a/plantcv/plantcv/annotate/points.py
+++ b/plantcv/plantcv/annotate/points.py
@@ -3,7 +3,7 @@
 import numpy as np
 from scipy.spatial import distance
 
-## INTERACTIVE ROI TOOLS ##
+# INTERACTIVE ROI TOOLS #
 
 
 def _find_closest_pt(pt, pts):


### PR DESCRIPTION
Changed the block comments from double hash symbols (##) to single hash symbols (#) for consistency with standard Python commenting practices.

**Describe your changes**
A clear and concise description of what changes are made by this pull request.
What was the previous functionality (if relevant) and what can we do now with
these changes.

**Type of update**
Is this a:
* Bug fix
* New feature or feature enhancement
* Update to documentation
* Work in progress

**Associated issues**
Reference associated issue numbers. Does this pull request close any issues?

**Additional context**
Add any other context about the problem here.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
