### PR TITLE
Update kmeans inputs

### DIFF
--- a/plantcv/plantcv/kmeans_classifier.py
+++ b/plantcv/plantcv/kmeans_classifier.py
@@ -10,16 +10,21 @@ from plantcv.plantcv._helpers import _logical_operation
 
 
 def predict_kmeans(img, model_path="./kmeansout.fit", patch_size=10):
-    """
-    Uses a trained, patch-based kmeans clustering model to predict clusters from an input image.
-    Inputs:
-    img = An image on which to predict clusters
-    model_path = Path to directory where the trained model output is stored
-    patch_size = Size of the NxN neighborhood around each pixel
-    :param img: numpy.ndarray
-    :param model_path: str
-    :param patch_size: positive non-zero integer
-    :return labeled: numpy.ndarray
+    """Uses a trained, patch-based kmeans clustering model to predict clusters from an input image.
+
+    Parameters
+    ----------
+    img : numpy.ndarray
+        An image on which to predict clusters
+    model_path : str, optional
+        Path to directory where the trained model output is stored, by default "./kmeansout.fit"
+    patch_size : int, optional
+        Size of the NxN neighborhood around each pixel, by default 10
+
+    Returns
+    -------
+    numpy.ndarray
+        An labeled mask with the predicted clusters
     """
     kmeans = load(model_path)
     train_img = img.copy()
@@ -54,18 +59,22 @@ def predict_kmeans(img, model_path="./kmeansout.fit", patch_size=10):
 
 
 def mask_kmeans(labeled_img, k, cat_list=None):
-    """
-    Uses the predicted clusters from a target image to generate a binary mask.
-    Inputs:
-    labeled_img = An image with predicted clusters
-    K = Number of clusters to fit
-    patch_size = Size of the NxN neighborhood around each pixel
-    cat_list = A list of the numeric classes for composing a combined mask.
-               If empty, function prints all classes as separate masks.
-    :param labeled_img: numpy.ndarray
-    :param K: positive non-zero integer
-    :param patch_size: positive non-zero integer
-    :param cat_list: list of positive non-zero integers
+    """Uses the predicted clusters from a target image to generate a binary mask.
+
+    Parameters
+    ----------
+    labeled_img : numpy.ndarray
+        An labeled mask with the predicted clusters
+    k : int
+        The number of clusters
+    cat_list : list, optional
+        A list of the numeric classes for composing a combined mask, by default None
+        If empty, function prints all classes as separate masks
+
+    Returns
+    -------
+    numpy.ndarray
+        A binary mask with the specified clusters
     """
     if cat_list is None:
         mask_dict = {}

--- a/plantcv/plantcv/kmeans_classifier.py
+++ b/plantcv/plantcv/kmeans_classifier.py
@@ -2,7 +2,6 @@
 
 import os
 import numpy as np
-import plantcv.plantcv as pcv
 from joblib import load
 from plantcv.plantcv._debug import _debug
 from plantcv.plantcv import params
@@ -23,7 +22,7 @@ def predict_kmeans(img, model_path="./kmeansout.fit", patch_size=10):
     :return labeled: numpy.ndarray
     """
     kmeans = load(model_path)
-    train_img, _, _ = pcv.readimage(img)
+    train_img = img.copy()
 
     before = after = int((patch_size - 1)/2)   # odd
     if patch_size % 2 == 0:   # even

--- a/tests/plantcv/test_kmeans_classifier.py
+++ b/tests/plantcv/test_kmeans_classifier.py
@@ -1,30 +1,61 @@
+import cv2
+import os
 from plantcv.plantcv.kmeans_classifier import mask_kmeans
 from plantcv.plantcv.kmeans_classifier import predict_kmeans
-from plantcv.plantcv import readimage
 
 
-def test_kmeans_classifier(test_data):
+def test_predict_kmeans_classifier(test_data):
     """Test for PlantCV."""
     input_dir = test_data.kmeans_classifier_dir
-    input_dir_gray = test_data.kmeans_classifier_gray_dir
-    labeled_img = predict_kmeans(img=input_dir+"/test_image.jpg", model_path=input_dir+"/kmeans_out.fit", patch_size=4)
-    labeled_img_gray = predict_kmeans(img=input_dir_gray+"/test_image_gray.jpg",
-                                      model_path=input_dir_gray+"/kmeans_out_gray.fit", patch_size=4)
-    test_labeled, _, _ = readimage(input_dir+"/labeled_image.png")
-    test_labeled_gray, _, _ = readimage(input_dir_gray+"/labeled_image_gray.png")
+    rgb_img = cv2.imread(os.path.join(input_dir, "test_image.jpg"), -1)
+    labeled_img = predict_kmeans(img=rgb_img, model_path=os.path.join(input_dir, "kmeans_out.fit"), patch_size=4)
+    test_labeled = cv2.imread(os.path.join(input_dir, "labeled_image.png"), -1)
     assert (labeled_img == test_labeled).all()
+
+
+def test_predict_kmeans_classifier_gray(test_data):
+    """Test for PlantCV."""
+    input_dir_gray = test_data.kmeans_classifier_gray_dir
+    gray_img = cv2.imread(os.path.join(input_dir_gray, "test_image_gray.jpg"), -1)
+    labeled_img_gray = predict_kmeans(img=gray_img, model_path=os.path.join(input_dir_gray, "kmeans_out_gray.fit"),
+                                      patch_size=4)
+    test_labeled_gray = cv2.imread(os.path.join(input_dir_gray, "labeled_image_gray.png"), -1)
     assert (labeled_img_gray == test_labeled_gray).all()
 
+
+def test_mask_kmeans(test_data):
+    """Test for PlantCV."""
+    input_dir = test_data.kmeans_classifier_dir
+    labeled_img = cv2.imread(os.path.join(input_dir, "labeled_image.png"), -1)
     mask_dict = mask_kmeans(labeled_img=labeled_img, k=4)
+    for i in range(4):
+        test_labeled = cv2.imread(os.path.join(input_dir, f"label_example_{i}.png"), -1)
+        assert (test_labeled == mask_dict[str(i)]).all()
+
+
+def test_mask_kmeans_gray(test_data):
+    """Test for PlantCV."""
+    input_dir_gray = test_data.kmeans_classifier_gray_dir
+    labeled_img_gray = cv2.imread(os.path.join(input_dir_gray, "labeled_image_gray.png"), -1)
     mask_dict_gray = mask_kmeans(labeled_img=labeled_img_gray, k=4)
     for i in range(4):
-        assert (readimage(input_dir+"/label_example_"+str(i)+".png")[0] == mask_dict[str(i)]).all()
-    for i in range(4):
-        assert (readimage(input_dir_gray+"/label_example_gray_"+str(i)+".png")[0] == mask_dict_gray[str(i)]).all()
+        test_labeled_gray = cv2.imread(os.path.join(input_dir_gray, f"label_example_gray_{i}.png"), -1)
+        assert (test_labeled_gray == mask_dict_gray[str(i)]).all()
 
+
+def test_mask_kmeans_combo(test_data):
+    """Test for PlantCV."""
+    input_dir = test_data.kmeans_classifier_dir
+    labeled_img = cv2.imread(os.path.join(input_dir, "labeled_image.png"), -1)
     combo_mask = mask_kmeans(labeled_img=labeled_img, k=4, cat_list=[1, 2])
-    combo_mask_gray = mask_kmeans(labeled_img=labeled_img_gray, k=4, cat_list=[1, 2])
-    combo_example, _, _ = readimage(input_dir+"/combo_mask_example.png")
-    combo_example_gray, _, _ = readimage(input_dir_gray+"/combo_mask_example_gray.png")
+    combo_example = cv2.imread(os.path.join(input_dir, "combo_mask_example.png"), -1)
     assert (combo_mask == combo_example).all()
+
+
+def test_mask_kmeans_combo_gray(test_data):
+    """Test for PlantCV."""
+    input_dir_gray = test_data.kmeans_classifier_gray_dir
+    labeled_img_gray = cv2.imread(os.path.join(input_dir_gray, "labeled_image_gray.png"), -1)
+    combo_mask_gray = mask_kmeans(labeled_img=labeled_img_gray, k=4, cat_list=[1, 2])
+    combo_example_gray = cv2.imread(os.path.join(input_dir_gray, "combo_mask_example_gray.png"), -1)
     assert (combo_mask_gray == combo_example_gray).all()


### PR DESCRIPTION
**Describe your changes**
Updates `predict_kmeans` to input a ndarray directly instead of reading from a file. Removes a circular import.

**Type of update**
Is this a: minor update

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
