### PR TITLE
update read_data to transform uint8 data

### DIFF
--- a/plantcv/plantcv/hyperspectral/read_data.py
+++ b/plantcv/plantcv/hyperspectral/read_data.py
@@ -319,6 +319,10 @@ def read_data(filename, mode="ENVI"):
     # Make pseudo-rgb image and replace it inside the class instance object
     pseudo_rgb = _make_pseudo_rgb(spectral_array)
     spectral_array.pseudo_rgb = pseudo_rgb
+    spectral_array.array_data = spectral_array.array_data.astype("float32")  # required for further calculations
+    if spectral_array.d_type == np.uint8:  # only convert if data seems to be uint8
+        spectral_array.array_data = spectral_array.array_data / 255  # convert 0-255 (orig.) to 0-1 range
+        spectral_array.d_type = np.float32
 
     _debug(visual=pseudo_rgb, filename=os.path.join(params.debug_outdir, str(params.device) + "_pseudo_rgb.png"))
 


### PR DESCRIPTION
**Describe your changes**
Transform `uint8` type Hyperspectral images, like those coming from the Rayn camera system, and make them compatiable with hyperspectral functionality downstream. 

**Type of update**
Is this a:
* Bug fix
* feature enhancement
* Work in progress

**Associated issues**
- #1599
- 
**Additional context**
Add any other context about the problem here.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
