### PR TITLE
Create helpers for color conversion

### DIFF
--- a/plantcv/plantcv/_helpers.py
+++ b/plantcv/plantcv/_helpers.py
@@ -457,3 +457,32 @@ def _grayscale_to_rgb(img):
         img = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
 
     return img
+
+
+def _rgb2lab(rgb_img, channel):
+    """Convert image from RGB colorspace to LAB colorspace. Returns the specified subchannel as a gray image.
+
+    Parameters
+    ----------
+    rgb_img : numpy.ndarray
+        RGB image data
+    channel : str
+        color subchannel (l = lightness, a = green-magenta, b = blue-yellow)
+
+    Returns
+    -------
+    numpy.ndarray
+        grayscale image from one LAB color channel
+    """
+    # The allowable channel inputs are l, a or b
+    channel = channel.lower()
+    if channel not in ["l", "a", "b"]:
+        fatal_error("Channel " + str(channel) + " is not l, a or b!")
+
+    # Convert the input BGR image to LAB colorspace
+    lab = cv2.cvtColor(rgb_img, cv2.COLOR_BGR2LAB)
+    # Split LAB channels
+    l, a, b = cv2.split(lab)
+    # Create a channel dictionaries for lookups by a channel name index
+    channels = {"l": l, "a": a, "b": b}
+    return channels[channel]

--- a/plantcv/plantcv/_helpers.py
+++ b/plantcv/plantcv/_helpers.py
@@ -486,3 +486,33 @@ def _rgb2lab(rgb_img, channel):
     # Create a channel dictionaries for lookups by a channel name index
     channels = {"l": l, "a": a, "b": b}
     return channels[channel]
+
+
+def _rgb2hsv(rgb_img, channel):
+    """Convert image from RGB colorspace to HSV colorspace. Returns the specified subchannel as a gray image.
+
+    Parameters
+    ----------
+    rgb_img : numpy.ndarray
+        RGB image data
+    channel : str
+        color subchannel (h = hue, s = saturation, v = value/intensity/brightness)
+
+    Returns
+    -------
+    numpy.ndarray
+        grayscale image from one HSV color channel
+    """
+    # The allowable channel inputs are h, s or v
+    channel = channel.lower()
+    if channel not in ["h", "s", "v"]:
+        fatal_error("Channel " + str(channel) + " is not h, s or v!")
+
+    # Convert the input BGR image to HSV colorspace
+    hsv = cv2.cvtColor(rgb_img, cv2.COLOR_BGR2HSV)
+    # Split HSV channels
+    h, s, v = cv2.split(hsv)
+    # Create a channel dictionaries for lookups by a channel name index
+    channels = {"h": h, "s": s, "v": v}
+
+    return channels[channel]

--- a/plantcv/plantcv/_helpers.py
+++ b/plantcv/plantcv/_helpers.py
@@ -516,3 +516,50 @@ def _rgb2hsv(rgb_img, channel):
     channels = {"h": h, "s": s, "v": v}
 
     return channels[channel]
+
+
+def _rgb2cmyk(rgb_img, channel):
+    """Convert image from RGB colorspace to CMYK colorspace. Returns the specified subchannel as a gray image.
+
+    Parameters
+    ----------
+    rgb_img : numpy.ndarray
+        RGB image data
+    channel : str
+        color subchannel (c = cyan, m = magenta, y = yellow, k=black)
+
+    Returns
+    -------
+    numpy.ndarray
+        grayscale image from one CMYK color channel
+    """
+    # Set NumPy to ignore divide by zero errors
+    _ = np.seterr(divide='ignore', invalid='ignore')
+    # The allowable channel inputs are c, m , y or k
+    channel = channel.lower()
+    if channel not in ["c", "m", "y", "k"]:
+        fatal_error("Channel " + str(channel) + " is not c, m, y or k!")
+
+    # Create float
+    bgr = rgb_img.astype(float)/255.
+
+    # K channel
+    k = 1 - np.max(bgr, axis=2)
+
+    # C Channel
+    c = (1 - bgr[..., 2] - k) / (1 - k)
+
+    # M Channel
+    m = (1 - bgr[..., 1] - k) / (1 - k)
+
+    # Y Channel
+    y = (1 - bgr[..., 0] - k) / (1 - k)
+
+    # Convert the input BGR image to LAB colorspace
+    cmyk = (np.dstack((c, m, y, k)) * 255).astype(np.uint8)
+    # Split CMYK channels
+    y, m, c, k = cv2.split(cmyk)
+    # Create a channel dictionaries for lookups by a channel name index
+    channels = {"c": c, "m": m, "y": y, "k": k}
+
+    return channels[channel]

--- a/plantcv/plantcv/_helpers.py
+++ b/plantcv/plantcv/_helpers.py
@@ -563,3 +563,21 @@ def _rgb2cmyk(rgb_img, channel):
     channels = {"c": c, "m": m, "y": y, "k": k}
 
     return channels[channel]
+
+
+def _rgb2gray(rgb_img):
+    """Convert image from RGB colorspace to Gray.
+
+    Parameters
+    ----------
+    rgb_img : numpy.ndarray
+        RGB image data
+
+    Returns
+    -------
+    numpy.ndarray
+        grayscale image
+    """
+    gray = cv2.cvtColor(rgb_img, cv2.COLOR_BGR2GRAY)
+
+    return gray

--- a/plantcv/plantcv/report_size_marker_area.py
+++ b/plantcv/plantcv/report_size_marker_area.py
@@ -2,10 +2,10 @@
 import cv2
 import numpy as np
 import os
-from plantcv.plantcv import params, outputs, fatal_error, apply_mask, rgb2gray_hsv
+from plantcv.plantcv import params, outputs, fatal_error, apply_mask
 from plantcv.plantcv.threshold import binary as binary_threshold
 from plantcv.plantcv._debug import _debug
-from plantcv.plantcv._helpers import _cv2_findcontours, _object_composition, _roi_filter
+from plantcv.plantcv._helpers import _cv2_findcontours, _object_composition, _roi_filter, _rgb2hsv
 
 
 def report_size_marker_area(img, roi, marker='define', objcolor='dark', thresh_channel=None,
@@ -66,7 +66,7 @@ def report_size_marker_area(img, roi, marker='define', objcolor='dark', thresh_c
             # Mask the input image
             masked = apply_mask(img=ref_img, mask=roi_mask, mask_color="black")
             # Convert the masked image to hue, saturation, or value
-            marker_hsv = rgb2gray_hsv(rgb_img=masked, channel=thresh_channel)
+            marker_hsv = _rgb2hsv(rgb_img=masked, channel=thresh_channel)
             # Threshold the HSV image
             marker_bin = binary_threshold(gray_img=marker_hsv, threshold=thresh, object_type=objcolor)
             # Identify contours in the masked image

--- a/plantcv/plantcv/rgb2gray.py
+++ b/plantcv/plantcv/rgb2gray.py
@@ -1,25 +1,26 @@
 # RGB -> Gray
 
-import cv2
 import os
 from plantcv.plantcv import params
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _rgb2gray
 
 
 def rgb2gray(rgb_img):
     """Convert image from RGB colorspace to Gray.
 
-    Inputs:
-    rgb_img    = RGB image data
+    Parameters
+    ----------
+    rgb_img : numpy.ndarray
+        RGB image data
 
-    Returns:
-    gray   = grayscale image
-
-    :param rgb_img: numpy.ndarray
-    :return gray: numpy.ndarray
+    Returns
+    -------
+    numpy.ndarray
+        grayscale image
     """
-    gray = cv2.cvtColor(rgb_img, cv2.COLOR_BGR2GRAY)
+    gray = _rgb2gray(rgb_img=rgb_img)
 
-    _debug(visual=gray, filename=os.path.join(params.debug_outdir, str(params.device) + "_gray.png"))
+    _debug(visual=gray, filename=os.path.join(params.debug_outdir, f"{params.device}_gray.png"))
 
     return gray

--- a/plantcv/plantcv/rgb2gray_cmyk.py
+++ b/plantcv/plantcv/rgb2gray_cmyk.py
@@ -1,59 +1,34 @@
 """Convert RGB to CMYK colorspace and return the specified subchannel as a grayscale image."""
 
-import cv2
 import os
 from plantcv.plantcv._debug import _debug
-from plantcv.plantcv import fatal_error
 from plantcv.plantcv import params
-import numpy as np
+from plantcv.plantcv._helpers import _rgb2cmyk
 
 
 def rgb2gray_cmyk(rgb_img, channel):
     """Convert image from RGB colorspace to CMYK colorspace. Returns the specified subchannel as a gray image.
 
-    Inputs:
-    rgb_img   = RGB image data
-    channel   = color subchannel (c = cyan, m = magenta, y = yellow, k=black)
+    Parameters
+    ----------
+    rgb_img : numpy.ndarray
+        RGB image data
+    channel : str
+        color subchannel (c = cyan, m = magenta, y = yellow, k=black)
 
-    Returns:
-    c | m | y | k = grayscale image from one CMYK color channel
-
-    :param rgb_img: numpy.ndarray
-    :param channel: str
-    :return channel: numpy.ndarray
+    Returns
+    -------
+    numpy.ndarray
+        grayscale image from one CMYK color channel
     """
-    # Set NumPy to ignore divide by zero errors
-    _ = np.seterr(divide='ignore', invalid='ignore')
+    # Convert RGB to CMYK and return the specified subchannel as a gray image
+    gray_img = _rgb2cmyk(rgb_img=rgb_img, channel=channel)
+
     # The allowable channel inputs are c, m , y or k
     names = {"c": "cyan", "m": "magenta", "y": "yellow", "k": "black"}
-    channel = channel.lower()
-    if channel not in names:
-        fatal_error("Channel " + str(channel) + " is not c, m, y or k!")
-
-    # Create float
-    bgr = rgb_img.astype(float)/255.
-
-    # K channel
-    k = 1 - np.max(bgr, axis=2)
-
-    # C Channel
-    c = (1 - bgr[..., 2] - k) / (1 - k)
-
-    # M Channel
-    m = (1 - bgr[..., 1] - k) / (1 - k)
-
-    # Y Channel
-    y = (1 - bgr[..., 0] - k) / (1 - k)
-
-    # Convert the input BGR image to LAB colorspace
-    cmyk = (np.dstack((c, m, y, k)) * 255).astype(np.uint8)
-    # Split CMYK channels
-    y, m, c, k = cv2.split(cmyk)
-    # Create a channel dictionaries for lookups by a channel name index
-    channels = {"c": c, "m": m, "y": y, "k": k}
 
     # Save or display the grayscale image
-    _debug(visual=channels[channel], filename=os.path.join(params.debug_outdir,
-                                                           str(params.device) + "_cmyk_" + names[channel] + ".png"))
+    _debug(visual=gray_img, filename=os.path.join(params.debug_outdir,
+                                                  str(params.device) + "_cmyk_" + names[channel.lower()] + ".png"))
 
-    return channels[channel]
+    return gray_img

--- a/plantcv/plantcv/rgb2gray_cmyk.py
+++ b/plantcv/plantcv/rgb2gray_cmyk.py
@@ -28,7 +28,7 @@ def rgb2gray_cmyk(rgb_img, channel):
     names = {"c": "cyan", "m": "magenta", "y": "yellow", "k": "black"}
 
     # Save or display the grayscale image
-    _debug(visual=gray_img, filename=os.path.join(params.debug_outdir,
-                                                  str(params.device) + "_cmyk_" + names[channel.lower()] + ".png"))
+    _debug(visual=gray_img,
+           filename=os.path.join(params.debug_outdir, f"{params.device}_cmyk_{names[channel.lower()]}.png"), cmap="gray")
 
     return gray_img

--- a/plantcv/plantcv/rgb2gray_hsv.py
+++ b/plantcv/plantcv/rgb2gray_hsv.py
@@ -28,7 +28,6 @@ def rgb2gray_hsv(rgb_img, channel):
     names = {"h": "hue", "s": "saturation", "v": "value"}
 
     _debug(visual=gray_img,
-           filename=os.path.join(params.debug_outdir,
-                                 str(params.device) + "_hsv_" + names[channel.lower()] + ".png"), cmap='gray')
+           filename=os.path.join(params.debug_outdir, f"{params.device}_hsv_{names[channel.lower()]}.png"), cmap='gray')
 
     return gray_img

--- a/plantcv/plantcv/rgb2gray_hsv.py
+++ b/plantcv/plantcv/rgb2gray_hsv.py
@@ -1,43 +1,34 @@
 # RGB -> HSV -> Gray
 
-import cv2
 import os
 from plantcv.plantcv._debug import _debug
-from plantcv.plantcv import fatal_error
 from plantcv.plantcv import params
+from plantcv.plantcv._helpers import _rgb2hsv
 
 
 def rgb2gray_hsv(rgb_img, channel):
+    """Convert image from RGB colorspace to HSV colorspace. Returns the specified subchannel as a gray image.
+
+    Parameters
+    ----------
+    rgb_img : numpy.ndarray
+        RGB image data
+    channel : str
+        color subchannel (h = hue, s = saturation, v = value/intensity/brightness)
+
+    Returns
+    -------
+    numpy.ndarray
+        grayscale image from one HSV color channel
     """
-    Convert an RGB color image to HSV colorspace and return a gray image (one channel).
+    # Convert RGB to HSV and return the specified subchannel as a gray image
+    gray_img = _rgb2hsv(rgb_img=rgb_img, channel=channel)
 
-    Inputs:
-    rgb_img = RGB image data
-    channel = color subchannel (h = hue, s = saturation, v = value/intensity/brightness)
-
-    Returns:
-    h | s | v = image from single HSV channel
-
-    :param rgb_img: numpy.ndarray
-    :param channel: str
-    :return channel: numpy.ndarray
-    """
     # The allowable channel inputs are h, s or v
     names = {"h": "hue", "s": "saturation", "v": "value"}
-    channel = channel.lower()
-    if channel not in names:
-        fatal_error("Channel " + str(channel) + " is not h, s or v!")
 
-    # Convert the input BGR image to HSV colorspace
-    hsv = cv2.cvtColor(rgb_img, cv2.COLOR_BGR2HSV)
-    # Split HSV channels
-    h, s, v = cv2.split(hsv)
-    # Create a channel dictionaries for lookups by a channel name index
-    channels = {"h": h, "s": s, "v": v}
-
-    _debug(visual=channels[channel],
+    _debug(visual=gray_img,
            filename=os.path.join(params.debug_outdir,
-                                 str(params.device) + "_hsv_" + names[channel] + ".png"),
-           cmap='gray')
+                                 str(params.device) + "_hsv_" + names[channel.lower()] + ".png"), cmap='gray')
 
-    return channels[channel]
+    return gray_img

--- a/plantcv/plantcv/rgb2gray_lab.py
+++ b/plantcv/plantcv/rgb2gray_lab.py
@@ -1,43 +1,35 @@
 # RGB -> LAB -> Gray
 
-import cv2
 import os
 from plantcv.plantcv._debug import _debug
-from plantcv.plantcv import fatal_error
 from plantcv.plantcv import params
+from plantcv.plantcv._helpers import _rgb2lab
 
 
 def rgb2gray_lab(rgb_img, channel):
+    """Convert image from RGB colorspace to LAB colorspace. Returns the specified subchannel as a gray image.
+
+    Parameters
+    ----------
+    rgb_img : numpy.ndarray
+        RGB image data
+    channel : str
+        color subchannel (l = lightness, a = green-magenta, b = blue-yellow)
+
+    Returns
+    -------
+    numpy.ndarray
+        grayscale image from one LAB color channel
     """
-    Convert image from RGB colorspace to LAB colorspace. Returns the specified subchannel as a gray image.
+    # Convert RGB to LAB and return the specified subchannel as a gray image
+    gray_img = _rgb2lab(rgb_img=rgb_img, channel=channel)
 
-    Inputs:
-    rgb_img   = RGB image data
-    channel   = color subchannel (l = lightness, a = green-magenta, b = blue-yellow)
-
-    Returns:
-    l | a | b = grayscale image from one LAB color channel
-
-    :param rgb_img: numpy.ndarray
-    :param channel: str
-    :return channel: numpy.ndarray
-    """
     # The allowable channel inputs are l, a or b
     names = {"l": "lightness", "a": "green-magenta", "b": "blue-yellow"}
-    channel = channel.lower()
-    if channel not in names:
-        fatal_error("Channel " + str(channel) + " is not l, a or b!")
 
-    # Convert the input BGR image to LAB colorspace
-    lab = cv2.cvtColor(rgb_img, cv2.COLOR_BGR2LAB)
-    # Split LAB channels
-    l, a, b = cv2.split(lab)
-    # Create a channel dictionaries for lookups by a channel name index
-    channels = {"l": l, "a": a, "b": b}
-
-    _debug(visual=channels[channel],
+    # Display debug image
+    _debug(visual=gray_img,
            filename=os.path.join(params.debug_outdir,
-                                 str(params.device) + "_lab_" + names[channel] + ".png"),
-           cmap="gray")
+                                 str(params.device) + "_lab_" + names[channel.lower()] + ".png"), cmap="gray")
 
-    return channels[channel]
+    return gray_img

--- a/plantcv/plantcv/rgb2gray_lab.py
+++ b/plantcv/plantcv/rgb2gray_lab.py
@@ -29,7 +29,6 @@ def rgb2gray_lab(rgb_img, channel):
 
     # Display debug image
     _debug(visual=gray_img,
-           filename=os.path.join(params.debug_outdir,
-                                 str(params.device) + "_lab_" + names[channel.lower()] + ".png"), cmap="gray")
+           filename=os.path.join(params.debug_outdir, f"{params.device}_lab_{names[channel.lower()]}.png"), cmap="gray")
 
     return gray_img

--- a/plantcv/plantcv/segment_image_series.py
+++ b/plantcv/plantcv/segment_image_series.py
@@ -8,10 +8,10 @@ from scipy import ndimage as ndi
 from skimage.segmentation import watershed
 from skimage.color import label2rgb
 from plantcv.plantcv import readimage
-from plantcv.plantcv import rgb2gray
 from plantcv.plantcv import fill_holes
 from plantcv.plantcv import params
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _rgb2gray
 
 
 def segment_image_series(imgs_paths, masks_paths, rois, save_labels=True, ksize=3):
@@ -84,7 +84,7 @@ def segment_image_series(imgs_paths, masks_paths, rois, save_labels=True, ksize=
             frame = min(N-1, max(n+m, 0))  # border handling
 
             img, _, _ = readimage(filename=imgs_paths[frame])
-            img_stack[:, :, stack_idx] = rgb2gray(rgb_img=img)
+            img_stack[:, :, stack_idx] = _rgb2gray(rgb_img=img)
             mask, _, _ = readimage(filename=masks_paths[frame], mode='gray')
             mask_stack[:, :, stack_idx] = mask
 

--- a/plantcv/plantcv/threshold/threshold_methods.py
+++ b/plantcv/plantcv/threshold/threshold_methods.py
@@ -5,11 +5,10 @@ import math
 import numpy as np
 from matplotlib import pyplot as plt
 from plantcv.plantcv import rgb2gray
-from plantcv.plantcv import rgb2gray_hsv
 from plantcv.plantcv import fatal_error, warn
 from plantcv.plantcv import params
 from plantcv.plantcv._debug import _debug
-from plantcv.plantcv._helpers import _rgb2lab
+from plantcv.plantcv._helpers import _rgb2lab, _rgb2hsv
 from skimage.feature import graycomatrix, graycoprops
 from scipy.ndimage import generic_filter
 
@@ -797,7 +796,7 @@ def mask_bad(float_img, bad_type='native'):
 
 
 # functions to get a given channel with parameters compatible
-# with _rgb2lab and rgb2gray_hsv to use in the dict
+# with _rgb2lab and _rgb2hsv to use in the dict
 def _get_R(rgb_img, _):
     """Get the red channel from a RGB image"""
     return rgb_img[:, :, 2]
@@ -860,9 +859,9 @@ def dual_channels(rgb_img, x_channel, y_channel, points, above=True):
         'a': _rgb2lab,
         'b': _rgb2lab,
         'gray': _get_gray,
-        'h': rgb2gray_hsv,
-        's': rgb2gray_hsv,
-        'v': rgb2gray_hsv,
+        'h': _rgb2hsv,
+        's': _rgb2hsv,
+        'v': _rgb2hsv,
         'index': _get_index,
     }
 

--- a/plantcv/plantcv/threshold/threshold_methods.py
+++ b/plantcv/plantcv/threshold/threshold_methods.py
@@ -6,10 +6,10 @@ import numpy as np
 from matplotlib import pyplot as plt
 from plantcv.plantcv import rgb2gray
 from plantcv.plantcv import rgb2gray_hsv
-from plantcv.plantcv import rgb2gray_lab
 from plantcv.plantcv import fatal_error, warn
 from plantcv.plantcv import params
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _rgb2lab
 from skimage.feature import graycomatrix, graycoprops
 from scipy.ndimage import generic_filter
 
@@ -797,7 +797,7 @@ def mask_bad(float_img, bad_type='native'):
 
 
 # functions to get a given channel with parameters compatible
-# with rgb2gray_lab and rgb2gray_hsv to use in the dict
+# with _rgb2lab and rgb2gray_hsv to use in the dict
 def _get_R(rgb_img, _):
     """Get the red channel from a RGB image"""
     return rgb_img[:, :, 2]
@@ -856,9 +856,9 @@ def dual_channels(rgb_img, x_channel, y_channel, points, above=True):
         'R': _get_R,
         'G': _get_G,
         'B': _get_B,
-        'l': rgb2gray_lab,
-        'a': rgb2gray_lab,
-        'b': rgb2gray_lab,
+        'l': _rgb2lab,
+        'a': _rgb2lab,
+        'b': _rgb2lab,
         'gray': _get_gray,
         'h': rgb2gray_hsv,
         's': rgb2gray_hsv,

--- a/plantcv/plantcv/threshold/threshold_methods.py
+++ b/plantcv/plantcv/threshold/threshold_methods.py
@@ -4,11 +4,10 @@ import cv2
 import math
 import numpy as np
 from matplotlib import pyplot as plt
-from plantcv.plantcv import rgb2gray
 from plantcv.plantcv import fatal_error, warn
 from plantcv.plantcv import params
 from plantcv.plantcv._debug import _debug
-from plantcv.plantcv._helpers import _rgb2lab, _rgb2hsv
+from plantcv.plantcv._helpers import _rgb2lab, _rgb2hsv, _rgb2gray
 from skimage.feature import graycomatrix, graycoprops
 from scipy.ndimage import generic_filter
 
@@ -814,7 +813,7 @@ def _get_B(rgb_img, _):
 
 def _get_gray(rgb_img, _):
     """Get the gray scale transformation of a RGB image"""
-    return rgb2gray(rgb_img=rgb_img)
+    return _rgb2gray(rgb_img=rgb_img)
 
 
 def _get_index(rgb_img, _):

--- a/plantcv/plantcv/transform/checkerboard_calib.py
+++ b/plantcv/plantcv/transform/checkerboard_calib.py
@@ -4,11 +4,11 @@ import cv2 as cv
 import os
 import numpy as np
 from plantcv.plantcv.readimage import readimage
-from plantcv.plantcv.rgb2gray import rgb2gray
 from plantcv.plantcv import params
 from plantcv.plantcv._debug import _debug
 from plantcv.plantcv.transform.color_correction import save_matrix
 from plantcv.plantcv.transform.color_correction import load_matrix
+from plantcv.plantcv._helpers import _rgb2gray
 
 
 def checkerboard_calib(img_path, col_corners, row_corners, out_dir):
@@ -37,7 +37,7 @@ def checkerboard_calib(img_path, col_corners, row_corners, out_dir):
     for fname in images:
         img, _, _ = readimage(filename=os.path.join(img_path, fname), mode="native")
         img1 = np.copy(img)
-        gray_img = rgb2gray(img1)
+        gray_img = _rgb2gray(img1)
         ret, corners = cv.findChessboardCorners(gray_img, (col_corners, row_corners))
         criteria = (cv.TERM_CRITERIA_EPS + cv.TERM_CRITERIA_MAX_ITER, 30, 0.001)
         if ret is True:

--- a/plantcv/plantcv/transform/detect_color_card.py
+++ b/plantcv/plantcv/transform/detect_color_card.py
@@ -8,6 +8,7 @@ import math
 import numpy as np
 from plantcv.plantcv import params, outputs, fatal_error, deprecation_warning
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _rgb2gray
 
 
 def _is_square(contour, min_size):
@@ -127,7 +128,7 @@ def detect_color_card(rgb_img, label=None, **kwargs):
     ncols = 4
 
     # Convert to grayscale, threshold, and findContours
-    imgray = cv2.cvtColor(rgb_img, cv2.COLOR_BGR2GRAY)
+    imgray = _rgb2gray(rgb_img=rgb_img)
     gaussian = cv2.GaussianBlur(imgray, (11, 11), 0)
     thresh = cv2.adaptiveThreshold(gaussian, 255, adaptive_method,
                                    cv2.THRESH_BINARY_INV, block_size, 2)

--- a/plantcv/plantcv/transform/nonuniform_illumination.py
+++ b/plantcv/plantcv/transform/nonuniform_illumination.py
@@ -4,10 +4,10 @@ import os
 import cv2
 import numpy as np
 from plantcv.plantcv import params
-from plantcv.plantcv import rgb2gray
 from plantcv.plantcv import gaussian_blur
 from plantcv.plantcv.transform import rescale
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _rgb2gray
 
 
 def nonuniform_illumination(img, ksize):
@@ -25,7 +25,7 @@ def nonuniform_illumination(img, ksize):
     :return corrected_img: numpy.ndarray
     """
     if len(np.shape(img)) == 3:
-        img = rgb2gray(img)
+        img = _rgb2gray(img)
 
     # Fill foreground objects
     kernel = np.ones((ksize, ksize), np.uint8)

--- a/plantcv/plantcv/visualize/colorspaces.py
+++ b/plantcv/plantcv/visualize/colorspaces.py
@@ -6,10 +6,9 @@ import numpy as np
 from plantcv.plantcv import params
 from plantcv.plantcv.transform import resize_factor
 from plantcv.plantcv import fatal_error
-from plantcv.plantcv import rgb2gray_hsv
 from plantcv.plantcv import rgb2gray_cmyk
 from plantcv.plantcv._debug import _debug
-from plantcv.plantcv._helpers import _rgb2lab
+from plantcv.plantcv._helpers import _rgb2lab, _rgb2hsv
 
 
 def colorspaces(rgb_img, original_img=True):
@@ -43,7 +42,7 @@ def colorspaces(rgb_img, original_img=True):
     # Loop through and create grayscale imgs from each colorspace
     for i in range(0, 3):
         channel = colorspace_names[i]
-        all_colorspaces.append(rgb2gray_hsv(rgb_img=rgb_img, channel=channel))
+        all_colorspaces.append(_rgb2hsv(rgb_img=rgb_img, channel=channel))
     for i in range(3, 6):
         channel = colorspace_names[i]
         all_colorspaces.append(_rgb2lab(rgb_img=rgb_img, channel=channel))

--- a/plantcv/plantcv/visualize/colorspaces.py
+++ b/plantcv/plantcv/visualize/colorspaces.py
@@ -7,10 +7,9 @@ from plantcv.plantcv import params
 from plantcv.plantcv.transform import resize_factor
 from plantcv.plantcv import fatal_error
 from plantcv.plantcv import rgb2gray_hsv
-from plantcv.plantcv import rgb2gray_lab
 from plantcv.plantcv import rgb2gray_cmyk
-
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _rgb2lab
 
 
 def colorspaces(rgb_img, original_img=True):
@@ -47,7 +46,7 @@ def colorspaces(rgb_img, original_img=True):
         all_colorspaces.append(rgb2gray_hsv(rgb_img=rgb_img, channel=channel))
     for i in range(3, 6):
         channel = colorspace_names[i]
-        all_colorspaces.append(rgb2gray_lab(rgb_img=rgb_img, channel=channel))
+        all_colorspaces.append(_rgb2lab(rgb_img=rgb_img, channel=channel))
     for i in range(6, 10):
         channel = colorspace_names[i]
         all_colorspaces.append(rgb2gray_cmyk(rgb_img=rgb_img, channel=channel))

--- a/plantcv/plantcv/visualize/colorspaces.py
+++ b/plantcv/plantcv/visualize/colorspaces.py
@@ -6,9 +6,8 @@ import numpy as np
 from plantcv.plantcv import params
 from plantcv.plantcv.transform import resize_factor
 from plantcv.plantcv import fatal_error
-from plantcv.plantcv import rgb2gray_cmyk
 from plantcv.plantcv._debug import _debug
-from plantcv.plantcv._helpers import _rgb2lab, _rgb2hsv
+from plantcv.plantcv._helpers import _rgb2lab, _rgb2hsv, _rgb2cmyk
 
 
 def colorspaces(rgb_img, original_img=True):
@@ -48,7 +47,7 @@ def colorspaces(rgb_img, original_img=True):
         all_colorspaces.append(_rgb2lab(rgb_img=rgb_img, channel=channel))
     for i in range(6, 10):
         channel = colorspace_names[i]
-        all_colorspaces.append(rgb2gray_cmyk(rgb_img=rgb_img, channel=channel))
+        all_colorspaces.append(_rgb2cmyk(rgb_img=rgb_img, channel=channel))
 
     # Plot labels of each colorspace on the corresponding img
     for i, colorspace in enumerate(all_colorspaces):

--- a/plantcv/plantcv/visualize/pixel_scatter_vis.py
+++ b/plantcv/plantcv/visualize/pixel_scatter_vis.py
@@ -4,8 +4,8 @@ import numpy as np
 import cv2 as cv
 from matplotlib import pyplot as plt
 from plantcv import plantcv as pcv
-from plantcv.plantcv import fatal_error
-from plantcv.plantcv import params
+from plantcv.plantcv import fatal_error, params
+from plantcv.plantcv._helpers import _rgb2lab
 
 
 MAX_MARKER_SIZE = 20
@@ -13,7 +13,7 @@ IMG_WIDTH = 128
 
 
 # functions to get a given channel with parameters compatible
-# with rgb2gray_lab and rgb2gray_hsv to use in the dict
+# with _rgb2lab and rgb2gray_hsv to use in the dict
 def _get_R(rgb_img, _):
     """Get the red channel from a RGB image."""
     return rgb_img[:, :, 2]
@@ -74,9 +74,9 @@ def pixel_scatter_plot(paths_to_imgs, x_channel, y_channel):
         'R': _get_R,
         'G': _get_G,
         'B': _get_B,
-        'l': pcv.rgb2gray_lab,
-        'a': pcv.rgb2gray_lab,
-        'b': pcv.rgb2gray_lab,
+        'l': _rgb2lab,
+        'a': _rgb2lab,
+        'b': _rgb2lab,
         'gray': _get_gray,
         'h': pcv.rgb2gray_hsv,
         's': pcv.rgb2gray_hsv,

--- a/plantcv/plantcv/visualize/pixel_scatter_vis.py
+++ b/plantcv/plantcv/visualize/pixel_scatter_vis.py
@@ -5,7 +5,7 @@ import cv2 as cv
 from matplotlib import pyplot as plt
 from plantcv import plantcv as pcv
 from plantcv.plantcv import fatal_error, params
-from plantcv.plantcv._helpers import _rgb2lab, _rgb2hsv
+from plantcv.plantcv._helpers import _rgb2lab, _rgb2hsv, _rgb2gray
 
 
 MAX_MARKER_SIZE = 20
@@ -31,7 +31,7 @@ def _get_B(rgb_img, _):
 
 def _get_gray(rgb_img, _):
     """Get the gray scale transformation of a RGB image."""
-    return pcv.rgb2gray(rgb_img=rgb_img)
+    return _rgb2gray(rgb_img=rgb_img)
 
 
 def _get_index(rgb_img, _):

--- a/plantcv/plantcv/visualize/pixel_scatter_vis.py
+++ b/plantcv/plantcv/visualize/pixel_scatter_vis.py
@@ -5,7 +5,7 @@ import cv2 as cv
 from matplotlib import pyplot as plt
 from plantcv import plantcv as pcv
 from plantcv.plantcv import fatal_error, params
-from plantcv.plantcv._helpers import _rgb2lab
+from plantcv.plantcv._helpers import _rgb2lab, _rgb2hsv
 
 
 MAX_MARKER_SIZE = 20
@@ -13,7 +13,7 @@ IMG_WIDTH = 128
 
 
 # functions to get a given channel with parameters compatible
-# with _rgb2lab and rgb2gray_hsv to use in the dict
+# with _rgb2lab and _rgb2hsv to use in the dict
 def _get_R(rgb_img, _):
     """Get the red channel from a RGB image."""
     return rgb_img[:, :, 2]
@@ -78,9 +78,9 @@ def pixel_scatter_plot(paths_to_imgs, x_channel, y_channel):
         'a': _rgb2lab,
         'b': _rgb2lab,
         'gray': _get_gray,
-        'h': pcv.rgb2gray_hsv,
-        's': pcv.rgb2gray_hsv,
-        'v': pcv.rgb2gray_hsv,
+        'h': _rgb2hsv,
+        's': _rgb2hsv,
+        'v': _rgb2hsv,
         'index': _get_index,
     }
 


### PR DESCRIPTION
**Describe your changes**
The `rgb2gray` color conversion functions are reused throughout PlantCV, which may cause circular import issues. This PR creates new helper functions for each type of color conversion, refactors the user-facing functions as wrappers for the helpers, and refactors other functions that use color conversion to use the helper functions instead to avoid import conflicts.

**Type of update**
Is this a: code cleanup

**Associated issues**
#1704

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [ ] PR approved
