### PR TITLE
Filepath metadata

### DIFF
--- a/docs/pipeline_parallel.md
+++ b/docs/pipeline_parallel.md
@@ -89,6 +89,10 @@ Valid metadata that can be collected from filenames (basenames) are `camera`, `i
 `lifter`, `timestamp`, `id`, `barcode`, `treatment`, `cartag`, `measurementlabel`, and `other`. Additionally, the file path starting from
 the `input_dir` can be used as `filepath` or individual components of it as `filepath{1:N}`, which may be useful for regex based filtering.
 
+Note that if a `metadata.json` or `SnapshotInfo.csv` file exists in your `config.input_dir` directory then that file will be used to supply
+metadata instead of any parsing specified in the `metadata` key. If one of those files exists the `filepath` and `filepath{1:N}` keys are
+still available to filter your data.
+
 To correctly process timestamps, you need to specify the timestamp format (`timestampformat` configuration
 parameter) code for the
 [strptime C library](https://docs.python.org/3.7/library/datetime.html#strftime-and-strptime-behavior).

--- a/docs/pipeline_parallel.md
+++ b/docs/pipeline_parallel.md
@@ -85,8 +85,9 @@ AABA002948_2014-03-14 03-29-45_Pilot-031014_VIS_TV_z3500.png
 
 **Valid Metadata**
 
-Valid metadata that can be collected from filenames are `camera`, `imgtype`, `zoom`, `exposure`, `gain`, `frame`, `rotation`,
-`lifter`, `timestamp`, `id`, `barcode`, `treatment`, `cartag`, `measurementlabel`, and `other`.
+Valid metadata that can be collected from filenames (basenames) are `camera`, `imgtype`, `zoom`, `exposure`, `gain`, `frame`, `rotation`,
+`lifter`, `timestamp`, `id`, `barcode`, `treatment`, `cartag`, `measurementlabel`, and `other`. Additionally, the file path starting from
+the `input_dir` can be used as `filepath` or individual components of it as `filepath{1:N}`, which may be useful for regex based filtering.
 
 To correctly process timestamps, you need to specify the timestamp format (`timestampformat` configuration
 parameter) code for the
@@ -110,6 +111,7 @@ Sample image filename: `cam1_16-08-06-16:45_el1100s1_p19.jpg`
     "imgformat": "jpg",
     "delimiter": "_",
     "metadata_filters": {"camera": "cam1"},
+	"metadata_regex": {},
     "timestampformat": "%y-%m-%d-%H:%M",
     "writeimg": true,
     "other_args": {},
@@ -186,6 +188,7 @@ in a list to the `filename_metadata` parameter.
     "imgformat": "jpg",
     "delimiter": '(.{3})_(.+)_(\d{4}-\d{2}-\d{2} \d{2}_\d{2}_\d{2})',
     "metadata_filters": {},
+	"metadata_regex": {},
     "timestampformat": "%Y-%m-%d %H_%M_%S",
     "writeimg": true,
     "other_args": {},
@@ -212,6 +215,15 @@ in a list to the `filename_metadata` parameter.
 
 If you need help building a regular expression, https://regexr.com/ is a useful site to help build and interpret
 patterns. Also feel free to post an [issue](https://github.com/danforthcenter/plantcv/issues).
+
+#### Using a pattern matching-based filename metadata filter
+
+Regex patterns can be supplied as dictionaries to the `metadata_regex` key of the configuration json.
+
+The `filepath` key will search for a regex pattern anywhere in the absolute path to an image.
+The `filepath1` key will search for a regex pattern in the first directory starting from the `input_dir`.
+Additional keys up to `filepathN` (the max depth directory containing an image in `input_dir`) are available.
+
 
 #### Grouping images for multi-image workflows
 

--- a/plantcv/parallel/__init__.py
+++ b/plantcv/parallel/__init__.py
@@ -27,6 +27,7 @@ class WorkflowConfig:
         self.imgformat = "png"
         self.delimiter = "_"
         self.metadata_filters = {}
+        self.metadata_regex = {}
         self.timestampformat = "%Y-%m-%dT%H:%M:%S.%fZ"
         self.writeimg = False
         self.other_args = {}

--- a/plantcv/parallel/parsers.py
+++ b/plantcv/parallel/parsers.py
@@ -140,7 +140,7 @@ def _apply_metadata_filters(df, config):
     # if there are regex filters then find the True indicies for each and only return those from the merged dataframe
     if bool(config.metadata_regex):
         for key, value in config.metadata_regex.items():
-            bools = np.array([bool(re.search(value, x)) for x in df[key]])
+            bools = [bool(re.search(value, x)) for x in df[key]]
             df = df.loc[bools]
     return df
 ###########################################
@@ -307,9 +307,9 @@ def _parse_filepath(df, config):
     :return meta2: pandas.dataframe
     """
     # remove extraneous config.input_dir from file path
-    df["filepath"] = df["filepath"].map(lambda st: st.replace(config.input_dir, ""))
+    paths_after_input = df["filepath"].map(lambda st: st.replace(config.input_dir, ""))
     path_metadata = []
-    for i, fp in enumerate(df["filepath"]):
+    for i, fp in enumerate(paths_after_input):
         # for every file path, split it and add the elements to a list
         splits = fp.split(os.sep)
         path_metadata.append(splits[0:len(splits) - 1])

--- a/tests/parallel/test_cli.py
+++ b/tests/parallel/test_cli.py
@@ -47,6 +47,7 @@ def test_parallel_cli_valid_config(parallel_test_data, tmpdir):
     config.input_dir = parallel_test_data.flat_imgdir
     config.json = conf_file.dirpath().join(os.path.basename(parallel_test_data.new_results_file)).strpath
     config.filename_metadata = ["imgtype", "camera", "frame", "zoom", "lifter", "gain", "exposure", "id"]
+    config.metadata_regex = {"filepath":".*"}
     config.workflow = parallel_test_data.workflow_script
     config.img_outdir = str(conf_file.dirpath())
     config.tmp_dir = str(conf_file.dirpath() / "tmp")


### PR DESCRIPTION
**Describe your changes**
Adding file path (not basename) regex based metadata filtering for parallel workflows run with a configuration json file.

This adds a new step to `metadata_parser` with the `_parse_filepath` helper, which splits the filename into several additional columns named `filepath{1:N}` (we index on 1 in this house so help me). A new `metadata_regex` key is added to the config json file and used after the standard metadata_filter inner join to subset the dataframe to only include matches.
There is also some additional context about metadata parsed from filenames vs metadata.json/SnapshotInfo.csv files added to the parallel pipeline docs.

**Type of update**
Is this a new feature or feature enhancement.

**Associated issues**
This closes [issue 1757](https://github.com/danforthcenter/plantcv/issues/1757).

**Additional context**
The docs are sort of complicated. I think we all read them in slightly different patterns/end up on different pages. I could totally have missed important stuff to include or other points to clarify and I'd be happy to make more changes there if anyone has insights.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
