### PR TITLE
Update PyPi deploy workflow to use OIDC authentication

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -33,7 +33,11 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-
+    environment:
+      name: pypi
+      url: https://pypi.org/p/plantcv
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@main
       with:
@@ -46,10 +50,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    - name: Build
       run: |
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
**Describe your changes**
Updates the GitHub Action workflow that deploys PlantCV releases to PyPI to use the PyPA Action and OIDC authentication.

**Type of update**
Is this a: update to new security protocols for PyPI

**Additional context**
GitHub Action: https://github.com/marketplace/actions/pypi-publish

PyPI no longer supports username/password authentication:

```
Username/Password authentication is no longer supported. Migrate to API
         Tokens or Trusted Publishers instead. See                              
         https://pypi.org/help/#apitoken and                                    
         https://pypi.org/help/#trusted-publishers  
```

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
