### PR TITLE
removing redundant object specification

### DIFF
--- a/plantcv/plantcv/classes.py
+++ b/plantcv/plantcv/classes.py
@@ -295,7 +295,7 @@ class PSII_data:
         self.__dict__[protocol.name] = protocol
 
 
-class Points(object):
+class Points:
     """Point annotation/collection class to use in Jupyter notebooks. It allows the user to
     interactively click to collect coordinates from an image. Left click collects the point and
     right click removes the closest collected point


### PR DESCRIPTION
**Describe your changes**
Removed a redundant specification about the Points class taking an object per deepsource recommendation.

**Type of update**
Is this a deepsource fix.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
