### PR TITLE
adding nd2 as a image read mode

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - statsmodels
   - xarray>=2022.11.0
   - mkdocs
+  - nd2
   - pytest
   - pytest-cov
   - flake8

--- a/plantcv/plantcv/readimage.py
+++ b/plantcv/plantcv/readimage.py
@@ -4,6 +4,7 @@ import os
 import cv2
 import numpy as np
 import pandas as pd
+import nd2
 from plantcv.plantcv import fatal_error
 from plantcv.plantcv import params
 from plantcv.plantcv.hyperspectral import read_data
@@ -15,7 +16,7 @@ def readimage(filename, mode="native"):
 
     Inputs:
     filename = name of image file
-    mode     = mode of imread ("native", "rgb", "rgba", "gray", "csv", "envi", "arcgis")
+    mode     = mode of imread ("native", "rgb", "rgba", "gray", "csv", "envi", "arcgis", "nd2")
 
     Returns:
     img      = image object as numpy array
@@ -40,6 +41,8 @@ def readimage(filename, mode="native"):
     elif mode.upper() in ["ENVI", "ARCGIS"]:
         array_data = read_data(filename, mode=mode)
         return array_data
+    elif mode.upper() == "ND2":
+        img = nd2.imread(filename)
     else:
         img = cv2.imread(filename, -1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "statsmodels",
     "altair",
     "vl-convert-python",
+    "nd2"
 ]
 requires-python = ">=3.8"
 authors = [


### PR DESCRIPTION
**Describe your changes**
Added "nd2" as a `readimage` mode to read in Nikon microscope images. 

**Type of update**
Is this a:
* New feature or feature enhancement

**Associated issues**
#1684

**Additional context**
Add any other context about the problem here.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
