### PR TITLE
Bump Python versions to 3.11-3.13

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.11', '3.12', '3.13']
         os: [ubuntu-latest]
     env:
       OS: ${{ matrix.os }}
@@ -38,7 +38,7 @@ jobs:
         pip install .
         py.test --cov-report=xml --cov=./
     - name: Upload coverage to Deepsource
-      if: ${{ matrix.python-version == '3.11' }}
+      if: ${{ matrix.python-version == '3.13' }}
       uses: deepsourcelabs/test-coverage-action@master
       with:
         key: python


### PR DESCRIPTION
**Describe your changes**
Updates GitHub Actions CI workflow to test Python versions 3.11, 3.12, and 3.13.

**Type of update**
Is this a: update to supported Python versions

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
