### PR TITLE
Add geospatial attributes to spectral_data class

### DIFF
--- a/docs/Spectral_data.md
+++ b/docs/Spectral_data.md
@@ -38,6 +38,10 @@ Attributes are accessed as spectral_data_instance.*attribute*.
 
 **filename**: The filename where the data originated from
 
+**geo_transform**: The affine transformation matrix used to convert from an xy coordinate system to a georeferenced coordinate system. Default is the input list used by the affine package to create an identity matrix.
+
+**geo_crs**: The original coordinate system of a georeferenced image. Default is "None".
+
 ### Example
 
 PlantCV functions from the hyperspectral sub-package use `Spectral_data` implicitly.

--- a/environment.yml
+++ b/environment.yml
@@ -25,6 +25,7 @@ dependencies:
   - altair
   - vl-convert-python
   - git
+  - affine
 
 channels:
   - conda-forge

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,6 @@ dependencies:
   - altair
   - vl-convert-python
   - git
-  - affine
 
 channels:
   - conda-forge

--- a/plantcv/plantcv/classes.py
+++ b/plantcv/plantcv/classes.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 from math import floor
 import altair as alt
 import pandas as pd
+import affine.Affine as Affine
 
 
 class Params:
@@ -299,7 +300,7 @@ class Spectral_data:
 
     def __init__(self, array_data, max_wavelength, min_wavelength, max_value, min_value, d_type, wavelength_dict,
                  samples, lines, interleave, wavelength_units, array_type, pseudo_rgb, filename, default_bands,
-                 geo_transform):
+                 geo_transform=None, geo_crs=None):
         # The actual array/datacube
         self.array_data = array_data
         # Min/max available wavelengths (for spectral datacube)
@@ -327,7 +328,10 @@ class Spectral_data:
         # The default band indices needed to make an pseudo_rgb image, if not available then store None
         self.default_bands = default_bands
         # The transformation matrix that converts xy coordinates to georeferenced coordinates
-        self.geo_transform = geo_transform
+        if not geo_transform:
+            self.geo_transform = Affine.identity()
+        # The coordinate system of a georeferenced image
+        self.geo_crs = geo_crs
 
 
 class PSII_data:

--- a/plantcv/plantcv/classes.py
+++ b/plantcv/plantcv/classes.py
@@ -328,6 +328,7 @@ class Spectral_data:
         self.default_bands = default_bands
         # The transformation matrix that converts xy coordinates to georeferenced coordinates
         # Default is the input list for affine.Affine to make an identity matrix
+        self.geo_transform = geo_transform
         if not geo_transform:
             self.geo_transform = (1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
         # The coordinate system of a georeferenced image

--- a/plantcv/plantcv/classes.py
+++ b/plantcv/plantcv/classes.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 from math import floor
 import altair as alt
 import pandas as pd
-import affine.Affine as Affine
+import affine
 
 
 class Params:
@@ -329,7 +329,7 @@ class Spectral_data:
         self.default_bands = default_bands
         # The transformation matrix that converts xy coordinates to georeferenced coordinates
         if not geo_transform:
-            self.geo_transform = Affine.identity()
+            self.geo_transform = affine.Affine.identity()
         # The coordinate system of a georeferenced image
         self.geo_crs = geo_crs
 

--- a/plantcv/plantcv/classes.py
+++ b/plantcv/plantcv/classes.py
@@ -327,7 +327,7 @@ class Spectral_data:
         # The default band indices needed to make an pseudo_rgb image, if not available then store None
         self.default_bands = default_bands
         # The transformation matrix that converts xy coordinates to georeferenced coordinates
-        self.transform = geo_transform
+        self.geo_transform = geo_transform
 
 
 class PSII_data:

--- a/plantcv/plantcv/classes.py
+++ b/plantcv/plantcv/classes.py
@@ -298,7 +298,8 @@ class Spectral_data:
     """PlantCV Hyperspectral data class"""
 
     def __init__(self, array_data, max_wavelength, min_wavelength, max_value, min_value, d_type, wavelength_dict,
-                 samples, lines, interleave, wavelength_units, array_type, pseudo_rgb, filename, default_bands):
+                 samples, lines, interleave, wavelength_units, array_type, pseudo_rgb, filename, default_bands,
+                 geo_transform):
         # The actual array/datacube
         self.array_data = array_data
         # Min/max available wavelengths (for spectral datacube)
@@ -325,6 +326,8 @@ class Spectral_data:
         self.filename = filename
         # The default band indices needed to make an pseudo_rgb image, if not available then store None
         self.default_bands = default_bands
+        # The transformation matrix that converts xy coordinates to georeferenced coordinates
+        self.transform = geo_transform
 
 
 class PSII_data:

--- a/plantcv/plantcv/classes.py
+++ b/plantcv/plantcv/classes.py
@@ -9,7 +9,6 @@ import matplotlib.pyplot as plt
 from math import floor
 import altair as alt
 import pandas as pd
-import affine
 
 
 class Params:
@@ -328,8 +327,9 @@ class Spectral_data:
         # The default band indices needed to make an pseudo_rgb image, if not available then store None
         self.default_bands = default_bands
         # The transformation matrix that converts xy coordinates to georeferenced coordinates
+        # Default is the input list for affine.Affine to make an identity matrix
         if not geo_transform:
-            self.geo_transform = affine.Affine.identity()
+            self.geo_transform = (1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
         # The coordinate system of a georeferenced image
         self.geo_crs = geo_crs
 


### PR DESCRIPTION
**Describe your changes**
Some functions in the add-on packaged plantcv-geospatial benefit from having additional metadata stored as attributes of spectral_data objects. This PR adds geo_transform and geo_crs, the affine transformation matrix to convert from geo referenced coordinates to raster coordinates and the coordinate system respectively. Because they are both added with appropriate defaults (the identity matrix and "None"), this change should not affect any core plantcv functions. 

**Type of update**
* New feature or feature enhancement (kind of)

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
