### PR TITLE
Pin scipy to <1.16

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - numpy>=2
   - pandas
   - python-dateutil
-  - scipy
+  - scipy<1.16
   - scikit-image>=0.19
   - scikit-learn
   - dask

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "numpy >= 2",
     "pandas",
     "python-dateutil",
-    "scipy",
+    "scipy <1.16",
     "scikit-image >= 0.19",
     "scikit-learn",
     "dask",


### PR DESCRIPTION
**Describe your changes**
`statsmodel` is not currently compatible with `scipy` 1.16: https://github.com/statsmodels/statsmodels/issues/9542

**Type of update**
Is this a: dependency fix

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [ ] PR approved
