### PR TITLE
Adapt patch_extract function for rgba imgs in train_kmeans.py

### DIFF
--- a/plantcv/learn/train_kmeans.py
+++ b/plantcv/learn/train_kmeans.py
@@ -83,6 +83,9 @@ def patch_extract(img, patch_size=10, sigma=5, sampling=None, seed=1):
         img_blur = np.round(gaussian(img, sigma=sigma)*255).astype(np.uint16)
     elif len(img.shape) == 3 and img.shape[2] == 3:
         img_blur = np.round(gaussian(img, sigma=sigma, channel_axis=2)*255).astype(np.uint16)
+    elif len(img.shape) == 3 and img.shape[2] == 4: #rgb with alpha
+        img = img[:,:,:3] #removes alpha channel
+        img_blur = np.round(gaussian(img, sigma=sigma, channel_axis=2)*255).astype(np.uint16)
 
     # Extract patches
     patches = image.extract_patches_2d(img_blur, (patch_size, patch_size),


### PR DESCRIPTION
**Describe your changes**
Adds an elif statement that addresses rgba images
The alpha channel is removed before applying gaussian blur

**Type of update**
* Bug fix

**Associated issues**
#1749 

**Additional context**

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
