### PR TITLE
Add method to quickly filter binary images

### DIFF
--- a/docs/roi_quick_filter.md
+++ b/docs/roi_quick_filter.md
@@ -1,0 +1,52 @@
+## Filter a Mask using a Region of Interest
+
+Filter objects (connected regions of non-zero pixels) within a region of interest. This function is similar to
+[plantcv.roi.filter](roi_filter.md) but is faster, though it only supports the partial overlap method
+(`roi_type='partial'` in `plantcv.roi.filter`).
+
+**plantcv.roi.quick_filter**(*mask, roi*)
+
+**returns** filtered_mask
+
+- **Parameters:**
+    - mask = binary image data to be filtered
+    - roi = region of interest, an instance of the Objects class, output from one of the pcv.roi subpackage functions
+
+- **Context:**
+    - Used to filter objects within a region of interest and decide which ones to keep.
+
+- **Example use:**
+    - Below
+
+**RGB image**
+
+![Screenshot](img/documentation_images/roi_filter/rgb_img.png)
+
+**Thresholded image (mask)**
+
+![Screenshot](img/documentation_images/roi_filter/bin_img.png)
+
+**ROI visualization**
+
+![Screenshot](img/documentation_images/roi_filter/roi_img.png)
+
+
+```python
+
+from plantcv import plantcv as pcv
+
+# Set global debug behavior to None (default), "print" (to file),
+# or "plot" (Jupyter Notebooks or X11)
+pcv.params.debug = "plot"
+
+# ROI filter keeps objects that are partially inside ROI
+filtered_mask = pcv.roi.quick_filter(mask=mask, roi=roi)
+
+```
+
+**Filtered mask**
+
+![Screenshot](img/documentation_images/roi_filter/mask_partial.png)
+
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/main/plantcv/plantcv/roi/quick_filter.py)

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -907,6 +907,11 @@ pages for more details on the input and output variable types.
 * post v3.1: roi_contours, roi_hierarchies = **plantcv.roi.multi**(*img, coord, radius, spacing=None, nrows=None, ncols=None*)
 * post v4.0: roi_objects = **plantcv.roi.multi**(*img, coord, radius=None, spacing=None, nrows=None, ncols=None*)
 
+#### plantcv.roi.quick_filter
+
+* pre v4.2.1: NA
+* post v4.2.1: filtered_mask = **plantcv.roi.quick_filter**(*mask, roi*)
+
 #### plantcv.roi_objects
 
 * pre v3.0dev2: device, kept_cnt, hierarchy, mask, obj_area = **plantcv.roi_objects**(*img, roi_type, roi_contour, roi_hierarchy, object_contour, obj_hierarchy, device, debug=None*)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
         - 'Create Multi ROIs': 'roi_multi.md'
         - 'Create Grid of ROIs Automatically': roi_auto_grid.md
         - 'Filter a mask by ROI': roi_filter.md
+        - 'Filter a mask by ROI (quickly)': roi_quick_filter.md
         - 'Convert ROI to Mask': roi2mask.md
       - 'Segment Image Series': segment_image_series.md
       - 'Shift Image': shift.md

--- a/plantcv/plantcv/roi/__init__.py
+++ b/plantcv/plantcv/roi/__init__.py
@@ -7,6 +7,7 @@ from plantcv.plantcv.roi.roi_methods import multi
 from plantcv.plantcv.roi.roi_methods import custom
 from plantcv.plantcv.roi.roi_methods import filter
 from plantcv.plantcv.roi.roi2mask import roi2mask
+from plantcv.plantcv.roi.quick_filter import quick_filter
 
 __all__ = ["circle", "ellipse", "from_binary_image", "rectangle", "auto_grid", "multi", "custom",
-           "filter", "roi2mask"]
+           "filter", "roi2mask", "quick_filter"]

--- a/plantcv/plantcv/roi/quick_filter.py
+++ b/plantcv/plantcv/roi/quick_filter.py
@@ -55,7 +55,7 @@ def quick_filter(mask, roi):
 
     # The summed image now only contains objects that overlap the ROI
     # Subtract 0.5 to remove the ROI mask
-    summed = (summed - 0.5)
+    summed = summed - 0.5
 
     # Round and set the data type back to uint8
     summed = summed.round().astype("uint8")

--- a/plantcv/plantcv/roi/quick_filter.py
+++ b/plantcv/plantcv/roi/quick_filter.py
@@ -1,0 +1,70 @@
+"""PlantCV quick_filter module."""
+import os
+import numpy as np
+from skimage.measure import label
+from plantcv.plantcv import params
+from plantcv.plantcv.roi import roi2mask
+from plantcv.plantcv._debug import _debug
+
+
+def quick_filter(mask, roi):
+    """Quickly filter a binary mask using a region of interest.
+    Inputs
+    ------
+    mask = binary mask
+    roi  = PlantCV ROI object
+
+    Returns
+    -------
+    filtered_mask = Filtered binary mask
+    """
+    # Increment the device counter
+    params.device += 1
+
+    # Store debug
+    debug = params.debug
+    params.debug = None
+
+    # Label objects in the image from 1 to n (labeled mask)
+    labels, num = label(label_image=mask, return_num=True)
+
+    # Convert the input ROI to a binary mask (only works on single ROIs)
+    roi_mask = roi2mask(img=mask, roi=roi)
+
+    # Convert the labeled mask and ROI mask to float data types
+    roi_mask = roi_mask.astype(float)
+    labels = labels.astype(float)
+
+    # Set the ROI mask value to 0.5
+    roi_mask[np.where(roi_mask == 255)] = 0.5
+
+    # Add the labeled mask and ROI mask together
+    summed = roi_mask + labels
+
+    # For each label, if at least one pixel of the object overlaps the ROI
+    # set all the label values to the label plus 0.5
+    for i in range(1, num + 1):
+        if i + 0.5 in summed:
+            summed[np.where(summed == i)] = i + 0.5
+
+    # Objects that do not overlap the ROI will round to an integer and have
+    # the same value before and after rounding.
+    # Objecs that overlap the ROI will round up/down and will not have the same value
+    # Where the values are equal (not overlapping)
+    summed[np.where(summed == summed.round())] = 0
+
+    # The summed image now only contains objects that overlap the ROI
+    # Subtract 0.5 to remove the ROI mask
+    summed = (summed - 0.5)
+
+    # Round and set the data type back to uint8
+    summed = summed.round().astype("uint8")
+
+    # Make sure the mask is binary
+    summed[np.where(summed > 0)] = 255
+
+    # Print/plot debug image
+    params.debug = debug
+    _debug(visual=summed, filename=os.path.join(params.debug_outdir, f"{params.device}_roi_filter.png"), cmap="gray")
+
+    return summed

--- a/tests/plantcv/roi/test_quick_filter.py
+++ b/tests/plantcv/roi/test_quick_filter.py
@@ -1,0 +1,21 @@
+"""quick_filter tests module."""
+import cv2
+import numpy as np
+from plantcv.plantcv import Objects
+from plantcv.plantcv.roi import quick_filter
+
+
+def test_quick_filter(test_data):
+    """Test for PlantCV."""
+    # Read in test data
+    img = cv2.imread(test_data.small_rgb_img)
+    mask = np.zeros(np.shape(img)[:2], dtype=np.uint8)
+    cnt, cnt_str = test_data.load_contours(test_data.small_contours_file)
+    cv2.drawContours(mask, cnt, -1, (255), -1, lineType=8, hierarchy=cnt_str)
+    roi = [np.array([[[150, 150]], [[150, 174]], [[249, 174]], [[249, 150]]], dtype=np.int32)]
+    roi_str = np.array([[[-1, -1, -1, -1]]], dtype=np.int32)
+    roi_obj = Objects(contours=[roi], hierarchy=[roi_str])
+    filtered_mask = quick_filter(mask=mask, roi=roi_obj)
+    area = cv2.countNonZero(filtered_mask)
+    # Assert that the contours were filtered as expected
+    assert area == 221


### PR DESCRIPTION
**Describe your changes**
Adds a new function `plantcv.roi.quick_filter` that is a companion to `plantcv.roi.filter`. The new function is significantly faster than `filter` but only supports the ROI partial overlap method (`roi_type="partial"` in `filter`).

**Type of update**
Is this a: New feature or feature enhancement

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
