### PR TITLE
Add DEEPSOURCE_DSN to environment

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,3 +50,5 @@ jobs:
         key: python
         coverage-file: coverage.xml
         dsn: ${{ secrets.DEEPSOURCE_DSN }}
+      env:
+        DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}


### PR DESCRIPTION
**Describe your changes**
DeepSource code coverage is not running on new PRs because it cannot find the DEEPSOURCE_DSN environmental variable even though it has been set in GitHub Secrets, so this PR tries to also add an environmental variable to set it in two places.

**Type of update**
Is this a: Bug fix

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
