### PR TITLE
Add image data classes

### DIFF
--- a/plantcv/data/__init__.py
+++ b/plantcv/data/__init__.py
@@ -1,0 +1,104 @@
+"""PlantCV data classes"""
+import numpy as np
+
+
+class Image(np.ndarray):
+    """Generic image class that extends the np.ndarray class."""
+
+    # From NumPy documentation
+    # Add uri attribute
+    def __new__(cls, input_array: np.ndarray, uri: str):
+        obj = np.asarray(input_array).view(cls)
+        # New attribute uri stores uniform resource identifier of the source file
+        obj.uri = uri
+        return obj
+
+    def __array_finalize__(self, obj):
+        if obj is not None:
+            self.uri = getattr(obj, "uri", None)
+
+    def __getitem__(self, key):
+        # Enhance the np.ndarray __getitem__ method
+        # Slice the array as requested but return an array of the same class
+        # Idea from NumPy examples of subclassing:
+        return super(Image, self).__getitem__(key)
+
+
+class GRAY(Image):
+    """Subclass of Image for grayscale images."""
+
+    def __new__(cls, input_array: np.ndarray, uri: str):
+        return Image.__new__(cls, input_array, uri)
+
+
+class BGR(Image):
+    """Subclass of Image for Blue, Green, Red (BGR) images."""
+
+    def __new__(cls, input_array: np.ndarray, uri: str):
+        return Image.__new__(cls, input_array, uri)
+
+    def __getitem__(self, key):
+        # Overwrite the __getitem__ method to return a GRAY object if the
+        # requested slice is 2D
+        new_arr = super(Image, self).__getitem__(key)
+        if len(new_arr.shape) == 2:
+            return GRAY(input_array=new_arr, uri=self.uri)
+        return new_arr
+
+
+class RGB(Image):
+    """Subclass of Image for Red, Green, Blue (RGB) images."""
+
+    def __new__(cls, input_array: np.ndarray, uri: str):
+        return Image.__new__(cls, input_array, uri)
+
+    def __getitem__(self, key):
+        # Overwrite the __getitem__ method to return a GRAY object if the
+        # requested slice is 2D
+        new_arr = super(Image, self).__getitem__(key)
+        if len(new_arr.shape) == 2:
+            return GRAY(input_array=new_arr, uri=self.uri)
+        return new_arr
+
+
+class HSI(Image):
+    """Subclass of Image for hyperspectral images."""
+
+    def __new__(cls, input_array: np.ndarray, uri: str, wavelengths: list, default_wavelengths: list,
+                wavelength_units: str = "nm"):
+        # Create an instance of Image with default attributes
+        obj = Image.__new__(cls, input_array, uri)
+        # Add HSI-specific attributes
+        obj.wavelengths = wavelengths
+        obj.wavelength_units = wavelength_units
+        obj.min_wavelength = np.min(wavelengths)
+        obj.max_wavelength = np.max(wavelengths)
+        obj.default_wavelengths = default_wavelengths
+        if default_wavelengths is None:
+            if obj.max_wavelength >= 635 and obj.min_wavelength <= 490:
+                obj.default_wavelengths = [480, 540, 710]
+            else:
+                obj.default_wavelengths = [wavelengths[np.argmax(np.sum(input_array, axis=(0, 1)))]]
+        return obj
+
+    def __init__(self, **kwargs):
+        self.thumb = self._create_thumb()
+
+    def get_wavelength(self, wavelength):
+        idx = np.abs(np.array(self.wavelengths) - wavelength).argmin()
+        obj = super(HSI, self).__getitem__(np.s_[:, :, idx])
+        obj.wavelengths = [self.wavelengths[idx]]
+        obj.min_wavelength = np.min(obj.wavelengths)
+        obj.max_wavelength = np.max(obj.wavelengths)
+        return obj
+
+    def _create_thumb(self):
+        if len(self.default_wavelengths) == 3:
+            thumb = BGR(input_array=np.dstack([self.get_wavelength(self.default_wavelengths[0]),
+                                               self.get_wavelength(self.default_wavelengths[1]),
+                                               self.get_wavelength(self.default_wavelengths[2])]),
+                        uri=self.uri)
+        else:
+            thumb = GRAY(input_array=self.get_wavelength(self.default_wavelengths[0]),
+                         uri=self.uri)
+        return thumb

--- a/tests/data/test_data_classes.py
+++ b/tests/data/test_data_classes.py
@@ -1,0 +1,78 @@
+import numpy as np
+from plantcv.data import Image, GRAY, BGR, RGB, HSI
+
+
+def test_image():
+    """Test creating an Image class image."""
+    img = Image(input_array=np.zeros((10, 10), dtype=np.uint8), uri="image.png")
+    assert isinstance(img, Image)
+
+
+def test_image_none():
+    """Test creating an Image class image."""
+    img = Image(input_array=None, uri=None)
+    assert isinstance(img, Image)
+
+
+def test_image_slice():
+    """Test subsetting an Image."""
+    img = Image(input_array=np.zeros((10, 10), dtype=np.uint8), uri="image.png")
+    assert img[0:5, 0:5].shape == (5, 5)
+
+
+def test_bgr():
+    """Test creating a BGR class image."""
+    bgr = BGR(input_array=np.zeros((10, 10, 3), dtype=np.uint8), uri="bgr.png")
+    assert isinstance(bgr, BGR)
+
+
+def test_bgr_slice():
+    """Test subsetting a BGR image."""
+    bgr = BGR(input_array=np.zeros((10, 10, 3), dtype=np.uint8), uri="bgr.png")
+    assert bgr[0:5, 0:5].shape == (5, 5, 3)
+
+
+def test_rgb():
+    """Test creating a RGB class image."""
+    bgr = RGB(input_array=np.zeros((10, 10, 3), dtype=np.uint8), uri="rgb.png")
+    assert isinstance(bgr, RGB)
+
+
+def test_rgb_slice():
+    """Test subsetting an RGB image."""
+    rgb = RGB(input_array=np.zeros((10, 10, 3), dtype=np.uint8), uri="rgb.png")
+    assert rgb[0:5, 0:5].shape == (5, 5, 3)
+
+
+def test_gray():
+    """Test creating a GRAY class image."""
+    gray = GRAY(input_array=np.zeros((10, 10), dtype=np.uint8), uri="gray.png")
+    assert isinstance(gray, GRAY)
+
+
+def test_bgr_to_gray():
+    """Test converting a BGR image to a GRAY image."""
+    bgr = BGR(input_array=np.zeros((10, 10, 3), dtype=np.uint8), uri="bgr.png")
+    gray = bgr[:, :, 0]
+    assert isinstance(gray, GRAY)
+
+
+def test_rgb_to_gray():
+    """Test converting a RGB image to a GRAY image."""
+    rgb = RGB(input_array=np.zeros((10, 10, 3), dtype=np.uint8), uri="rgb.png")
+    gray = rgb[:, :, 0]
+    assert isinstance(gray, GRAY)
+
+
+def test_hsi():
+    """Test creating an HSI class image."""
+    hsi = HSI(input_array=np.zeros((10, 10, 5), dtype=np.uint8), uri="hsi.data", wavelengths=[480, 540, 710, 800, 900],
+              default_wavelengths=None, wavelength_units="nm")
+    assert isinstance(hsi, HSI)
+
+
+def test_hsi_grayscale_thumb():
+    """Test creating an HSI class image."""
+    hsi = HSI(input_array=np.zeros((10, 10, 5), dtype=np.uint8), uri="hsi.data", wavelengths=[700, 800, 900],
+              default_wavelengths=None, wavelength_units="nm")
+    assert isinstance(hsi, HSI)


### PR DESCRIPTION
**Describe your changes**
Adds a `data` subpackage with classes for a generic `Image`, color images (`RGB` and `BGR`), grayscale (`GRAY`), and hyperspectral (`HSI`). Adds tests for initializing the classes. `Image` is a subclass of `numpy.ndarray` and the other classes are subclasses of `Image`. For the standard data types this mostly just adds a `uri` (unique resource identifier such as a file path, URL, etc.) attribute to the arrays. `HSI` replicates what we have done with `Spectral_data` but in a NumPy compatible framework.

**Type of update**
Is this a: New feature or feature enhancement

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
