### PR TITLE
Add dual obj size filter

### DIFF
--- a/plantcv/plantcv/filters/__init__.py
+++ b/plantcv/plantcv/filters/__init__.py
@@ -1,4 +1,4 @@
 from plantcv.plantcv.filters.eccentricity import eccentricity
-from plantcv.plantcv.filters.area import area
+from plantcv.plantcv.filters.area import obj_area
 
-__all__ = ["eccentricity", "area"]
+__all__ = ["eccentricity", "obj_area"]

--- a/plantcv/plantcv/filters/__init__.py
+++ b/plantcv/plantcv/filters/__init__.py
@@ -1,3 +1,4 @@
 from plantcv.plantcv.filters.eccentricity import eccentricity
+from plantcv.plantcv.filters.area import area
 
-__all__ = ["eccentricity"]
+__all__ = ["eccentricity", "area"]

--- a/plantcv/plantcv/filters/area
+++ b/plantcv/plantcv/filters/area
@@ -1,0 +1,46 @@
+# Filter regions based on object area
+import os
+import numpy as np
+from skimage.measure import label, regionprops
+from plantcv.plantcv import params
+from plantcv.plantcv._debug import _debug
+
+
+def area(bin_img, upper_thresh, lower_thresh=0):
+    """Detect/filter regions in a binary image based on object area.
+
+    Inputs:
+    bin_img         = Binary image containing the connected regions to consider
+    upper_thresh    = Upper threshold size, above which an object is removed from the bin_img
+    lower_thresh    = (Optional) Lower threshold size, below which an object is removed (default = 0)
+
+
+    Returns:
+    filtered_mask  = Binary image that contains only the filtered regions
+
+    :param bin_img: numpy.ndarray
+    :param upper_thresh: float
+    :param lower_thresh: float
+    :return filtered_mask: numpy.ndarray
+    """
+    params.device += 1
+    # label connected regions
+    labeled_img = label(bin_img)
+    # measure region properties
+    obj_measures = regionprops(labeled_img)
+    # blank masks to draw discs onto
+    large = np.zeros(labeled_img.shape, dtype=np.uint8)
+    medium_large = np.zeros(labeled_img.shape, dtype=np.uint8)
+    # Store the list of coordinates (row,col) for the objects that pass
+    for obj in obj_measures:
+        if obj.area > upper_thresh:
+            # Where region area is too large, draw the region 
+            large += np.where(labeled_img == obj.label, 255, 0).astype(np.uint8)
+        if obj.area > lower_thresh:
+            # Where region area is large enough to keep, draw the region 
+            medium_large += np.where(labeled_img == obj.label, 255, 0).astype(np.uint8)
+    # Keep middle sized objects
+    keep = medium_large - large
+    _debug(visual=keep, filename=os.path.join(params.debug_outdir, f"{params.device}_filters_area.png"))
+
+    return keep

--- a/plantcv/plantcv/filters/area.py
+++ b/plantcv/plantcv/filters/area.py
@@ -6,7 +6,7 @@ from plantcv.plantcv import params
 from plantcv.plantcv._debug import _debug
 
 
-def area(bin_img, upper_thresh, lower_thresh=0):
+def obj_area(bin_img, upper_thresh, lower_thresh=0):
     """Detect/filter regions in a binary image based on object area.
 
     Inputs:


### PR DESCRIPTION
**Describe your changes**
A clear and concise description of what changes are made by this pull request.
What was the previous functionality (if relevant) and what can we do now with
these changes.

**Type of update**
Is this a:
* New feature or feature enhancement
* Work in progress

**Associated issues**
#1508 

**Additional context**
Fills in objects larger than the `upper_thresh` and optional lower threshold will work pretty much identically to `pcv.fill`. 

```
# Example 
import plantcv from plantcv as pcv 

img, _ , _ = pcv.readimage(filename="../../GitHub/plantcv/tests/testdata/floodfill.png")
vis = pcv.visualize.obj_sizes(img=img, mask=img)
filtered_mask = pcv.filters.obj_area(bin_img=img, upper_thresh=2000, lower_thresh=1400)
```

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
