### PR TITLE
Pin NumPy to v1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = {file = "LICENSE"}
 dynamic = ["version"]
 dependencies = [
     "matplotlib >= 1.5",
-    "numpy >= 1.11",
+    "numpy >= 1.11, < 2",
     "pandas",
     "python-dateutil",
     "scipy",


### PR DESCRIPTION
**Describe your changes**
Limits maximum NumPy version to exclude v2 for now to avoid breaking changes.

**Type of update**
Is this a: Bug fix

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
