### PR TITLE
Add NDCI to spectral indices supported 

### DIFF
--- a/docs/spectral_index.md
+++ b/docs/spectral_index.md
@@ -236,6 +236,26 @@ Index range: -∞, ∞
     - hsi         - Hyperspectral image object, an instance of the `Spectral_data` class in plantcv (read in using [pcv.readimage](read_image.md) with `mode='envi'`)
     - distance    - Amount of flexibility (in nanometers) regarding the bands used to calculate an index.
 
+### NDCI
+
+Calculates the Normalized Difference Chlorophyll Edge index using reflectance values ([Mishra & Mishra, 2012](#references)):
+
+```
+NDCI = (R708 - R665) / (R708 + R665)
+
+```
+
+Index range: -1.0, 1.0
+
+**plantcv.spectral_index.ndci**(*hsi, distance=20*)
+
+**returns** calculated index array (instance of the `Spectral_data` class)
+
+- **Parameters:**
+    - hsi         - Hyperspectral image object, an instance of the `Spectral_data` class in plantcv (read in using [pcv.readimage](read_image.md) with `mode='envi'`)
+    - distance    - Amount of flexibility (in nanometers) regarding the bands used to calculate an index.
+
+
 ### NDRE
 
 Calculates the Normalized Difference Red Edge index using reflectance values ([Barnes et al., 2000](#references)):

--- a/plantcv/plantcv/spectral_index/__init__.py
+++ b/plantcv/plantcv/spectral_index/__init__.py
@@ -28,9 +28,10 @@ from plantcv.plantcv.spectral_index.spectral_index import sr
 from plantcv.plantcv.spectral_index.spectral_index import vari
 from plantcv.plantcv.spectral_index.spectral_index import vi_green
 from plantcv.plantcv.spectral_index.spectral_index import wi
+from plantcv.plantcv.spectral_index.spectral_index import ndci
 
 
 # add new functions to end of lists
 __all__ = ["ndvi", "gdvi", "savi", "pri", "ari", "ci_rededge", "cri550", "cri700", "egi", "evi", "gli", "mari", "mcari",
            "mtci", "ndre", "npci", "psnd_chla", "psnd_chlb", "psnd_car", "psri", "pssr_chla", "pssr_chlb", "pssr_car",
-           "rgri", "rvsi", "sipi", "sr", "vari", "vi_green", "wi"]
+           "rgri", "rvsi", "sipi", "sr", "vari", "vi_green", "wi", "ndci"]

--- a/plantcv/plantcv/spectral_index/spectral_index.py
+++ b/plantcv/plantcv/spectral_index/spectral_index.py
@@ -492,6 +492,36 @@ def mtci(hsi, distance=20):
     return None
 
 
+def ndci(hsi, distance=20):
+    """Normalized Difference Chlorophyll Difference.
+
+    NDCI = (R708 - R665) / (R708 + R665)
+
+    The theoretical range for NDCI is [-1.0, 1.0].
+
+    Inputs:
+    hsi         = hyperspectral image (PlantCV Spectral_data instance)
+    distance    = how lenient to be if the required wavelengths are not available
+
+    Returns:
+    index_array = Index data as a Spectral_data instance
+
+    :param hsi: __main__.Spectral_data
+    :param distance: int
+    :return index_array: __main__.Spectral_data
+    """
+    if (float(hsi.max_wavelength) + distance) >= 708 and (float(hsi.min_wavelength) - distance) <= 665:
+        r708_index = _find_closest(np.array([float(i) for i in hsi.wavelength_dict.keys()]), 708)
+        r665_index = _find_closest(np.array([float(i) for i in hsi.wavelength_dict.keys()]), 665)
+        r708 = (hsi.array_data[:, :, r708_index])
+        r665 = (hsi.array_data[:, :, r665_index])
+        # Naturally ranges from -1 to 1
+        with np.errstate(divide="ignore", invalid="ignore"):
+            index_array_raw = (r708 - r665) / (r708 + r665)
+        return _package_index(hsi=hsi, raw_index=index_array_raw, method="NDCI")
+    warn("Available wavelengths are not suitable for calculating NDCI. Try increasing distance.")
+    return None
+
 def ndre(hsi, distance=20):
     """Normalized Difference Red Edge.
 

--- a/tests/plantcv/spectral_index/test_spectral_index.py
+++ b/tests/plantcv/spectral_index/test_spectral_index.py
@@ -375,3 +375,15 @@ def test_wi_bad_input(spectral_index_test_data):
     """Test for PlantCV."""
     index_array = spectral_index.wi(spectral_index_test_data.load_hsi(), distance=20)
     assert spectral_index.wi(hsi=index_array, distance=20) is None
+
+
+def test_ndci(spectral_index_test_data):
+    """Test for PlantCV."""
+    index_array = spectral_index.ndci(spectral_index_test_data.load_hsi(), distance=20)
+    assert np.shape(index_array.array_data) == (1, 1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+
+def test_ndci_bad_input(spectral_index_test_data):
+    """Test for PlantCV."""
+    index_array = spectral_index.ndci(spectral_index_test_data.load_hsi(), distance=20)
+    assert spectral_index.wi(hsi=index_array, distance=20) is None


### PR DESCRIPTION
**Describe your changes**
Adds NDCI to `pcv.spectral_index` subpackage

**Type of update**
Is this a:
* New feature 

**Associated issues**
- closes #1713 

**Additional context**
Useful for quantifying chlorophyll-a 

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
