### PR TITLE
Fix casting issues that trigger NumPy deprecation warnings

### DIFF
--- a/plantcv/plantcv/homology/constella.py
+++ b/plantcv/plantcv/homology/constella.py
@@ -5,7 +5,7 @@ from scipy.cluster.hierarchy import cut_tree
 from plantcv.plantcv import params
 
 
-def get_empty_count(cur_index_id):
+def _get_empty_count(cur_index_id):
     """Helper function for getting empty count"""
     empty_count = 0
     for i in cur_index_id:
@@ -14,7 +14,7 @@ def get_empty_count(cur_index_id):
     return empty_count
 
 
-def get_empty_indicies(cur_index, cur_plms_copy):
+def _get_empty_indicies(cur_index, cur_plms_copy):
     """Helper function for getting empty indicies"""
     empty_index = []
     for i, v in zip(cur_index, cur_plms_copy.iloc[cur_index, 0].values):
@@ -23,7 +23,7 @@ def get_empty_indicies(cur_index, cur_plms_copy):
     return empty_index
 
 
-def get_unique_ids(cur_index_id):
+def _get_unique_ids(cur_index_id):
     """Helper function for getting id's"""
     unique_ids = []
     for id_ in cur_index_id:
@@ -32,7 +32,7 @@ def get_unique_ids(cur_index_id):
     return unique_ids
 
 
-def get_rogues(cur_plms_copy):
+def _get_rogues(cur_plms_copy):
     """Helper function for getting rogues"""
     rogues = []
     for i, x in enumerate(cur_plms_copy['group'].values):
@@ -41,7 +41,7 @@ def get_rogues(cur_plms_copy):
     return rogues
 
 
-def generate_labelnames(plmnames, grpnames):
+def _generate_labelnames(plmnames, grpnames):
     """Helper function for generating label names"""
     labelnames = []
     for li in range(0, len(plmnames)):
@@ -50,7 +50,7 @@ def generate_labelnames(plmnames, grpnames):
     return labelnames
 
 
-def pair_unnassigned(unique_ids, cur_index, cur_index_id, cur_plms_copy, empty_count, sanity_check_pos):
+def _pair_unnassigned(unique_ids, cur_index, cur_index_id, cur_plms_copy, empty_count, sanity_check_pos):
     """Helper function for pairing unassigned"""
     for uid in unique_ids:
         # If only one plm assigned a name in current cluster and a second unnamed plm exists
@@ -115,10 +115,10 @@ def constella(cur_plms, pc_starscape, group_iter, outfile_prefix):
             # Create list of current clusters present group identity assignments
             cur_index_id = np.array(cur_plms_copy.iloc[cur_index, 0])
             # Are any of the plms in the current cluster unnamed, how many?
-            empty_count = get_empty_count(cur_index_id)
-            empty_index = get_empty_indicies(cur_index, cur_plms_copy)
+            empty_count = _get_empty_count(cur_index_id)
+            empty_index = _get_empty_indicies(cur_index, cur_plms_copy)
             # Are any of the plms in the current cluster already assigned an identity, what are those identities?
-            unique_ids = get_unique_ids(cur_index_id)
+            unique_ids = _get_unique_ids(cur_index_id)
             # If cluster is two unnamed plms exactly, assign this group their own identity as a pair
             if empty_count == 2:
                 pair_names = cur_plms_copy.iloc[empty_index, 1].values
@@ -131,8 +131,8 @@ def constella(cur_plms, pc_starscape, group_iter, outfile_prefix):
                     cur_plms_copy.iloc[empty_index[1], 0] = group_iter + 1
                     group_iter = group_iter + 2
             # If cluster is one unnamed plm and one plm with an identity, assign the unnamed plm the identity of the
-            pair_unnassigned(unique_ids, cur_index, cur_index_id, cur_plms_copy, empty_count, sanity_check_pos)
-    rogues = get_rogues(cur_plms_copy)
+            _pair_unnassigned(unique_ids, cur_index, cur_index_id, cur_plms_copy, empty_count, sanity_check_pos)
+    rogues = _get_rogues(cur_plms_copy)
     for rogue in rogues:
         cur_plms_copy.iloc[[rogue], 0] = group_iter
         group_iter = group_iter + 1
@@ -140,7 +140,7 @@ def constella(cur_plms, pc_starscape, group_iter, outfile_prefix):
     grpnames = cur_plms_copy.loc[:, ['group']].values
     plmnames = cur_plms_copy.loc[:, ['plmname']].values
 
-    labelnames = generate_labelnames(plmnames, grpnames)
+    labelnames = _generate_labelnames(plmnames, grpnames)
 
     if params.debug is not None:
         plt.figure()

--- a/plantcv/plantcv/homology/constella.py
+++ b/plantcv/plantcv/homology/constella.py
@@ -45,7 +45,7 @@ def _generate_labelnames(plmnames, grpnames):
     """Helper function for generating label names"""
     labelnames = []
     for li in range(0, len(plmnames)):
-        labelname = f'{plmnames[li]} ({int(grpnames[li])})'
+        labelname = f'{plmnames[li]} ({grpnames[li]})'
         labelnames.append(labelname)
     return labelnames
 

--- a/plantcv/plantcv/homology/space.py
+++ b/plantcv/plantcv/homology/space.py
@@ -22,11 +22,11 @@ def space(cur_plms, include_bound_dist=False, include_centroid_dist=False, inclu
     :return new_plms: pandas.core.frame.DataFrame
     """
     new_plms = cur_plms.copy(deep=True)
-    bot_left = [int(min(new_plms.loc[:, ['plm_x']].values)), int(max(new_plms.loc[:, ['plm_y']].values))]
-    bot_right = [int(max(new_plms.loc[:, ['plm_x']].values)), int(max(new_plms.loc[:, ['plm_y']].values))]
-    top_left = [int(min(new_plms.loc[:, ['plm_x']].values)), int(min(new_plms.loc[:, ['plm_y']].values))]
-    top_right = [int(max(new_plms.loc[:, ['plm_x']].values)), int(min(new_plms.loc[:, ['plm_y']].values))]
-    centroid = [int(np.mean(new_plms.loc[:, ['plm_x']].values)), int(np.mean(new_plms.loc[:, ['plm_y']].values))]
+    bot_left = [int(min(new_plms.loc[:, ['plm_x']].values).item()), int(max(new_plms.loc[:, ['plm_y']].values).item())]
+    bot_right = [int(max(new_plms.loc[:, ['plm_x']].values).item()), int(max(new_plms.loc[:, ['plm_y']].values).item())]
+    top_left = [int(min(new_plms.loc[:, ['plm_x']].values).item()), int(min(new_plms.loc[:, ['plm_y']].values).item())]
+    top_right = [int(max(new_plms.loc[:, ['plm_x']].values).item()), int(min(new_plms.loc[:, ['plm_y']].values).item())]
+    centroid = [int(np.mean(new_plms.loc[:, ['plm_x']].values).item()), int(np.mean(new_plms.loc[:, ['plm_y']].values).item())]
 
     bot_left_dist = np.sqrt(np.square(new_plms.loc[:, ['plm_x']].values - bot_left[0]) + np.square(
         new_plms.loc[:, ['plm_y']].values - bot_left[1]))
@@ -70,7 +70,7 @@ def space(cur_plms, include_bound_dist=False, include_centroid_dist=False, inclu
             a = 90 - (np.arctan(rise[m] / run[m]) * (180 / np.pi))
         elif run[m] < 0:
             a = -(90 - (np.arctan(rise[m] / run[m]) * (180 / np.pi)))
-        orientation.append(float(a))
+        orientation.append(float(np.array(a).item()))
 
         # Use the sign of the run to determine if the weight should
         # shift in the 0-180 or 180-360 range for 360 arc conversion
@@ -79,7 +79,7 @@ def space(cur_plms, include_bound_dist=False, include_centroid_dist=False, inclu
             centroid_a = 90 - (np.arctan(centroid_rise[m] / centroid_run[m]) * (180 / np.pi))
         elif centroid_run[m] < 0:
             centroid_a = -(90 - (np.arctan(centroid_rise[m] / centroid_run[m]) * (180 / np.pi)))
-        centroid_orientation.append(float(centroid_a))
+        centroid_orientation.append(float(np.array(centroid_a).item()))
 
     if include_orient_angles is True:
         new_plms.insert(len(new_plms.columns), 'orientation', orientation, True)

--- a/plantcv/plantcv/morphology/analyze_stem.py
+++ b/plantcv/plantcv/morphology/analyze_stem.py
@@ -46,7 +46,7 @@ def analyze_stem(rgb_img, stem_objects, label=None):
                             value=height, label=None)
     outputs.add_observation(sample=label, variable='stem_angle', trait='angle of combined stem object',
                             method='plantcv.plantcv.morphology.analyze_stem', scale='degrees', datatype=float,
-                            value=float(slope), label=None)
+                            value=float(slope.item()), label=None)
     outputs.add_observation(sample=label, variable='stem_length', trait='path length of combined stem object',
                             method='plantcv.plantcv.morphology.analyze_stem', scale='None', datatype=float,
                             value=stem_length, label=None)
@@ -56,8 +56,8 @@ def analyze_stem(rgb_img, stem_objects, label=None):
     # Draw combined stem angle
     x_min = 0  # Set bounds for regression lines to get drawn
     x_max = img_x
-    intercept1 = int(((x - x_min) * slope) + y)
-    intercept2 = int(((x - x_max) * slope) + y)
+    intercept1 = int(np.array(((x - x_min) * slope) + y).item())
+    intercept2 = int(np.array(((x - x_max) * slope) + y).item())
     if slope > 1000000 or slope < -1000000:
         print("Slope  is ", slope, " and cannot be plotted.")
     else:

--- a/plantcv/plantcv/morphology/segment_angle.py
+++ b/plantcv/plantcv/morphology/segment_angle.py
@@ -50,8 +50,8 @@ def segment_angle(segmented_img, objects, label=None):
         # Find line fit to each segment
         [vx, vy, x, y] = cv2.fitLine(objects[i], cv2.DIST_L2, 0, 0.01, 0.01)
         slope = -vy / vx
-        left_list = int(((x - x_min) * slope) + y)
-        right_list = int(((x - x_max) * slope) + y)
+        left_list = int(np.array(((x - x_min) * slope) + y).item())
+        right_list = int(np.array(((x - x_max) * slope) + y).item())
 
         if slope > 1000000 or slope < -1000000:
             print("Slope of contour with ID#", i, "is", slope, "and cannot be plotted.")

--- a/plantcv/plantcv/morphology/segment_insertion_angle.py
+++ b/plantcv/plantcv/morphology/segment_insertion_angle.py
@@ -134,16 +134,16 @@ def segment_insertion_angle(skel_img, segmented_img, leaf_objects, stem_objects,
     [vx, vy, x, y] = cv2.fitLine(combined_stem[0], cv2.DIST_L2, 0, 0.01, 0.01)
     stem_slope = -vy / vx
     stem_slope = stem_slope[0]
-    lefty = int((-x * vy / vx) + y)
-    righty = int(((cols - x) * vy / vx) + y)
+    lefty = int(np.array((-x * vy / vx) + y).item())
+    righty = int(np.array(((cols - x) * vy / vx) + y).item())
     cv2.line(labeled_img, (cols - 1, righty), (0, lefty), (150, 150, 150), 3)
 
     for t, segment in enumerate(insertion_segments):
         # Find line fit to each segment
         [vx, vy, x, y] = cv2.fitLine(segment, cv2.DIST_L2, 0, 0.01, 0.01)
         slope = -vy / vx
-        left_list = int((-x * vy / vx) + y)
-        right_list = int(((cols - x) * vy / vx) + y)
+        left_list = int(np.array((-x * vy / vx) + y).item())
+        right_list = int(np.array(((cols - x) * vy / vx) + y).item())
         segment_slopes.append(slope[0])
 
         # Draw slope lines if possible

--- a/plantcv/plantcv/morphology/segment_tangent_angle.py
+++ b/plantcv/plantcv/morphology/segment_tangent_angle.py
@@ -83,10 +83,10 @@ def segment_tangent_angle(segmented_img, objects, size, label=None):
             x_min = int(df['x'].min())
 
             # Find line fit to each segment
-            [vx, vy, x, y] = cv2.fitLine(obj, cv2.DIST_L2, 0, 0.01, 0.01)
+            vx, vy, x, y = cv2.fitLine(obj, cv2.DIST_L2, 0, 0.01, 0.01)
             slope = -vy / vx
-            left_list = int(((x - x_min) * slope) + y)
-            right_list = int(((x - x_max) * slope) + y)
+            left_list = int(np.array(((x - x_min) * slope) + y).item())
+            right_list = int(np.array(((x - x_max) * slope) + y).item())
             slopes.append(slope)
 
             if slope > 1000000 or slope < -1000000:


### PR DESCRIPTION
**Describe your changes**
In NumPy 1.25, casting single value arrays to Python data types is deprecated. In general this PR extracts the single value before casting to fix the issue (or avoids casting when unnecessary).

**Type of update**
Is this a: cleanup

**Associated issues**
#1566

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
