### PR TITLE
Add emtpy mask handling within threshold.otsu 

### DIFF
--- a/plantcv/plantcv/threshold/threshold_methods.py
+++ b/plantcv/plantcv/threshold/threshold_methods.py
@@ -170,6 +170,11 @@ def otsu(gray_img, object_type="light"):
 
     params.device += 1
 
+    # If the grayscale image is all zeros, return copy of input image.
+    if np.count_nonzero(gray_img) == 0:
+        out = np.copy(gray_img)
+        return out
+
     # Threshold the image
     bin_img = _call_threshold(gray_img, 0, threshold_method, "_otsu_threshold_")
 

--- a/plantcv/plantcv/threshold/threshold_methods.py
+++ b/plantcv/plantcv/threshold/threshold_methods.py
@@ -172,8 +172,9 @@ def otsu(gray_img, object_type="light"):
 
     # If the grayscale image is all zeros, return copy of input image.
     if np.count_nonzero(gray_img) == 0:
-        out = np.copy(gray_img)
-        return out
+        bin_img = np.copy(gray_img)
+        _debug(visual=bin_img, filename=os.path.join(params.debug_outdir, f"{params.device}_otsu_empty.png"))
+        return bin_img
 
     # Threshold the image
     bin_img = _call_threshold(gray_img, 0, threshold_method, "_otsu_threshold_")

--- a/tests/plantcv/threshold/test_threshold_methods.py
+++ b/tests/plantcv/threshold/test_threshold_methods.py
@@ -255,3 +255,10 @@ def test_dual_channels_bad_channel():
     pts = [(0, 0), (255, 255)]
     with pytest.raises(RuntimeError):
         _ = dual_channels(img, x_channel='wrong_ch', y_channel='index', points=pts, above=True)
+
+def test_otsu_empty_mask():
+    """Test for PlantCV."""
+    mask = np.zeros((100, 100))
+    fmask = otsu(mask)
+    assert np.sum(fmask) == 0
+


### PR DESCRIPTION
**Describe your changes**
An empty mask np.zeros((100, 100)) without specifying dtype=np.uint8 fails and causes error. The bugfix returns the copy of original mask if its an empty mask.

**Type of update**
Is this a:
* Bug fix

**Associated issues**
Avoid fatal errors and instead just pass an empty mask as return #1742

**Additional context**
This is one part of the issues in #1742 and the fix is similar to #1811 

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
