### PR TITLE
Bump supported versions of Python to 3.10-3.12

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.10', '3.11', '3.12']
         os: [ubuntu-latest]
     env:
       OS: ${{ matrix.os }}
@@ -39,7 +39,7 @@ jobs:
         pip install .
         py.test --cov-report=xml --cov=./
     - name: Upload coverage to Deepsource
-      if: ${{ matrix.python-version == '3.10' }}
+      if: ${{ matrix.python-version == '3.12' }}
       uses: deepsourcelabs/test-coverage-action@master
       with:
         key: python

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@main

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@
 - macOS x86 (Intel) and M (ARM) processors
 - Windows 64-bit, x86 processors
 
-PlantCV requires Python (tested with versions 3.8, 3.9, and 3.10) and these [Python packages](https://github.com/danforthcenter/plantcv/blob/main/requirements.txt).
+PlantCV requires Python (tested with versions 3.10, 3.11, and 3.12) and these [Python packages](https://github.com/danforthcenter/plantcv/blob/main/requirements.txt).
 Additionally, we recommend installing [JupyterLab](https://jupyter.org/).
 
 ### Install via a package manager <a name="install"></a>

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@
 # optionally, change channel name with -n {plantcv-dev}
 name: plantcv
 dependencies:
-  - python=3.10
+  - python=3.12
   - matplotlib>=1.5
   - numpy>=1.11
   - pandas


### PR DESCRIPTION
**Describe your changes**
Modifies GitHub Actions workflows, conda environment template, and installation instructions to bump the supported versions of Python to 3.10, 3.11, and 3.12.

**Type of update**
Is this a: New feature or feature enhancement

**Associated issues**
#1490 

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
