### PR TITLE
Turn plotting off after use in tests to avoid warnings

### DIFF
--- a/tests/plantcv/filters/test_filter_objs.py
+++ b/tests/plantcv/filters/test_filter_objs.py
@@ -1,17 +1,18 @@
 import cv2
 import pytest
-import plantcv.plantcv as pcv
+from plantcv.plantcv import params
 from plantcv.plantcv.filters import obj_props
 from plantcv.plantcv import create_labels
 
 
 def test_filter_objs_upper_na(filters_test_data):
     """Test for PlantCV."""
-    pcv.params.debug = "plot"
+    params.debug = "plot"
     # Read in test data
     mask = cv2.imread(filters_test_data.barley_example)
     filtered_mask = obj_props(bin_img=mask)
     _, nobjs = create_labels(mask=filtered_mask)
+    params.debug = None
     assert nobjs == 20
 
 

--- a/tests/plantcv/homology/test_acute.py
+++ b/tests/plantcv/homology/test_acute.py
@@ -13,6 +13,7 @@ def test_acute(win, exp, homology_test_data):
     img = cv2.imread(homology_test_data.small_rgb_img)
     mask = cv2.imread(homology_test_data.small_bin_img, -1)
     homology_pts, _, _, _, _, _ = acute(img=img, mask=mask, win=win, threshold=15)
+    params.debug = None
     assert len(homology_pts) == exp
 
 
@@ -28,6 +29,7 @@ def test_acute_small_contours(obj, win, thresh, exp, homology_test_data):
     mask = np.zeros(img.shape[:2], dtype=np.uint8)
     cv2.drawContours(mask, [obj], -1, 255, -1)
     homology_pts, _, _, _, _, _ = acute(img=img, mask=mask, win=win, threshold=thresh)
+    params.debug = None
     assert len(homology_pts) == exp
 
 

--- a/tests/plantcv/test_debug.py
+++ b/tests/plantcv/test_debug.py
@@ -5,7 +5,7 @@ from plantcv.plantcv import params
 from plantcv.plantcv._debug import _debug
 
 
-@pytest.mark.parametrize("debug", ["print", "plot"])
+@pytest.mark.parametrize("debug", ["print", "plot", None])
 def test_debug(debug, test_data, tmpdir):
     """Test for PlantCV."""
     # Create a test tmp directory


### PR DESCRIPTION
**Describe your changes**
During tests, many warnings are due to matplotlib being unable to open a display. To reduce the number of warnings, only tests that need to test plotting should have the plot debug mode turned on. Because it is a global parameter, turning it on leaves it on for other tests. This PR turns it off after plot is turned on for specific tests.

**Type of update**
Is this a: cleanup

**Associated issues**
#1566

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
