### PR TITLE
Metadata inspection

### DIFF
--- a/docs/parallel_inspect_config.md
+++ b/docs/parallel_inspect_config.md
@@ -1,0 +1,28 @@
+## Inspect data for a parallel workflow configuration
+
+### inspect_dataset
+
+Once you have a [`WorkflowConfig` class object](parallel_config.md), or at the very least an input directory of image data, you may want to check which and how many images would be used running that workflow. This can be helpful in troubleshooting metadata filters among other configuration options.
+
+**plantcv.parallel.inspect_dataset**(*config*)
+
+**returns** summary_df, df
+	- summary_df shows whether images were kept and if not where they why they were removed (status column) then groups images by status and any metadata from `config.metadata_filters` and returns how many unique values each term has and what they are (if there are 3 or fewer unique values).
+	- df shows all the images collected by the workflow, including the same status information as in summary_df.
+
+
+- **Parameters:**
+	- config - Plantcv.parallel.WorkflowConfig object or str. String input should be a filepath to be used in place of `config.input_dir`. Note that there are several useful defaults expected from a `WorkflowConfig` object, so results from using just a file path may be less detailed.
+- **Context:**
+	- Used to check what would be collected by a given workflow configuration.
+- **Example use:**
+	- See below
+
+```python
+from plantcv import parallel as pcvpar
+
+config = pcvpar.WorkflowConfig()
+config.input_dir("./my_images")
+
+summary, meta = pcvpar.inspect_dataset(config)
+```

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -789,6 +789,36 @@ pages for more details on the input and output variable types.
 * pre v3.12: NA
 * post v3.12: **plantcv.outputs.save_results**(*filename, outformat="json"*)
 
+#### plantcv.parallel.create_dask_cluster
+
+* pre v4.10: Untracked
+* post v4.10: **plantcv.parallel.create_dask_cluster**(*config, cluster_config*)
+
+#### plantcv.parallel.inspect_dataset
+
+* pre v4.10: NA
+* post v4.10: **plantcv.parallel.inspect_dataset**(*config*)
+
+#### plantcv.parallel.job_builder
+
+* pre v4.10: Untracked
+* post v4.10: **plantcv.parallel.job_builder**(*meta, config*)
+
+#### plantcv.parallel.metadata_parser
+
+* pre v4.10: Untracked
+* post 4.10: **plantcv.parallel.metadata_parser**(*config*)
+
+#### plantcv.parallel.multiprocess
+
+* pre v4.10: Untracked
+* post v4.10: **plantcv.parallel.multiprocess**(*jobs, client*)
+
+#### plantcv.parallel.workflow_inputs
+
+* pre v4.10: Untracked
+* post v4.10: **plantcv.parallel.workflow_inputs**(*\*other_args*)
+
 #### plantcv.photosynthesis.analyze_fvfm
 
 * pre v3.10: see plantcv.fluor_fvfm

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -225,6 +225,7 @@ nav:
       - 'Naive Bayes Multiclass': naive_bayes_multiclass.md
     - 'Parallelization':
         - 'Configure Parallelization': parallel_config.md
+        - 'Inspect Configuration': parallel_inspect_config.md
         - 'Workflow Inputs Management': parallel_workflow_inputs.md
         - 'Metadata Parser': parallel_metadata_parser.md
         - 'Job Builder': parallel_job_builder.md

--- a/plantcv/parallel/__init__.py
+++ b/plantcv/parallel/__init__.py
@@ -3,6 +3,7 @@ import sys
 import json
 import datetime
 from plantcv.parallel.parsers import metadata_parser
+from plantcv.parallel.inspect_dataset import inspect_dataset
 from plantcv.parallel.job_builder import job_builder
 from plantcv.parallel.process_results import process_results
 from plantcv.parallel.multiprocess import multiprocess

--- a/plantcv/parallel/__init__.py
+++ b/plantcv/parallel/__init__.py
@@ -10,7 +10,7 @@ from plantcv.parallel.multiprocess import multiprocess
 from plantcv.parallel.multiprocess import create_dask_cluster
 from plantcv.parallel.workflow_inputs import workflow_inputs, WorkflowInputs
 
-__all__ = ["metadata_parser", "job_builder", "process_results", "multiprocess", "create_dask_cluster", "WorkflowConfig",
+__all__ = ["metadata_parser", "inspect_dataset", "job_builder", "process_results", "multiprocess", "create_dask_cluster", "WorkflowConfig",
            "workflow_inputs", "WorkflowInputs"]
 
 

--- a/plantcv/parallel/cli.py
+++ b/plantcv/parallel/cli.py
@@ -87,7 +87,7 @@ def main():
     ###########################################
     parser_start_time = time.time()
     print("Reading image metadata...", file=sys.stderr)
-    meta = plantcv.parallel.metadata_parser(config=config)
+    meta, _ = plantcv.parallel.metadata_parser(config=config)
     parser_clock_time = time.time() - parser_start_time
     print(f"Reading image metadata took {parser_clock_time} seconds.", file=sys.stderr)
     ###########################################

--- a/plantcv/parallel/inspect_dataset.py
+++ b/plantcv/parallel/inspect_dataset.py
@@ -1,0 +1,33 @@
+import pandas as pd
+from plantcv.parallel import WorkflowConfig
+
+
+def inspect_dataset(config):
+    """Inspect a dataset before running plantcv in parallel over the directory
+    Parameters
+    ----------
+    config   = plantcv.parallel.WorkflowConfig object or str, if string then this should be the input directory path.
+
+    Returns = pandas.core.frame.DataFrame, dataframe of image metadata.
+    -------
+    """
+    # if config is a path then make a config out of it
+    if isinstance(config, str):
+        input_dir = config
+        config = WorkflowConfig()
+        config.input_dir = input_dir
+    # run the metadata parser to find images and return dataframes
+    meta, removed = metadata_parser(config)
+    # make dataframe out of groupby object
+    meta = meta.apply(lambda x: x, include_groups=False)
+    # flag kept images
+    meta["status"] = "Kept"
+    # combine both dataframes
+    df = pd.concat([meta, removed])
+    return df
+
+
+def _summarize_dataset(df):
+    """
+    """
+    return(df)

--- a/plantcv/parallel/inspect_dataset.py
+++ b/plantcv/parallel/inspect_dataset.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from plantcv.parallel import WorkflowConfig
+from plantcv.parallel.workflow_inputs import WorkflowConfig
 
 
 def inspect_dataset(config):

--- a/plantcv/parallel/inspect_dataset.py
+++ b/plantcv/parallel/inspect_dataset.py
@@ -6,30 +6,11 @@ def inspect_dataset(config):
     """Inspect a dataset before running plantcv in parallel over the directory
     Parameters
     ----------
-    config   = plantcv.parallel.WorkflowConfig object or str, if string then this should be the input directory path.
+    config   = plantcv.parallel.WorkflowConfig object
 
     Returns = pandas.core.frame.DataFrame, dataframe of image metadata.
     -------
     """
-    # if config is a path then make a config out of it
-    # NOTE i can't just grab WorkflowConfig from parallel because I can't
-    # export this while with parallel while that workflowconfig class is defined
-    # in that __init__.py file.
-    if isinstance(config, str):
-        input_dir = config
-        # if there is no config file then make a cheap copy
-        config = type('dummyconfig', (), {'input_dir': input_dir,
-                                          'filename_metadata': ["filepath"],
-                                          'include_all_subdirs':True,
-                                          'metadata_terms': {'timestamp'},
-                                          'metadata_filters':{},
-                                          'timestampformat':"%Y-%m-%dT%H:%M:%S.%fZ",
-                                          'start_date': None,
-                                          'end_date': None,
-                                          'imgformat':"png",
-                                          'delimiter':'&&&',
-                                          'groupby':'filepath'
-                                          })
     # run the metadata parser to find images and return dataframes
     meta, removed = metadata_parser(config)
     # make dataframe out of groupby object

--- a/plantcv/parallel/inspect_dataset.py
+++ b/plantcv/parallel/inspect_dataset.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from plantcv.parallel.workflow_inputs import WorkflowConfig
+from plantcv.parallel.parsers import metadata_parser
 
 
 def inspect_dataset(config):
@@ -12,14 +12,32 @@ def inspect_dataset(config):
     -------
     """
     # if config is a path then make a config out of it
+    # NOTE i can't just grab WorkflowConfig from parallel because I can't
+    # export this while with parallel while that workflowconfig class is defined
+    # in that __init__.py file.
     if isinstance(config, str):
         input_dir = config
-        config = WorkflowConfig()
-        config.input_dir = input_dir
+        # if there is no config file then make a cheap copy
+        config = type('dummyconfig', (), {'input_dir': input_dir,
+                                          'filename_metadata': ["filepath"],
+                                          'include_all_subdirs':True,
+                                          'metadata_terms': {'timestamp'},
+                                          'metadata_filters':{},
+                                          'timestampformat':"%Y-%m-%dT%H:%M:%S.%fZ",
+                                          'start_date': None,
+                                          'end_date': None,
+                                          'imgformat':"png",
+                                          'delimiter':'&&&',
+                                          'groupby':'filepath'
+                                          })
     # run the metadata parser to find images and return dataframes
     meta, removed = metadata_parser(config)
     # make dataframe out of groupby object
+    meta_filepaths = []
+    for i, _ in meta["filepath"]:
+        meta_filepaths.append(i[0])
     meta = meta.apply(lambda x: x, include_groups=False)
+    meta["filepath"] = meta_filepaths
     # flag kept images
     meta["status"] = "Kept"
     # combine both dataframes

--- a/plantcv/parallel/inspect_dataset.py
+++ b/plantcv/parallel/inspect_dataset.py
@@ -1,32 +1,98 @@
 import pandas as pd
-from plantcv.parallel.parsers import metadata_parser
+import os
+from plantcv.parallel.parsers import metadata_parser, _read_dataset
 
 
 def inspect_dataset(config):
     """Inspect a dataset before running plantcv in parallel over the directory
     Parameters
     ----------
-    config   = plantcv.parallel.WorkflowConfig object
+    config   = plantcv.parallel.WorkflowConfig object or str, if str then very minimal processing is done
 
-    Returns = pandas.core.frame.DataFrame, dataframe of image metadata.
+    Returns
     -------
+    summary_df     = pandas.core.frame.DataFrame,
+        dataframe of number of unique values of metadata filters and statuses.
+    meta     = pandas.core.frame.DataFrame, dataframe of image metadata.
     """
-    # run the metadata parser to find images and return dataframes
-    meta, removed = metadata_parser(config)
-    # make dataframe out of groupby object
-    meta_filepaths = []
-    for i, _ in meta["filepath"]:
-        meta_filepaths.append(i[0])
-    meta = meta.apply(lambda x: x, include_groups=False)
-    meta["filepath"] = meta_filepaths
+    if isinstance(config, str):
+        input_dir = config
+        config = type('inspectionconfig', (), {'input_dir':input_dir,
+                                               'imgformat':'png',
+                                               'include_all_subdirs':True,
+                                               'delimiter':'_',
+                                               'filename_metadata': ["filepath"],
+                                               'metadata_filters':{},
+                                               'metadata_terms':{'filepath'}
+                                               })
+        dataset = _read_dataset(config)
+        meta = _naive_dataset2dataframe(dataset, config)
+        removed = pd.DataFrame()
+    else:
+        # run the metadata parser to find images and return dataframes
+        meta, removed = metadata_parser(config)
+        # make dataframe out of groupby object
+        meta_filepaths = []
+        for i, _ in meta["filepath"]:
+            meta_filepaths.append(i[0])
+        meta = meta.apply(lambda x: x, include_groups=False)
+        meta["filepath"] = meta_filepaths
     # flag kept images
     meta["status"] = "Kept"
     # combine both dataframes
-    df = pd.concat([meta, removed])
+    if not removed.empty:
+        meta = pd.concat(df.dropna(axis=1, how='all') for df in [meta, removed])
+    # pull extensions
+    meta['extension'] = meta['filepath'].apply(
+        lambda x: os.path.splitext(os.path.basename(x))[1]
+    )
+    # count unique values by all filtered metadata and steps where images were dropped
+    summary_df = meta.groupby(
+        ['status', *config.metadata_filters],
+        dropna = False
+    ).agg(_agg_unique_values)
+    return summary_df, meta
+
+
+def _naive_dataset2dataframe(dataset, config):
+    """Convert a dataset to a dataframe with little additional information.
+    Parameters
+    ----------
+    dataset = dict, metadata dictionary as returned by plantcv.parallel.parsers._read_dataset
+
+    Return
+    ------
+    meta    = pandas.DataFrame, metadata dataframe
+    """
+    metadata = {
+        "filepath": []
+    }
+    for image in dataset["images"]:
+        metadata["filepath"].append(os.path.join(config.input_dir, image))
+    df = pd.DataFrame(data=metadata)
     return df
 
 
-def _summarize_dataset(df):
+def _agg_unique_values(series):
+    """Aggregate columns to a number of unique values and possibly their values
+    Parameters
+    ----------
+    series     = pandas.core.series.Series, a metadata column of a pandas dataframe
+
+    Return
+    ------
+    label      = str, a string describing the number of unique values and their
+                 observed levels if there are <4.
     """
-    """
-    return(df)
+    n_unique = series.nunique()
+    context = ""
+    if n_unique:
+        context = " (...)"
+    series = series.astype("string")
+    # if there are only a few options then print what they are
+    if n_unique and n_unique < 4:
+        uniques = series.dropna().unique()
+        unique_vals = ", ".join(uniques)
+        context = " (" + unique_vals + ")"
+    label = str(n_unique) + context
+    return label

--- a/plantcv/parallel/parsers.py
+++ b/plantcv/parallel/parsers.py
@@ -27,7 +27,7 @@ def metadata_parser(config):
     meta = _dataset2dataframe(dataset=dataset, config=config)
 
     # Apply user-supplied metadata filters
-    meta = _apply_metadata_filters(df=meta, config=config)
+    meta, removed_df = _apply_metadata_filters(df=meta, config=config)
 
     # Apply user-supplied date range filters
     meta = _apply_date_range_filter(df=meta, config=config)

--- a/plantcv/parallel/parsers.py
+++ b/plantcv/parallel/parsers.py
@@ -109,17 +109,15 @@ def _dataset2dataframe(dataset, config):
 ###########################################
 def _apply_metadata_filters(df, config):
     """Apply filters to metadata.
-
-    Keyword arguments:
-    df = metadata dataframe
+    Parameters
+    ----------
+    df = pandas.core.frame.Dataframe, metadata dataframe
     config = plantcv.parallel.WorkflowConfig object
 
-    Outputs:
-    filtered_df = filtered metadata dataframe
-
-    :param df: pandas.core.frame.DataFrame
-    :param config: plantcv.parallel.WorkflowConfig
-    :return filtered_df: pandas.core.frame.DataFrame
+    Returns:
+    --------
+    filtered_df = pandas.core.frame.Dataframe, filtered metadata dataframe
+    removed_df  = pandas.core.frame.Dataframe, metadata dataframe of what was removed
     """
     # Convert all metadata filter values to a list type
     for term in config.metadata_filters:

--- a/plantcv/parallel/parsers.py
+++ b/plantcv/parallel/parsers.py
@@ -134,8 +134,11 @@ def _apply_metadata_filters(df, config):
     # If there are no filters provide the metadata_filter dataframe will be empty and we can return the input dataframe
     if not metadata_filter.empty:
         filtered_df = df.merge(metadata_filter, how="inner")
-        return filtered_df
-    return df
+        outer = df.merge(metadata_filter, how='outer', indicator=True)
+        removed_df = outer[(outer._merge=='left_only')].drop('_merge', axis=1)
+        removed_df["status"] = "Removed by config.metadata_filters"
+        return filtered_df, removed_df
+    return df, pd.DataFrame()
 ###########################################
 
 

--- a/tests/parallel/test_inspect_config.py
+++ b/tests/parallel/test_inspect_config.py
@@ -1,0 +1,26 @@
+import pytest
+from plantcv.parallel import inspect_dataset, WorkflowConfig
+
+
+def test_inspect_dataset(parallel_test_data):
+    """Test for PlantCV
+    Testing inspection for config files
+    """
+    # initialize config
+    config = WorkflowConfig()
+    config.input_dir = parallel_test_data.flat_imgdir
+    config.imgformat = "jpg"
+    # inspect dataset
+    sdf, df = inspect_dataset(config)
+
+    assert sdf.shape == (1, 18) and df.shape == (2, 19)
+
+
+def test_inspect_dataset_string(parallel_test_data):
+    """Test for PlantCV
+    Testing inspection for config files
+    """
+    # initialize config
+    sdf, df = inspect_dataset(parallel_test_data.flat_imgdirconfig)
+    # nothing found because default is png imgformat
+    assert sdf.shape == (0, 2) and df.shape == (0, 3)


### PR DESCRIPTION
**Describe your changes**
Adding a metadata inspection tool to inspect a configuration file before running a workflow in parallel, `plantcv.parallel.inspect_dataset`. It can also take a filepath but with reduced functionality.

`inspect_dataset` returns two dataframes, the first is a summary of what steps removed images and what was removed in each step, the second is the un-summarized dataframe of what images were found, their metadata, and whether or not they were kept and would go to your workflow.

**Type of update**
This is a new feature.

**Associated issues**
Closes #1788 

**Additional context**
We had at least two different goals brought up about this feature. My thought was that it is mostly to check a configuration file before running something in parallel, @kmurphy61 and some other people might want a more general use tool to do broader file exploration.

There are a few places where this is a little clunky so far, most obvious to me being what it does if there is a `metadata.json` or `SnapshotInfo.csv` file. In those cases I sort of think it could do nothing and that would be fine. I think this will also be more useful after changes from [PR 1774](https://github.com/danforthcenter/plantcv/pull/1774) and [PR 1776](https://github.com/danforthcenter/plantcv/pull/1776) allowing for multiple imgformats and defaulting to all image formats, respectively.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
