### PR TITLE
Hough circle regional filter

### DIFF
--- a/docs/roi_auto_wells.md
+++ b/docs/roi_auto_wells.md
@@ -1,6 +1,6 @@
 ## Autodetect Cicular Regions of Interest (ROI) 
 
-**plantcv.roi.auto_wells**(*gray_img, mindist, candec, accthresh, minradius, maxradius, nrows, ncols, radiusadjust=None*)
+**plantcv.roi.auto_wells**(*gray_img, mindist, candec, accthresh, minradius, maxradius, nrows, ncols, radiusadjust=None, roi=None*)
 
 **returns** roi_objects
 
@@ -14,6 +14,7 @@
     - nrows               = expected number of rows
     - ncols               = expected number of columns
     - radiusadjust        = amount to adjust the average radius, this can be desirable if you want ROI to sit inside a well, for example (in that case you might set it to a negative value).
+	- roi                 = Optional rectangular ROI as returned by [`pcv.roi.rectangle`](roi_rectangle.md) to detect wells within a given region.
 - **Context:**
     - Uses a Hough Circle detector to find circular shapes, then uses a gaussian mixture model to sort found circular objects so they are ordered from 
     top left to bottom right. We assume that circles are of approximately equal size because we calculate an average radius of all of the found circles.

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -953,6 +953,7 @@ pages for more details on the input and output variable types.
 
 * pre v4.6: NA
 * post v4.6: roi_objects = **pcv.roi.auto_wells**(*gray_img, mindist, candec, accthresh, minradius, maxradius, nrows, ncols, radiusadjust=None*)
+* post v4.9: roi_objects = **pcv.roi.auto_wells**(*gray_img, mindist, candec, accthresh, minradius, maxradius, nrows, ncols, radiusadjust=None, roi=None*)
 
 #### plantcv.roi.multi
 

--- a/plantcv/plantcv/roi/roi_methods.py
+++ b/plantcv/plantcv/roi/roi_methods.py
@@ -11,6 +11,7 @@ from plantcv.plantcv import color_palette
 from plantcv.plantcv._helpers import _cv2_findcontours
 from plantcv.plantcv._helpers import _roi_filter
 from plantcv.plantcv._helpers import _hough_circle
+from plantcv.plantcv._helpers import _rect_filter, _rect_replace
 from plantcv.plantcv import fatal_error, warn, params, Objects
 
 
@@ -527,7 +528,7 @@ def multi(img, coord, radius=None, spacing=None, nrows=None, ncols=None):
     return roi_objects
 
 
-def auto_wells(gray_img, mindist, candec, accthresh, minradius, maxradius, nrows, ncols, radiusadjust=None):
+def auto_wells(gray_img, mindist, candec, accthresh, minradius, maxradius, nrows, ncols, radiusadjust=None, roi=None):
     """Hough Circle Well Detection.
 
     Keyword inputs:
@@ -542,6 +543,7 @@ def auto_wells(gray_img, mindist, candec, accthresh, minradius, maxradius, nrows
     radiusadjust = amount to adjust the average radius, this can be desirable
     if you want ROI to sit inside a well, for example (in that case you might
     set it to a negative value).
+    roi = optional rectangular ROI to find wells within.
 
     :param gray_img: np.ndarray
     :param mindist: int
@@ -551,12 +553,25 @@ def auto_wells(gray_img, mindist, candec, accthresh, minradius, maxradius, nrows
     :param maxradius: int
     :param nrows = int
     :param ncols = int
+    :param roi = plantcv.plantcv.classes.Objects
     :return roi: plantcv.plantcv.classes.Objects
     """
     # Use hough circle helper function
     maxfind = nrows * ncols
-    df, img = _hough_circle(gray_img, mindist, candec, accthresh, minradius,
-                            maxradius, maxfind)
+    df, sub_img = _rect_filter(gray_img, roi, _hough_circle,
+                               **{"mindist": mindist, "candec": candec,
+                               "accthresh": accthresh, "minradius": minradius,
+                               "maxradius": maxradius, "maxfound": maxfind})
+    # cast gray image to color
+    cimg = cv2.cvtColor(gray_img, cv2.COLOR_GRAY2BGR)
+    # slice ROI back into original image
+    img = _rect_replace(cimg, sub_img, roi)
+    # adjust data.frame x/y points to match full scale image if ROI was used
+    if roi is not None:
+        xstart = roi.contours[0][0][0][0][0].astype("int32")
+        ystart = roi.contours[0][0][0][0][1].astype("int32")
+        df['x'] = df['x'] + xstart
+        df['y'] = df['y'] + ystart
 
     _debug(img, filename=os.path.join(params.debug_outdir, str(params.device) + '_roi_houghcircle.png'), cmap='gray')
 

--- a/plantcv/plantcv/roi/roi_methods.py
+++ b/plantcv/plantcv/roi/roi_methods.py
@@ -560,8 +560,8 @@ def auto_wells(gray_img, mindist, candec, accthresh, minradius, maxradius, nrows
     maxfind = nrows * ncols
     df, sub_img = _rect_filter(gray_img, roi, _hough_circle,
                                **{"mindist": mindist, "candec": candec,
-                               "accthresh": accthresh, "minradius": minradius,
-                               "maxradius": maxradius, "maxfound": maxfind})
+                                  "accthresh": accthresh, "minradius": minradius,
+                                  "maxradius": maxradius, "maxfound": maxfind})
     # cast gray image to color
     cimg = cv2.cvtColor(gray_img, cv2.COLOR_GRAY2BGR)
     # slice ROI back into original image

--- a/tests/plantcv/roi/test_roi.py
+++ b/tests/plantcv/roi/test_roi.py
@@ -181,6 +181,16 @@ def test_auto_wells(test_data):
     assert len(rois.hierarchy) == 24
 
 
+def test_auto_wells_in_region(test_data):
+    """Test for PlantCV."""
+    img = cv2.imread(test_data.hough_circle, -1)
+    roi_cont = [np.array([[[50, 50]], [[50, 499]], [[399, 499]], [[399, 50]]], dtype=np.int32)]
+    roi_str = np.array([[[-1, -1, -1, -1]]], dtype=np.int32)
+    rect = Objects(contours=[roi_cont], hierarchy=[roi_str])
+    rois = auto_wells(img, 20, 50, 30, 40, 50, 4, 6, -10, roi=rect)
+    assert len(rois.hierarchy) == 12
+    
+
 def test_multi_input_coords(roi_test_data):
     """Test for PlantCV."""
     # Read in test RGB image


### PR DESCRIPTION
Added regional filtering to `pcv.roi.auto_wells` per [1753](https://github.com/danforthcenter/plantcv/issues/1753).

Minimal example syntax:
```
import cv2
import numpy as np
from plantcv import plantcv as pcv 
%matplotlib widget
pcv.params.debug = "plot"
img = cv2.imread("/home/josh/plantcv/tests/testdata/circle-wells.png", -1)
rois = pcv.roi.auto_wells(img, 20, 50, 30, 40, 50, 4, 6, -10)
rect = pcv.roi.rectangle(img, x=50, y =50, h=450,  w=350)
print(rect.contours)
rois2 = pcv.roi.auto_wells(img, 20, 50, 30, 40, 50, 4, 6, -10, roi=rect)
```

This is a new feature or feature enhancement and should close [1753](https://github.com/danforthcenter/plantcv/issues/1753)

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
