### PR TITLE
Add higher order `auto_correct_color` for non-linear 

### DIFF
--- a/plantcv/plantcv/transform/__init__.py
+++ b/plantcv/plantcv/transform/__init__.py
@@ -21,9 +21,10 @@ from plantcv.plantcv.transform.checkerboard_calib import checkerboard_calib, cal
 from plantcv.plantcv.transform.merge_images import merge_images
 from plantcv.plantcv.transform.auto_correct_color import auto_correct_color
 from plantcv.plantcv.transform.detect_color_card import mask_color_card
+from plantcv.plantcv.transform.auto_correct_color import auto_correct_color_nonlinear
 
 __all__ = ["get_color_matrix", "get_matrix_m", "calc_transformation_matrix", "apply_transformation_matrix",
            "save_matrix", "load_matrix", "correct_color", "create_color_card_mask", "quick_color_check",
            "find_color_card", "std_color_matrix", "affine_color_correction", "rescale", "nonuniform_illumination", "resize",
            "resize_factor", "warp", "rotate", "warp", "warp_align", "gamma_correct", "detect_color_card", "checkerboard_calib",
-           "calibrate_camera", "merge_images", "auto_correct_color", "mask_color_card"]
+           "calibrate_camera", "merge_images", "auto_correct_color", "mask_color_card", "auto_correct_color_nonlinear"]

--- a/plantcv/plantcv/transform/auto_correct_color.py
+++ b/plantcv/plantcv/transform/auto_correct_color.py
@@ -2,7 +2,7 @@
 
 from plantcv.plantcv import params, deprecation_warning
 from plantcv.plantcv.transform.detect_color_card import detect_color_card
-from plantcv.plantcv.transform.color_correction import get_color_matrix, std_color_matrix, affine_color_correction
+from plantcv.plantcv.transform.color_correction import get_color_matrix, std_color_matrix, affine_color_correction, calc_transformation_matrix, get_matrix_m
 
 
 def auto_correct_color(rgb_img, label=None, color_chip_size=None, roi=None, **kwargs):
@@ -44,3 +44,39 @@ def auto_correct_color(rgb_img, label=None, color_chip_size=None, roi=None, **kw
     std_matrix = std_color_matrix(pos=3)
     return affine_color_correction(rgb_img=rgb_img, source_matrix=card_matrix,
                                    target_matrix=std_matrix)
+
+
+def auto_correct_color_nonlinear(rgb_img, label=None, color_chip_size=None, roi=None, **kwargs):
+    """Automatically detect a color card and applies non-linear color correction
+    Parameters
+    ----------
+    rgb_img : numpy.ndarray
+        Input RGB image data containing a color card.
+    label : str, optional
+        modifies the variable name of observations recorded (default = pcv.params.sample_label).
+    color_chip_size: str, tuple, optional
+        "passport", "classic", "cameratrax"; or tuple formatted (width, height)
+        in millimeters (default = None)
+    roi: plantcv.plantcv.Objects, optional
+        Objects class rectangular ROI passed to detect_color_card (default None)
+    **kwargs
+        Other keyword arguments passed to cv2.adaptiveThreshold, cv2.circle and _rect_filter.
+        Valid keyword arguments:
+        adaptive_method: 0 (mean) or 1 (Gaussian) (default = 1)
+        block_size: int (default = 51)
+        radius: int (default = 20)
+        min_size: int (default = 1000)
+        aspect_ratio: float (default = 1.27)
+        solidity: float (default = 0.8)
+    Returns
+    -------
+    numpy.ndarray
+        Color corrected image
+    """
+    labeled_mask = detect_color_card(rgb_img=rgb_img, color_chip_size=color_chip_size, roi=roi, **kwargs)
+    _, card_matrix = get_color_matrix(rgb_img=rgb_img, mask=labeled_mask)
+    std_matrix = std_color_matrix(pos=3)
+    _, matrix_m, matrix_b = get_matrix_m(target_matrix=std_matrix, source_matrix=card_matrix)
+    # calculate transformation_matrix and save
+    _, transformation_matrix = calc_transformation_matrix(matrix_m, matrix_b)
+    return 

--- a/plantcv/plantcv/transform/auto_correct_color.py
+++ b/plantcv/plantcv/transform/auto_correct_color.py
@@ -2,8 +2,14 @@
 
 from plantcv.plantcv import params, deprecation_warning
 from plantcv.plantcv.transform.detect_color_card import detect_color_card
-from plantcv.plantcv.transform.color_correction import get_color_matrix, std_color_matrix, affine_color_correction, calc_transformation_matrix, get_matrix_m
-
+from plantcv.plantcv.transform.color_correction import (
+    apply_transformation_matrix,
+    get_color_matrix,
+    std_color_matrix,
+    affine_color_correction,
+    calc_transformation_matrix,
+    get_matrix_m,
+)
 
 def auto_correct_color(rgb_img, label=None, color_chip_size=None, roi=None, **kwargs):
     """Automatically detect a color card.
@@ -79,4 +85,6 @@ def auto_correct_color_nonlinear(rgb_img, label=None, color_chip_size=None, roi=
     _, matrix_m, matrix_b = get_matrix_m(target_matrix=std_matrix, source_matrix=card_matrix)
     # calculate transformation_matrix and save
     _, transformation_matrix = calc_transformation_matrix(matrix_m, matrix_b)
-    return 
+    # apply non-linear color transformation to the input image
+    corrected = apply_transformation_matrix(source_img=rgb_img, transformation_matrix=transformation_matrix)
+    return corrected

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -334,19 +334,17 @@ def calc_transformation_matrix(matrix_m, matrix_b):
     return 1-t_det, transformation_matrix
 
 
-def apply_transformation_matrix(source_img, target_img, transformation_matrix):
+def apply_transformation_matrix(source_img, transformation_matrix):
     """Apply the transformation matrix to the source_image.
 
     Inputs:
     source_img      = an RGB image to be corrected to the target color space
-    target_img      = an RGB image with the target color space
     transformation_matrix        = a 9x9 matrix of transformation coefficients
 
     Outputs:
     corrected_img    = an RGB image in correct color space
 
     :param source_img: numpy.ndarray
-    :param target_img: numpy.ndarray
     :param transformation_matrix: numpy.ndarray
     :return corrected_img: numpy.ndarray
     """
@@ -396,7 +394,7 @@ def apply_transformation_matrix(source_img, target_img, transformation_matrix):
 
     # For debugging, create a horizontal view of source_img, corrected_img, and target_img to the plotting device
     # plot horizontal comparison of source_img, corrected_img (with rounded elements) and target_img
-    out_img = np.hstack([source_img, corrected_img, target_img])
+    out_img = np.hstack([source_img, corrected_img])
     # Change range of visualization image to 0-255 and convert to uin8
     out_img = ((255.0/max_val)*out_img).astype(np.uint8)
     _debug(visual=out_img, filename=os.path.join(params.debug_outdir, str(params.device) + '_corrected.png'))

--- a/plantcv/plantcv/transform/color_correction.py
+++ b/plantcv/plantcv/transform/color_correction.py
@@ -489,7 +489,7 @@ def correct_color(target_img, target_mask, source_img, source_mask, output_direc
     save_matrix(transformation_matrix, os.path.join(output_directory, "transformation_matrix.npz"))
 
     # apply transformation
-    corrected_img = apply_transformation_matrix(source_img, target_img, transformation_matrix)
+    corrected_img = apply_transformation_matrix(source_img, transformation_matrix)
 
     return target_matrix, source_matrix, transformation_matrix, corrected_img
 

--- a/tests/plantcv/transform/test_auto_correct_color.py
+++ b/tests/plantcv/transform/test_auto_correct_color.py
@@ -1,7 +1,7 @@
 """Tests for auto_correct_color."""
 import numpy as np
 import cv2
-from plantcv.plantcv.transform import auto_correct_color
+from plantcv.plantcv.transform import auto_correct_color, auto_correct_color_nonlinear
 from plantcv.plantcv import Objects
 
 
@@ -21,4 +21,12 @@ def test_auto_correct_color_subset(transform_test_data):
     roi_str = np.array([[[-1, -1, -1, -1]]], dtype=np.int32)
     roi_obj = Objects(contours=[roi], hierarchy=[roi_str])
     corrected_img = auto_correct_color(rgb_img=rgb_img, roi=roi_obj)
+    assert np.shape(corrected_img) == np.shape(rgb_img) and np.sum(corrected_img) != np.sum(rgb_img)
+
+
+def test_auto_correct_color_nonaffine(transform_test_data):
+    """Test for PlantCV."""
+    # Load rgb image
+    rgb_img = cv2.imread(transform_test_data.colorcard_img)
+    corrected_img = auto_correct_color_nonlinear(rgb_img=rgb_img)
     assert np.shape(corrected_img) == np.shape(rgb_img) and np.sum(corrected_img) != np.sum(rgb_img)

--- a/tests/plantcv/transform/test_color_correction.py
+++ b/tests/plantcv/transform/test_color_correction.py
@@ -181,9 +181,8 @@ def test_apply_transformation(transform_test_data):
     # read in matrices
     matrix_t = transform_test_data.load_npz(transform_test_data.transformation_matrix_file)
     # read in images
-    target_img = cv2.imread(transform_test_data.target_img)
     source_img = cv2.imread(transform_test_data.source1_img)
-    corrected_img = apply_transformation_matrix(source_img, target_img, matrix_t)
+    corrected_img = apply_transformation_matrix(source_img, matrix_t)
     # assert source and corrected have same shape
     assert np.array_equal(corrected_img, corrected_compare)
 
@@ -193,10 +192,9 @@ def test_apply_transformation_incorrect_t(transform_test_data):
     # read in matrices
     matrix_t = transform_test_data.load_npz(transform_test_data.matrix_b1_file)
     # read in images
-    target_img = cv2.imread(transform_test_data.target_img)
     source_img = cv2.imread(transform_test_data.source1_img)
     with pytest.raises(RuntimeError):
-        _ = apply_transformation_matrix(source_img, target_img, matrix_t)
+        _ = apply_transformation_matrix(source_img, matrix_t)
 
 
 def test_apply_transformation_incorrect_img(transform_test_data):
@@ -204,10 +202,9 @@ def test_apply_transformation_incorrect_img(transform_test_data):
     # read in matrices
     matrix_t = transform_test_data.load_npz(transform_test_data.transformation_matrix_file)
     # read in images
-    target_img = cv2.imread(transform_test_data.target_img)
     source_img = cv2.imread(transform_test_data.colorcard_mask, -1)
     with pytest.raises(RuntimeError):
-        _ = apply_transformation_matrix(source_img, target_img, matrix_t)
+        _ = apply_transformation_matrix(source_img, matrix_t)
 
 
 def test_save_matrix(transform_test_data, tmpdir):


### PR DESCRIPTION
**Describe your changes**
Makes a one-step color correction function for non-linear method

**Type of update**
Is this a:
* New feature 

**Associated issues**

**Additional context**
-be able to apply non-linear color correction without the need for a "target_img" 

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
