### PR TITLE
Use opencv headless

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - scikit-learn
   - dask
   - dask-jobqueue
-  - opencv
+  - opencv-python-headless
   - statsmodels
   - xarray>=2022.11.0
   - mkdocs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "scikit-learn",
     "dask",
     "dask-jobqueue",
-    "opencv-python",
+    "opencv-python-headless",
     "xarray >= 2022.11.0",
     "statsmodels",
     "altair",


### PR DESCRIPTION
**Describe your changes**
Alter PlantCV dependencies from PyPI and Conda-Forge to use the OpenCV headless package instead of the full version since we do not use OpenCV GUI features.

**Type of update**
Is this a: improvement for efficiency 

**Associated issues**
#1515

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
