### PR TITLE
Add global size parameters to `Params` class

### DIFF
--- a/docs/params.md
+++ b/docs/params.md
@@ -51,6 +51,12 @@ the morphology sub-package. Default = 2.
 **saved_color_scale**: Using the `color_palette` function will save the color scale here for reuse in downstream functions. Set to `None` to remove. Default = `None`.
 
 **verbose**: Set the status of verboseness. When in "verbose" mode, the deprecation warning will always be printed once triggered. Default: `True`. Users can turn off deprecation warnings by setting `verbose=False`.
+
+**unit**: Set the units of the size outputs. Users can scale size measurements by updating the `unit`, `px_height` and `px_width` Default: `pixels`
+
+**px_height** Set the size scaling factor to enable automatic conversion between pixels and a real world unit, such as centimeters. Users can scale size measurements by updating the `unit`, `px_height` and `px_width` Default: `1`
+
+**px_width** Set the size scaling factor to enable automatic conversion between pixels and a real world unit, such as centimeters. Users can scale size measurements by updating the `unit`, `px_height` and `px_width` Default: `1`
 ### Example
 
 Updated PlantCV functions use `params` implicitly, so overriding the `params` defaults will alter the behavior of

--- a/plantcv/plantcv/classes.py
+++ b/plantcv/plantcv/classes.py
@@ -19,7 +19,7 @@ class Params:
     def __init__(self, device=0, debug=None, debug_outdir=".", line_thickness=5,
                  line_color=(255, 0, 255), dpi=100, text_size=0.55,
                  text_thickness=2, marker_size=60, color_scale="gist_rainbow", color_sequence="sequential",
-                 sample_label="default", saved_color_scale=None, verbose=True):
+                 sample_label="default", saved_color_scale=None, verbose=True, unit="pixels", px_height=1, px_width=1):
         """Initialize parameters.
 
         Keyword arguments/parameters:
@@ -37,6 +37,10 @@ class Params:
         sample_label      = Sample name prefix. Used in analyze functions. (default: "default")
         saved_color_scale = Saved color scale that will be applied next time color_palette is called. (default: None)
         verbose           = Whether or not in verbose mode. (default: True)
+        unit              = Units of size trait outputs. (default: "pixels")
+        px_height         = Size scaling information about pixel height (default: 1)
+        px_width          = Size scaling information about pixel height (default: 1)
+
 
         :param device: int
         :param debug: str
@@ -51,6 +55,10 @@ class Params:
         :param sample_label: str
         :param saved_color_scale: list
         :param verbose: bool
+        :param unit: str
+        :param px_height: float
+        :param px_width: float
+
         """
         self.device = device
         self.debug = debug
@@ -66,6 +74,9 @@ class Params:
         self.sample_label = sample_label
         self.saved_color_scale = saved_color_scale
         self.verbose = verbose
+        self.unit = unit
+        self.px_height = px_height
+        self.px_width = px_width
 
 
 class Outputs:


### PR DESCRIPTION
**Describe your changes**
Add global size parameters (`unit` `px_width` and `px_height`) to `Params` class to prepare for functionality support to do size scaling directly during analysis steps. Also update documentation page to include the new parameters. 

**Associated issues**
- staged update related to #1649 

**Additional context**
Next steps: PR2: use units/px factors in analyze functions; PR3: sets global params given color card chip sizes

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
