### PR TITLE
Add metadata attribute to spectral_data class

### DIFF
--- a/docs/Spectral_data.md
+++ b/docs/Spectral_data.md
@@ -38,11 +38,7 @@ Attributes are accessed as spectral_data_instance.*attribute*.
 
 **filename**: The filename where the data originated from
 
-**geo_transform**: The affine transformation matrix used to convert from an xy coordinate system to a georeferenced coordinate system. Default is the input list used by the affine package to create an identity matrix.
-
-**geo_crs**: The original coordinate system of a georeferenced image. Default is "None".
-
-**geo_res**: The resolution of a geospatial image. Default is "None".
+**metadata**: Metadata in a dictionary. Included keys might be specific to hyperspectral or geospatial image types 
 
 ### Example
 

--- a/docs/Spectral_data.md
+++ b/docs/Spectral_data.md
@@ -42,6 +42,8 @@ Attributes are accessed as spectral_data_instance.*attribute*.
 
 **geo_crs**: The original coordinate system of a georeferenced image. Default is "None".
 
+**geo_res**: The resolution of a geospatial image. Default is "None".
+
 ### Example
 
 PlantCV functions from the hyperspectral sub-package use `Spectral_data` implicitly.

--- a/plantcv/plantcv/classes.py
+++ b/plantcv/plantcv/classes.py
@@ -299,7 +299,7 @@ class Spectral_data:
 
     def __init__(self, array_data, max_wavelength, min_wavelength, max_value, min_value, d_type, wavelength_dict,
                  samples, lines, interleave, wavelength_units, array_type, pseudo_rgb, filename, default_bands,
-                 geo_transform=None, geo_crs=None, geo_res=None):
+                 metadata=None):
         # The actual array/datacube
         self.array_data = array_data
         # Min/max available wavelengths (for spectral datacube)
@@ -326,15 +326,10 @@ class Spectral_data:
         self.filename = filename
         # The default band indices needed to make an pseudo_rgb image, if not available then store None
         self.default_bands = default_bands
-        # The transformation matrix that converts xy coordinates to georeferenced coordinates
-        # Default is the input list for affine.Affine to make an identity matrix
-        self.geo_transform = geo_transform
-        if not geo_transform:
-            self.geo_transform = (1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
-        # The coordinate system of a georeferenced image
-        self.geo_crs = geo_crs
-        # The resolution of a geospatial image
-        self.geo_res = geo_res
+        # Metadata, flexible components in a dictionary
+        self.metadata = metadata
+        if not metadata:
+            self.metadata = {}
 
 
 class PSII_data:

--- a/plantcv/plantcv/classes.py
+++ b/plantcv/plantcv/classes.py
@@ -299,7 +299,7 @@ class Spectral_data:
 
     def __init__(self, array_data, max_wavelength, min_wavelength, max_value, min_value, d_type, wavelength_dict,
                  samples, lines, interleave, wavelength_units, array_type, pseudo_rgb, filename, default_bands,
-                 geo_transform=None, geo_crs=None):
+                 geo_transform=None, geo_crs=None, geo_res=None):
         # The actual array/datacube
         self.array_data = array_data
         # Min/max available wavelengths (for spectral datacube)
@@ -333,6 +333,8 @@ class Spectral_data:
             self.geo_transform = (1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
         # The coordinate system of a georeferenced image
         self.geo_crs = geo_crs
+        # The resolution of a geospatial image
+        self.geo_res = geo_res
 
 
 class PSII_data:


### PR DESCRIPTION
**Describe your changes**
Previously, we had added some additional attributes to the `spectral_data` class to accommodate some of the metadata associated with geospatial data. This PR now replaces those individual metadata terms with an attribute called "metadata". The default is an empty dictionary, but it can be populated with any number of keys specific to various data types, like hyperspectral and geospatial.    

**Type of update**
Is this a:
* New feature or feature enhancement


**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
