### PR TITLE
Add `num_acute_pts` outputs observation to `homology.acute`

### DIFF
--- a/docs/homology_acute.md
+++ b/docs/homology_acute.md
@@ -30,6 +30,9 @@ landmark cluster edges, and angle score for entire contour.  Used in troubleshoo
     - Use `pcv.params.verbose = False` to quiet print statements
 - **Example use:**
     - [Use In Homology Tutorial](https://github.com/danforthcenter/plantcv-homology-tutorials/blob/main/README.md)
+- **Output data stored:** Data ('num_acute_pts') automatically
+gets stored to the [`Outputs` class](outputs.md) when this function is ran. These data can always get accessed during a
+workflow (example below). For more detail about data output see [Summary of Output Observations](output_measurements.md#summary-of-output-observations)
 
 **Original image**
 
@@ -45,12 +48,15 @@ from plantcv import plantcv as pcv
 
 # Set global debug behavior to None (default), "print" (to file), 
 # or "plot" (Jupyter Notebooks or X11)
-
 pcv.params.debug = "plot"
+# Optionally, set a sample label name
+pcv.params.sample_label = "plant"
 
 # Given an image, mask, and object contours, identify pseudo-landmarks with acute
-
 homolog_pts, start_pts, stop_pts, ptvals, chain, max_dist = pcv.homology.acute(img=img, mask=mask, win=25, threshold=90)
+
+# Access data stored in outputs
+num_pts = pcv.outputs.observations['plant']['num_acute_pts']['value']
 
 ```
 

--- a/docs/output_measurements.md
+++ b/docs/output_measurements.md
@@ -156,7 +156,7 @@ Functions that automatically store data to the [`Outputs` class](outputs.md) are
 [analyze.thermal](analyze_thermal.md), 
 [analyze.yii](analyze_yii.md), 
 [analyze.npq](analyze_npq.md), 
-[homology.acute](homology_landmark_reference_pt_dist.md), 
+[homology.acute](homology_acute.md), 
 [homology.landmark_reference_pt_dist](homology_landmark_reference_pt_dist.md), 
 [homology.x_axis_pseudolandmarks](homology_x_axis_pseudolandmarks.md), 
 [homology.y_axis_pseudolandmarks](homology_y_axis_pseudolandmarks.md), 
@@ -174,8 +174,9 @@ Functions that automatically store data to the [`Outputs` class](outputs.md) are
 [report_size_marker_area](report_size_marker.md), 
 [transform.find_color_card](find_color_card.md), 
 [transform.detect_color_card](transform_detect_color_card.md)
-[watershed_segmentation](watershed.md), and
-[within_frame](within_frame.md).
+[watershed_segmentation](watershed.md), 
+[within_frame](within_frame.md), and
+[watershed](watershed.md).
 
 All of these functions include an optional `label` parameter 
 that allows users to append custom prefixes to the unique variable identifier. 

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -18,14 +18,25 @@ functions:
 * `analyze.spectral_index`
 * `analyze.spectral_reflectance`
 * `analyze.yii`
-* `report_size_marker_area`
+* `homology.acute` 
+* `homology.landmark_reference_pt_dist`
+* `homology.x_axis_pseudolandmarks`
+* `homology.y_axis_pseudolandmarks`
+* `morphology.analyze_stem`
 * `morphology.check_cycles`
 * `morphology.euclidean_length`
+* `morphology.fill_segments`
+* `morphology.find_tips`
+* `morphology.find_branch_pts`
 * `morphology.segment_angle`
 * `morphology.segment_curvature`
+* `morphology.segment_euclidean_length`
 * `morphology.segment_insertion_angle`
 * `morphology.segment_path_length`
 * `morphology.segment_tangent_angle` 
+* `report_size_marker_area`
+* `transform.detect_color_card`
+* `transform.auto_correct_color`
 * `within_frame`
 * `watershed`
 

--- a/plantcv/plantcv/homology/acute.py
+++ b/plantcv/plantcv/homology/acute.py
@@ -3,12 +3,12 @@
 import numpy as np
 import math
 import cv2
-from plantcv.plantcv import params
+from plantcv.plantcv import params, outputs
 from plantcv.plantcv._debug import _debug
 from plantcv.plantcv._helpers import _cv2_findcontours, _object_composition
 
 
-def acute(img, mask, win, threshold):
+def acute(img, mask, win, threshold, label=None):
     """Identify landmark positions within a contour for morphometric analysis
 
     Inputs:
@@ -18,6 +18,8 @@ def acute(img, mask, win, threshold):
                   score; 1 cm in pixels often works well
     threshold   = angle score threshold to be applied for mapping out landmark
                   coordinate clusters within each contour
+    label       = Optional label parameter, modifies the variable name of
+                  observations recorded (default = pcv.params.sample_label).
 
     Outputs:
     homolog_pts    = pseudo-landmarks selected from each landmark cluster
@@ -42,6 +44,10 @@ def acute(img, mask, win, threshold):
     :return chain: list
     :return max_dist: list
     """
+     # Set lable to params.sample_label if None
+    if label is None:
+        label = params.sample_label
+
     # Find contours
     contours, hierarchy = _cv2_findcontours(bin_img=mask)
     obj = _object_composition(contours=contours, hierarchy=hierarchy)
@@ -195,6 +201,12 @@ def acute(img, mask, win, threshold):
         cv2.drawContours(ori_img, homolog_pts, -1, (255, 255, 255), params.line_thickness)
         # print/plot debug image
         _debug(visual=ori_img, filename=f"{params.device}_acute_plms.png")
+        outputs.add_observation(sample=label, variable='num_acute_pts', trait='number of acute points',
+                            method='plantcv.plantcv.homology.acute', scale='none', datatype=int,
+                            value=len(homolog_pts), label='none')
 
         return homolog_pts, start_pts, stop_pts, ptvals, chain, max_dist
+    outputs.add_observation(sample=label, variable='num_acute_pts', trait='number of acute points',
+                            method='plantcv.plantcv.homology.acute', scale='none', datatype=int,
+                            value=0, label='none')
     return [], [], [], [], [], []

--- a/plantcv/plantcv/homology/acute.py
+++ b/plantcv/plantcv/homology/acute.py
@@ -44,7 +44,7 @@ def acute(img, mask, win, threshold, label=None):
     :return chain: list
     :return max_dist: list
     """
-     # Set lable to params.sample_label if None
+    # Set lable to params.sample_label if None
     if label is None:
         label = params.sample_label
 
@@ -201,9 +201,10 @@ def acute(img, mask, win, threshold, label=None):
         cv2.drawContours(ori_img, homolog_pts, -1, (255, 255, 255), params.line_thickness)
         # print/plot debug image
         _debug(visual=ori_img, filename=f"{params.device}_acute_plms.png")
+        # Store number of acute points IDed to Outputs
         outputs.add_observation(sample=label, variable='num_acute_pts', trait='number of acute points',
-                            method='plantcv.plantcv.homology.acute', scale='none', datatype=int,
-                            value=len(homolog_pts), label='none')
+                                method='plantcv.plantcv.homology.acute', scale='none', datatype=int,
+                                value=len(homolog_pts), label='none')
 
         return homolog_pts, start_pts, stop_pts, ptvals, chain, max_dist
     outputs.add_observation(sample=label, variable='num_acute_pts', trait='number of acute points',

--- a/plantcv/plantcv/homology/landmark_reference_pt_dist.py
+++ b/plantcv/plantcv/homology/landmark_reference_pt_dist.py
@@ -98,29 +98,29 @@ def landmark_reference_pt_dist(points_r, centroid_r, bline_r, label=None):
     ang_ave_b = np.mean(angles_b)
 
     outputs.add_observation(sample=label, variable='vert_ave_c', trait='average vertical distance from centroid',
-                            method='plantcv.plantcv.landmark_reference_pt_dist', scale='pixels', datatype=float,
+                            method='plantcv.plantcv.homology.landmark_reference_pt_dist', scale='pixels', datatype=float,
                             value=vert_ave_c, label='pixels')
     outputs.add_observation(sample=label, variable='hori_ave_c', trait='average horizontal distance from centeroid',
-                            method='plantcv.plantcv.landmark_reference_pt_dist', scale='pixels', datatype=float,
+                            method='plantcv.plantcv.homology.landmark_reference_pt_dist', scale='pixels', datatype=float,
                             value=hori_ave_c, label='pixels')
     outputs.add_observation(sample=label, variable='euc_ave_c', trait='average euclidean distance from centroid',
-                            method='plantcv.plantcv.landmark_reference_pt_dist', scale='pixels', datatype=float,
+                            method='plantcv.plantcv.homology.landmark_reference_pt_dist', scale='pixels', datatype=float,
                             value=euc_ave_c, label='pixels')
     outputs.add_observation(sample=label, variable='ang_ave_c',
                             trait='average angle between landmark point and centroid',
-                            method='plantcv.plantcv.landmark_reference_pt_dist', scale='degrees', datatype=float,
+                            method='plantcv.plantcv.homology.landmark_reference_pt_dist', scale='degrees', datatype=float,
                             value=ang_ave_c, label='degrees')
     outputs.add_observation(sample=label, variable='vert_ave_b', trait='average vertical distance from baseline',
-                            method='plantcv.plantcv.landmark_reference_pt_dist', scale='pixels', datatype=float,
+                            method='plantcv.plantcv.homology.landmark_reference_pt_dist', scale='pixels', datatype=float,
                             value=vert_ave_b, label='pixels')
     outputs.add_observation(sample=label, variable='hori_ave_b', trait='average horizontal distance from baseline',
-                            method='plantcv.plantcv.landmark_reference_pt_dist', scale='pixels', datatype=float,
+                            method='plantcv.plantcv.homology.landmark_reference_pt_dist', scale='pixels', datatype=float,
                             value=hori_ave_b, label='pixels')
     outputs.add_observation(sample=label, variable='euc_ave_b', trait='average euclidean distance from baseline',
-                            method='plantcv.plantcv.landmark_reference_pt_dist', scale='pixels', datatype=float,
+                            method='plantcv.plantcv.homology.landmark_reference_pt_dist', scale='pixels', datatype=float,
                             value=euc_ave_b, label='pixels')
     outputs.add_observation(sample=label, variable='ang_ave_b',
                             trait='average angle between landmark point and baseline',
-                            method='plantcv.plantcv.landmark_reference_pt_dist', scale='degrees', datatype=float,
+                            method='plantcv.plantcv.homology.landmark_reference_pt_dist', scale='degrees', datatype=float,
                             value=ang_ave_b, label='degrees')
     return None

--- a/plantcv/plantcv/homology/x_axis_pseudolandmark.py
+++ b/plantcv/plantcv/homology/x_axis_pseudolandmark.py
@@ -219,13 +219,13 @@ def x_axis_pseudolandmarks(img, mask, label=None):
         center_v_list.append(pt[0].tolist())
 
     outputs.add_observation(sample=label, variable='top_lmk', trait='top landmark coordinates',
-                            method='plantcv.plantcv.x_axis_pseudolandmarks', scale='none', datatype=tuple,
+                            method='plantcv.plantcv.homology.x_axis_pseudolandmarks', scale='none', datatype=tuple,
                             value=tuple(top_list), label='none')
     outputs.add_observation(sample=label, variable='bottom_lmk', trait='bottom landmark coordinates',
-                            method='plantcv.plantcv.x_axis_pseudolandmarks', scale='none', datatype=tuple,
+                            method='plantcv.plantcv.homology.x_axis_pseudolandmarks', scale='none', datatype=tuple,
                             value=tuple(bottom_list), label='none')
     outputs.add_observation(sample=label, variable='center_v_lmk', trait='center vertical landmark coordinates',
-                            method='plantcv.plantcv.x_axis_pseudolandmarks', scale='none', datatype=tuple,
+                            method='plantcv.plantcv.homology.x_axis_pseudolandmarks', scale='none', datatype=tuple,
                             value=tuple(center_v_list), label='none')
 
     return top, bottom, center_v

--- a/plantcv/plantcv/homology/y_axis_pseudolandmarks.py
+++ b/plantcv/plantcv/homology/y_axis_pseudolandmarks.py
@@ -216,13 +216,13 @@ def y_axis_pseudolandmarks(img, mask, label=None):
         center_h_list.append(pt[0].tolist())
 
     outputs.add_observation(sample=label, variable='left_lmk', trait='left landmark coordinates',
-                            method='plantcv.plantcv.x_axis_pseudolandmarks', scale='none', datatype=tuple,
+                            method='plantcv.plantcv.homology.x_axis_pseudolandmarks', scale='none', datatype=tuple,
                             value=tuple(left_list), label='none')
     outputs.add_observation(sample=label, variable='right_lmk', trait='right landmark coordinates',
-                            method='plantcv.plantcv.x_axis_pseudolandmarks', scale='none', datatype=tuple,
+                            method='plantcv.plantcv.homology.x_axis_pseudolandmarks', scale='none', datatype=tuple,
                             value=tuple(right_list), label='none')
     outputs.add_observation(sample=label, variable='center_h_lmk', trait='center horizontal landmark coordinates',
-                            method='plantcv.plantcv.x_axis_pseudolandmarks', scale='none', datatype=tuple,
+                            method='plantcv.plantcv.homology.x_axis_pseudolandmarks', scale='none', datatype=tuple,
                             value=tuple(center_h_list), label='none')
 
     return left, right, center_h

--- a/tests/plantcv/homology/test_acute.py
+++ b/tests/plantcv/homology/test_acute.py
@@ -12,7 +12,7 @@ def test_acute(win, exp, homology_test_data):
     # Read in test data
     img = cv2.imread(homology_test_data.small_rgb_img)
     mask = cv2.imread(homology_test_data.small_bin_img, -1)
-    homology_pts, _, _, _, _, _ = acute(img=img, mask=mask, win=win, threshold=15)
+    homology_pts, _, _, _, _, _ = acute(img=img, mask=mask, win=win, threshold=15, label="plant")
     params.debug = None
     assert len(homology_pts) == exp
 


### PR DESCRIPTION
**Describe your changes**
Add `num_acute_pts` outputs observation to `pcv.homology.acute`

**Type of update**
Is this a:
* feature enhancement
* Work in progress

**Associated issues**
- closes #1754 

**Additional context**
A power user would need to add a custom observation if they are interested in saving the actual coordinates returned by this function `homolog_pts`. Making an output CSV with variable number of coordinates per object analyzed is [messy](https://github.com/danforthcenter/plantcv/pull/1652). 

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
