### PR TITLE
Update d type in fill_holes.py check 

### DIFF
--- a/plantcv/plantcv/fill_holes.py
+++ b/plantcv/plantcv/fill_holes.py
@@ -22,7 +22,7 @@ def fill_holes(bin_img):
     :return filtered_img: numpy.ndarray
     """
     # Make sure the image is binary
-    if len(np.shape(bin_img)) != 2 or len(np.unique(bin_img)) != 2:
+    if len(np.shape(bin_img)) != 2 or len(np.unique(bin_img)) > 2:
         fatal_error("Image is not binary")
 
     # Cast binary image to boolean


### PR DESCRIPTION
Changing data type check for catching grayscale and rgb while still allowing a pure black/white mask

**Describe your changes**
A clear and concise description of what changes are made by this pull request.
What was the previous functionality (if relevant) and what can we do now with
these changes.

**Type of update**
Bug fix

**Associated issues**
#1635 

**Additional context**
N/A

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
