### PR TITLE
Report size marker warning message

### DIFF
--- a/docs/report_size_marker.md
+++ b/docs/report_size_marker.md
@@ -47,7 +47,7 @@ image = pcv.report_size_marker_area(img=img1, roi=roi, marker='detect',
                                     thresh=120)
 
 # Access data stored out from report_size_marker_area
-marker_area = pcv.outputs.observations['marker']['marker_area']['value']
+marker_area = pcv.outputs.metadata['marker_area']['value']
 
 # Scale length & area Outputs collected downstream
 # by updating size scaling parameters

--- a/plantcv/plantcv/report_size_marker_area.py
+++ b/plantcv/plantcv/report_size_marker_area.py
@@ -2,7 +2,7 @@
 import cv2
 import numpy as np
 import os
-from plantcv.plantcv import params, outputs, fatal_error, apply_mask
+from plantcv.plantcv import params, outputs, fatal_error, apply_mask, warn
 from plantcv.plantcv.threshold import binary as binary_threshold
 from plantcv.plantcv._debug import _debug
 from plantcv.plantcv._helpers import _cv2_findcontours, _object_composition, _roi_filter, _rgb2hsv
@@ -97,40 +97,40 @@ def report_size_marker_area(img, roi, marker='define', objcolor='dark', thresh_c
     # Calculate the marker area
     marker_area = m['m00']
 
-    # Fit a bounding ellipse to the marker
-    _, axes, _ = cv2.fitEllipse(marker_contour)
-    major_axis = np.argmax(axes)
-    minor_axis = 1 - major_axis
-    major_axis_length = axes[major_axis]
-    minor_axis_length = axes[minor_axis]
-    # Calculate the bounding ellipse eccentricity
-    eccentricity = np.sqrt(1 - (axes[minor_axis] / axes[major_axis]) ** 2)
+    if marker_contour > 1:
+        # Fit a bounding ellipse to the marker
+        _, axes, _ = cv2.fitEllipse(marker_contour)
+        major_axis = np.argmax(axes)
+        minor_axis = 1 - major_axis
+        major_axis_length = axes[major_axis]
+        minor_axis_length = axes[minor_axis]
+        # Calculate the bounding ellipse eccentricity
+        eccentricity = np.sqrt(1 - (axes[minor_axis] / axes[major_axis]) ** 2)
 
-    cv2.drawContours(ref_img, marker_contour, -1, (255, 0, 0), 5)
-    analysis_image = ref_img
+        cv2.drawContours(ref_img, marker_contour, -1, (255, 0, 0), 5)
+        analysis_image = ref_img
 
-    # Reset debug mode
-    params.debug = debug
+        # Reset debug mode
+        params.debug = debug
 
-    _debug(visual=ref_img,
-           filename=os.path.join(params.debug_outdir, str(params.device) + '_marker_shape.png'))
+        _debug(visual=ref_img,
+            filename=os.path.join(params.debug_outdir, str(params.device) + '_marker_shape.png'))
 
-    outputs.add_observation(sample=label, variable='marker_area', trait='marker area',
-                            method='plantcv.plantcv.report_size_marker_area', scale='pixels', datatype=int,
-                            value=marker_area, label='pixels')
-    outputs.add_observation(sample=label, variable='marker_ellipse_major_axis',
-                            trait='marker ellipse major axis length',
-                            method='plantcv.plantcv.report_size_marker_area', scale='pixels', datatype=int,
-                            value=major_axis_length, label='pixels')
-    outputs.add_observation(sample=label, variable='marker_ellipse_minor_axis',
-                            trait='marker ellipse minor axis length',
-                            method='plantcv.plantcv.report_size_marker_area', scale='pixels', datatype=int,
-                            value=minor_axis_length, label='pixels')
-    outputs.add_observation(sample=label, variable='marker_ellipse_eccentricity', trait='marker ellipse eccentricity',
-                            method='plantcv.plantcv.report_size_marker_area', scale='none', datatype=float,
-                            value=eccentricity, label='none')
+        # Store size marker values as metadata
+        outputs.add_metadata(term="marker_area", datatype=int, value=marker_area)
+        outputs.add_metadata(term="marker_ellipse_major_axis", datatype=int, value=major_axis_length)
+        outputs.add_metadata(term="marker_ellipse_minor_axis", datatype=int, value=minor_axis_length)
+        outputs.add_metadata(term="marker_ellipse_eccentricity", datatype=float, value=eccentricity)
 
-    # Store images
-    outputs.images.append(analysis_image)
+        return analysis_image
+    
+    else:
+        # Store size marker values as metadata
+        outputs.add_metadata(term="marker_area", datatype=str, value='none')
+        outputs.add_metadata(term="marker_ellipse_major_axis", datatype=str, value='none')
+        outputs.add_metadata(term="marker_ellipse_minor_axis", datatype=str, value='none')
+        outputs.add_metadata(term="marker_ellipse_eccentricity", datatype=str, value='none')
 
-    return analysis_image
+        warn("Size marker is not detectable.")
+
+


### PR DESCRIPTION
**Describe your changes**
A clear and concise description of what changes are made by this pull request.
What was the previous functionality (if relevant) and what can we do now with
these changes.

Changes report_size_marker to output as metadata instead of observations and to fail gracefully if size marker is not detected.

**Type of update**
Is this a:
* Bug fix
* **New feature or feature enhancement**
* Update to documentation
* Work in progress

**Associated issues**
Reference associated issue numbers. Does this pull request close any issues?
closes #1638 

**Additional context**
Add any other context about the problem here.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
