### PR TITLE
Randomize color order default for pcv.watershed()

### DIFF
--- a/plantcv/plantcv/watershed.py
+++ b/plantcv/plantcv/watershed.py
@@ -40,6 +40,10 @@ def watershed_segmentation(rgb_img, mask, distance=10, label=None):
     debug = params.debug
     params.debug = None
 
+    # Store color sequence mode and set to random for watershed_img debug
+    color_sequence = params.color_sequence
+    params.color_sequence = "random"
+
     # Set lable to params.sample_label if None
     if label is None:
         label = params.sample_label
@@ -68,6 +72,9 @@ def watershed_segmentation(rgb_img, mask, distance=10, label=None):
 
     # Reset debug mode
     params.debug = debug
+
+    # Reset color sequence mode
+    params.color_sequence = color_sequence
     _debug(visual=dist_transform,
            filename=os.path.join(params.debug_outdir, str(params.device) + '_watershed_dist_img.png'),
            cmap='gray')


### PR DESCRIPTION
**Describe your changes**
Changed default params.color_sequence behavior for watershed. Color_sequence default is now random and restored alongside params.debug.

**Type of update**
* New feature or feature enhancement

**Associated issues**
#1428

**Additional context**
Unsure if further implementation required.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
