### PR TITLE
Speed improvements for creating multiple ROIs

### DIFF
--- a/plantcv/plantcv/roi/roi_methods.py
+++ b/plantcv/plantcv/roi/roi_methods.py
@@ -360,7 +360,7 @@ def _rois_from_coordinates(img, coord=None, radius=None):
     # Get the height and width of the reference image
     height, width = np.shape(img)[:2]
     radius = _adjust_radius_coord(height, width, coord, radius)
-    overlap_img = np.zeros((height, width))
+    overlap_img = np.zeros((height, width), dtype=np.uint8)
     roi_objects = Objects()
     for i in range(0, len(coord)):
         # Initialize a binary image for each circle
@@ -370,7 +370,7 @@ def _rois_from_coordinates(img, coord=None, radius=None):
         # Draw the circle on the binary image
         # Keep track of each roi individually to check overlapping
         circle_img = cv2.circle(bin_img, (x, y), radius, 255, -1)
-        overlap_img = overlap_img + circle_img
+        overlap_img = cv2.circle(overlap_img, (x, y), radius, 255, -1)
         # Make a list of contours and hierarchies
         rc, rh = cv2.findContours(circle_img, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)[-2:]
         roi_objects.append(rc, rh)


### PR DESCRIPTION
**Describe your changes**
Creating multiple ROIs in the context of 10s of ROIs has not been an issue, but creating 100s of ROIs is slow. This PR aims to make adjustments to ROI functions to improve performance.

**Type of update**
Is this a: New feature or feature enhancement

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
