### PR TITLE
Prune test and doc files from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,4 @@
 include LICENSE
+prune tests
+prune docs
+prune vice


### PR DESCRIPTION
**Describe your changes**
Prunes the tests, docs, and vice folders from the PyPI source distribution package (sdist) to decrease the size of the source package to below the 100MB limit on PyPI.

**Type of update**
Is this a: Bug fix

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
