### PR TITLE
color card corners error

### DIFF
--- a/plantcv/plantcv/transform/detect_color_card.py
+++ b/plantcv/plantcv/transform/detect_color_card.py
@@ -156,6 +156,11 @@ def _color_card_detection(rgb_img, **kwargs):
     rect = cv2.minAreaRect(rect)
     # Get the corners of the rectangle
     corners = np.array(np.intp(cv2.boxPoints(rect)))
+    # Check that corners are in image
+    dim = np.shape(imgray)
+    for pt in corners:
+        if pt[0] > dim[1] or pt[1] > dim[0]:
+            fatal_error('Color card corners could not be detected accurately')
     # Determine which corner most likely contains the white chip
     white_index = np.argmin([np.mean(math.dist(rgb_img[corner[1], corner[0], :], (255, 255, 255))) for corner in corners])
     corners = corners[np.argsort([math.dist(corner, corners[white_index]) for corner in corners])[[0, 1, 3, 2]]]


### PR DESCRIPTION
**Describe your changes**
Adding a `fatal_error` if the corners of the color card are outside of the image as seen in #1606 and mentioned in #1610

**Type of update**
Is this a feature enhancement

**Associated issues**
Closes #1610

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
