### PR TITLE
Use a self-hosted image for testing

### DIFF
--- a/tests/plantcv/io/test_open_url.py
+++ b/tests/plantcv/io/test_open_url.py
@@ -13,6 +13,6 @@ def test_open_url():
 
 def test_open_url_unsupported():
     """PlantCV Test"""
-    url = "https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif"
+    url = "https://datasci.danforthcenter.org/test.gif"
     with pytest.raises(RuntimeError):
         _ = open_url(url=url)


### PR DESCRIPTION
**Describe your changes**
One of the tests for `open_url` uses a GIF hosted at Wikipedia and the test now fails. I suspect we were accessing the image programmatically enough that we were blocked. This PR changes to a self-hosted synthetic GIF image.

**Type of update**
Is this a: Bug fix

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
