### PR TITLE
Obj size ecdf docs bugfix

### DIFF
--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1334,6 +1334,12 @@ pages for more details on the input and output variable types.
 
 * pre v3.13: NA
 * post v3.13: fig_ecdf = **plantcv.visualize.obj_size_ecdf**(*mask, title=None*)
+* post v4.0: fig_ecdf = **plantcv.visualize.obj_size_ecdf**(*mask*)
+
+#### plantcv.visualize.obj_sizes
+
+* pre v3.13: NA
+* post v3.13: plotting_img = **pcv.visualize.obj_sizes**(*img, mask, num_objects=100*)
 
 #### plantcv.visualize.pseudocolor
 
@@ -1342,11 +1348,6 @@ pages for more details on the input and output variable types.
 * post v3.3: pseudo_img = **plantcv.visualize.pseudocolor**(*gray_img, obj=None, mask=None, cmap=None, background="image", min_value=0, max_value=255, axes=True, colorbar=True*)
 * post v3.12: pseudo_img = **plantcv.visualize.pseudocolor**(*gray_img, obj=None, mask=None, cmap=None, background="image", min_value=0, max_value=255, axes=True, colorbar=True, obj_padding="auto", title=None*)
 * post v4.0: pseudo_img = **plantcv.visualize.pseudocolor**(*gray_img, mask=None, cmap=None, background="image", min_value=0, max_value=255, axes=True, colorbar=True, title=None*)
-
-#### plantcv.visualize.obj_sizes
-
-* pre v3.13: NA
-* post v3.13: plotting_img = **pcv.visualize.obj_sizes**(*img, mask, num_objects=100*)
 
 #### plantcv.visualize.pixel_scatter_plot
 

--- a/docs/visualize_obj_size_ecdf.md
+++ b/docs/visualize_obj_size_ecdf.md
@@ -3,12 +3,11 @@
 This is a visualization method used to examine the distribution of object sizes. It is an alternative to histogram 
 visualization.
 
-**plantcv.visualize.ecdf.obj_size**(*mask, title=None*)
+**plantcv.visualize.obj_size_ecdf**(*mask*)
 **returns** fig_ecdf
 
 - **Parameters:**
     - mask - Binary mask made from selected contours (default mask=None).
-    - title - The title for the ecdf plot (default title=None) 
     
 **Context:**
 - Examine the cumulative distribution of object sizes found in a binary mask. This can be used as an alternative 
@@ -26,7 +25,7 @@ visualization.
 ```python
 from plantcv import plantcv as pcv
 pcv.params.debug = "plot"
-fig_ecdf = pcv.visualize.ecdf.obj_size(mask=mask)
+fig_ecdf = pcv.visualize.obj_size_ecdf(mask=mask)
 ```
 
 **Cumulative distribution of object sizes**


### PR DESCRIPTION
**Describe your changes**
Update docs to reflect the latest syntax of `pcv.visualize.obj_size_ecdf` 

**Type of update**
Is this a:
* Update to documentation

**Associated issues**
- closes #1620 

**Additional context**
- thank you to @hkmanching for bringing this issue to our attention 

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
