### PR TITLE
Json2csv update: handle lists of coordinates

### DIFF
--- a/plantcv/plantcv/morphology/segment_id.py
+++ b/plantcv/plantcv/morphology/segment_id.py
@@ -7,7 +7,7 @@ from plantcv.plantcv import params
 from plantcv.plantcv._debug import _debug
 
 
-def segment_id(skel_img, objects, mask=None):
+def segment_id(skel_img, objects, mask=None, optimal_assignment=None):
     """Plot segment IDs.
 
     Inputs:
@@ -38,9 +38,14 @@ def segment_id(skel_img, objects, mask=None):
     # Create a color scale, use a previously stored scale if available
     rand_color = color_palette(num=len(objects), saved=True)
 
+    
     # Plot all segment contours
     for i, cnt in enumerate(objects):
-        cv2.drawContours(segmented_img, cnt, -1, rand_color[i], params.line_thickness, lineType=8)
+        if optimal_assignment is not None:
+            color_index = optimal_assignment[i]
+        else: 
+            color_index = i
+        cv2.drawContours(segmented_img, cnt, -1, rand_color[color_index], params.line_thickness, lineType=8)
         # Store coordinates for labels
         label_coord_x.append(objects[i][0][0][0])
         label_coord_y.append(objects[i][0][0][1])
@@ -48,12 +53,20 @@ def segment_id(skel_img, objects, mask=None):
     labeled_img = segmented_img.copy()
 
     for i, cnt in enumerate(objects):
-        # Label slope lines
+        if optimal_assignment is not None:
+            # relabel IDs
+            text = f"{optimal_assignment[i]}"
+            color_index = optimal_assignment[i]
+
+        else:
+            text = f"{i}"
+            color_index = i
+        # Label segments
         w = label_coord_x[i]
         h = label_coord_y[i]
-        text = f"ID:{i}"
+        
         cv2.putText(img=labeled_img, text=text, org=(w, h), fontFace=cv2.FONT_HERSHEY_SIMPLEX,
-                    fontScale=params.text_size, color=rand_color[i], thickness=params.text_thickness)
+                    fontScale=params.text_size, color=rand_color[color_index], thickness=params.text_thickness)
 
     _debug(visual=labeled_img, filename=os.path.join(params.debug_outdir, f"{params.device}_segmented_ids.png"))
 

--- a/plantcv/utils/converters.py
+++ b/plantcv/utils/converters.py
@@ -67,7 +67,9 @@ def json2csv(json_file, csv_prefix):
             for sample, var in itertools.product(entity["observations"].keys(), multi_vars):
                 data_rows = _create_data_rows(var=var, obs=entity["observations"][sample])
                 for row in data_rows:
-                    csv.write(",".join(map(str, meta_row + [sample] + row)) + "\n")
+                    coord_f = str(row[1]).replace(",", " ")
+                    row_formatted = [str(row[0]), str(coord_f), str(row[2])]
+                    csv.write(",".join(map(str, meta_row + [sample] + row_formatted)) + "\n")
 
     # Create a CSV file of scalar traits
     # Initialize a dictionary to store the data


### PR DESCRIPTION
**Describe your changes**
Adjust the `json2csv` utility function to handle lists of coordinates e.g. leaf tip coordinates from the morphology subpackage. 

**Type of update**
Is this a:
* Bug fix (previously `json2csv` would run but would have squished syntax, and this bad syntax would throw an error while reading the resulting csv in with `pandas` as a dataframe)
*  feature enhancement
* Work in progress

**Associated issues**

**Additional context**
Add any other context about the problem here.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
