### PR TITLE
Fix PYL-R1714

### DIFF
--- a/plantcv/plantcv/photosynthesis/reassign_frame_labels.py
+++ b/plantcv/plantcv/photosynthesis/reassign_frame_labels.py
@@ -29,7 +29,7 @@ def reassign_frame_labels(ps_da, mask):
     params.device += 1
 
     try:
-        if ps_da.name != "ojip_light" and ps_da.name != "ojip_dark":
+        if ps_da.name in ("ojip_light", "ojip_dark"):
             fatal_error("You must provide a xarray DataArray with name ojip_light or ojip_dark")
     except AttributeError:
         if isinstance(ps_da, PSII_data):

--- a/plantcv/plantcv/visualize/chlorophyll_fluorescence.py
+++ b/plantcv/plantcv/visualize/chlorophyll_fluorescence.py
@@ -29,7 +29,7 @@ def chlorophyll_fluorescence(ps_da, labeled_mask, n_labels=1, label="object"):
 
     # Check that the dataarray is valid
     try:
-        if ps_da.name != "ojip_light" and ps_da.name != "ojip_dark":
+        if ps_da.name in ("ojip_light", "ojip_dark"):
             fatal_error("You must provide a xarray DataArray with name ojip_light or ojip_dark")
     except AttributeError:
         if isinstance(ps_da, PSII_data):


### PR DESCRIPTION
**Describe your changes**
PYL-R1714: use `in` instead of multiple comparisons.

**Type of update**
Is this a: cleanup

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
