### PR TITLE
update FAQ to mention color standardization

### DIFF
--- a/docs/analysis_approach.md
+++ b/docs/analysis_approach.md
@@ -54,6 +54,7 @@ downstream image processing steps like thresholding to be the same between image
 * Normalizing color across a dataset using a reference
 color card with [color correction](https://plantcv.org/tutorials/color-correction) is highly recommended, especially when color analysis is one 
 of the analysis objectives. See the [detect color card documentation](transform_detect_color_card.md) for more detail.
+* Supported color cards can also be used to automatically size scale measurements (from pixels to millimeters and millimeters<sup>2</sup>) recorded by PlantCV. 
 
 #####Object Segmentation Approaches
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -47,7 +47,10 @@ and [updating documentation](documentation.md).
     a [practical guide](https://doi.org/10.1071/FP12028)
     on growth conditions by Poorter et al. (2012),
     or a [glossary and general advice](https://doi.org/10.1242/dev.076414)
-    by Roeder et al. (2012).
+    by Roeder et al. (2012). Normalizing color across a dataset using a reference
+    color card with [color correction](https://plantcv.org/tutorials/color-correction) is highly recommended,
+    especially when color analysis is one of the analysis objectives. See the
+    [detect color card documentation](transform_detect_color_card.md) for more detail.
 - Q: Can I use PlantCV to process photos taken with a Raspberry Pi camera?
     - A: Yes.
     <!-- This is related to the previous question. -->

--- a/docs/transform_detect_color_card.md
+++ b/docs/transform_detect_color_card.md
@@ -27,6 +27,8 @@ Automatically detects a Macbeth ColorChecker style color card and creates a labe
     - If the goal is to color correct the image colorspace to the standard color card values, consider using [`pcv.transform.auto_correct_color`](transform_auto_correct_color.md) since this new function is a one-step wrapper of plantcv.transform.detect_color_card, [plantcv.transform.std_color_matrix](std_color_matrix.md),
     and [plantcv.transform.affine_color_correction](transform_affine_color_correction.md).
     - This mask output will be consistent in chip order regardless of orientation, where the white chip is detected and labeled first with index=0.
+    - This algorithm uses an adaptive edge detection, and filters objects based on their size, apparent aspect ratio, and solidity.
+    - QR codes are often falsely detected by this algorithm, but can be ignored during detection if the optional `roi` parameter is used.
 - **Example use:**
     - [Color Correction Tutorial](https://plantcv.org/tutorials/color-correction) since this function is called during [`pcv.transform.auto_correct_color`](transform_auto_correct_color.md). 
 

--- a/docs/transform_detect_color_card.md
+++ b/docs/transform_detect_color_card.md
@@ -34,7 +34,7 @@ Automatically detects a Macbeth ColorChecker style color card and creates a labe
 
 !!! note
     Color chip size can only be used reasonably as a scaling factor (converting pixels to a known real world scale like cms)
-    only when the color card is on a consistent plane relative to the subject AND the color card is parallel to the camera. 
+    only when the color card is on a consistent plane relative to the subject AND the color card is parallel to the camera. It's a good idea to test your image capture protocol and color card detection before collecting a dataset.
     There are a few important assumptions that must be met in order to automatically detect color cards:
     
     - There is only one color card in the image.


### PR DESCRIPTION
Add some context to documentation page `transform_detect_color_card.md` and add mention of color standardization to the `faq.md`. Added size standardization mention to `analysis_approach.md`. 

**Type of update**
- Update to documentation

**Associated issues**
- Closes #1675

**Additional context**
- Color cards are the way that we recommend to do size and color standardization of images within a dataset. We've added recent functionality to help with quality control for inaccurate detection. Detection of color cards is sensitive to other objects in the image such (e.g. calculator buttons and tape grids and additional color cards). Understanding how the detection algorithm works will hopefully prevent some known issues from being introduced during image capture protocol. Best practice is to test the image capture protocol and validate no problems with color card detection. 

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
