### PR TITLE
`morphology.segment_skeleton` returned segment_objects to list

### DIFF
--- a/plantcv/plantcv/morphology/segment_skeleton.py
+++ b/plantcv/plantcv/morphology/segment_skeleton.py
@@ -58,4 +58,4 @@ def segment_skeleton(skel_img, mask=None):
 
     _debug(visual=segmented_img, filename=os.path.join(params.debug_outdir, f"{params.device}_segmented.png"))
 
-    return segmented_img, segment_objects
+    return segmented_img, list(segment_objects)


### PR DESCRIPTION
**Describe your changes**
The `segment_objects` returned by `pcv.morphology.segment_skeleton` is supposed to be a list of OpenCV contours. This change casts the tuple type list of objects into a proper `list` type object.

**Type of update**
Is this a:
* Bug fix

**Associated issues**
- closes #1719 

**Additional context**
 It appears that something upstream changed within `cv2.findContours` which formats the contours inside a tuple. This causes an error downstream within the `pcv.morphology.fill_segments` analysis function, since `tuple` type objects are not supported with the operation `.copy()` which the function does to preserve the input list of objects/contours.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
