### PR TITLE
Add min_size to `detect_color_card` kwargs

### DIFF
--- a/docs/transform_detect_color_card.md
+++ b/docs/transform_detect_color_card.md
@@ -13,6 +13,7 @@ Automatically detects a color card and creates a labeled mask.
         - adaptive_method - Adaptive threhold method. 0 (mean) or 1 (Gaussian) (default = 1).
         - block_size      - Size of a pixel neighborhood that is used to calculate a threshold value (default = 51). We suggest using 127 if using `adaptive_method=0`.
         - radius         - Radius of circle to make the color card labeled mask (default = 20).
+        - min_size         - Minimum chip size for filtering objects after edge detection (default = 1000)
 - **Returns**
     - labeled_mask     - Labeled color card mask (useful downstream of this step in `pcv.transform.get_color_matrix` and `pcv.transform.correct_color`)
 - **Example use:**


### PR DESCRIPTION
**Describe your changes**
Add min_size to `detect_color_card` kwargs

**Type of update**
Is this a:
*  feature enhancement

**Associated issues**
Reference associated issue numbers. Does this pull request close any issues?

**Additional context**
Low resolution images plus small color card varieties can make color cards too small for detection at the default 1000 pixel filtering size. Enable users to lower this if it helps in their dataset. 

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
