### PR TITLE
`Rotate` transformation is not applied about the center of an image

### DIFF
--- a/plantcv/plantcv/transform/rotate.py
+++ b/plantcv/plantcv/transform/rotate.py
@@ -27,7 +27,7 @@ def rotate(img, rotation_deg, crop):
     # Extract image spatial dimensions
     iy, ix = np.shape(img)[:2]
 
-    m = cv2.getRotationMatrix2D((ix / 2, iy / 2), rotation_deg, 1)
+    m = cv2.getRotationMatrix2D(((ix-1)/2, (iy-1)/2), rotation_deg, 1)
 
     cos = np.abs(m[0, 0])
     sin = np.abs(m[0, 1])


### PR DESCRIPTION
**Describe your changes**
The `rotate` function finds the center of rotation as half the length and width of an image. This is offset from the actual center by half a pixel, and in some specific use-cases can significantly reduce the average color value of a rotated region. This PR updates `rotate` to account for the half-pixel offset to re-center rotation transformations.

**Type of update**
This is a:
* Bug fix

**Associated issues**
None

**Additional context**
An example figure illustrating the effect of off-center rotation and 0 values being inserted, as well as the behavior with this bugfix, is shown here:
![image](https://github.com/user-attachments/assets/0e444b0c-3007-415c-8dd2-effae050f383)


**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
