### PR TITLE
Fix bug in plotting debug mode

### DIFF
--- a/plantcv/learn/__init__.py
+++ b/plantcv/learn/__init__.py
@@ -1,9 +1,3 @@
-import os
-import matplotlib
-# If there is no display or a matplotlib backend already defined, use the non-GUI backend
-if "DISPLAY" not in os.environ or "MPLBACKEND" not in os.environ:
-    matplotlib.use("Agg")
-
 from plantcv.learn.naive_bayes import naive_bayes
 from plantcv.learn.naive_bayes import naive_bayes_multiclass
 from plantcv.learn.train_kmeans import train_kmeans


### PR DESCRIPTION
**Describe your changes**
We recently added a new feature that cross imported from the `learn` submodule, which contains code that checks the environment and sets `matplotlib` to a non-plotting backend if needed. But this caused PlantCV imports to switch `matplotlib` to the `agg` backend unintentionally, which breaks the plotting debug mode. This PR removes the unneeded `matplotlib` backend code from the `learn` submodule.

**Type of update**
Is this a: Bug fix

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
