### PR TITLE
parallel docs for windows Update

### DIFF
--- a/docs/parallel_config.md
+++ b/docs/parallel_config.md
@@ -215,12 +215,5 @@ To run `plantcv-run-workflow` with a config file you can use the following:
 plantcv-run-workflow --config my_config.json
 ```
 
-Remember that `python` and `plantcv-run-workflow` need to be in your PATH, for example with Conda environment. On 
-Windows you will need to specify the whole path to `plantcv-run-workflow`.
-
-```shell
-plantcv-run-workflow --config my_config.json
-```
-
 **Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/main/plantcv/parallel/__init__.py)
 

--- a/docs/parallel_config.md
+++ b/docs/parallel_config.md
@@ -219,7 +219,7 @@ Remember that `python` and `plantcv-run-workflow` need to be in your PATH, for e
 Windows you will need to specify the whole path to `plantcv-run-workflow`.
 
 ```shell
-python %CONDA_PREFIX%/Scripts/plantcv-run-workflow --config my_config.json
+plantcv-run-workflow --config my_config.json
 ```
 
 **Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/main/plantcv/parallel/__init__.py)

--- a/docs/roi_auto_grid.md
+++ b/docs/roi_auto_grid.md
@@ -14,7 +14,7 @@
     - Used to define a grid of multiple circular regions of interest in the same binary mask. Users
       specify a number of rows and columns, and the function detects a grid of circular ROIs based
       on the inputs. A custom radius can optionally be set for the individual circles. If the image from
-      which the binary mask was created is passed as an argumnet, ROIs will be drawn on that image if
+      which the binary mask was created is passed as an argument, ROIs will be drawn on that image if
       debug is set to plot. Otherwise, they will be drawn on the binary mask. Returns an Objects
       dataclass that can be used in downstream steps. It is not necessary for there to be a plant
       in every grid cell, just that the objects follow a general grid structure and that there is at


### PR DESCRIPTION
**Describe your changes**
Change during v4 allows for simpler syntax for Windows users, now command is the same? 

**Type of update**
Is this a:
* Bug fix
* Update to documentation

**Associated issues**
- closes #1514 
- 
**Additional context**
Add any other context about the problem here.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
