### PR TITLE
Add empty mask handling within pcv.visualize.obj_size_ecdf

### DIFF
--- a/plantcv/plantcv/visualize/obj_size_ecdf.py
+++ b/plantcv/plantcv/visualize/obj_size_ecdf.py
@@ -27,6 +27,16 @@ def obj_size_ecdf(mask):
     # Remove objects with areas < 1px
     areas = [i for i in areas if i >= 1.0]
 
+    # If the mask is empty, return empty chart
+    if len(areas) == 0:
+        ecdf_df = pd.DataFrame({'object_area': [], 'cumulative_probability': []})
+        chart = alt.Chart(ecdf_df).mark_circle(size=10).encode(
+            x=alt.X("object area:Q").scale(type='log'),
+            y="cumulative probability:Q",
+            tooltip=['object area', 'cumulative probability']
+        )
+        return chart.interactive()
+
     ecdf = ECDF(areas, side='right')
 
     ecdf_df = pd.DataFrame({'object area': ecdf.x[1:], 'cumulative probability': ecdf.y[1:]})

--- a/tests/plantcv/visualize/test_obj_size_ecdf.py
+++ b/tests/plantcv/visualize/test_obj_size_ecdf.py
@@ -1,5 +1,7 @@
 """Tests for pcv.visualize.obj_size_ecdf."""
 import cv2
+import numpy as np
+import pandas as pd
 from altair.vegalite.v5.api import Chart
 from plantcv.plantcv.visualize import obj_size_ecdf
 
@@ -9,3 +11,11 @@ def test_obj_size_ecdf(visualize_test_data):
     mask = cv2.imread(visualize_test_data.small_bin_img, -1)
     fig_ecdf = obj_size_ecdf(mask=mask)
     assert isinstance(fig_ecdf, Chart)
+
+
+def test_obj_size_ecdf_empty_mask():
+    """Test for empty mask"""
+    mask = np.zeros((100, 100), dtype=np.uint8)
+    chart = obj_size_ecdf(mask=mask)
+    assert isinstance(chart.data, pd.DataFrame)
+    assert chart.data.shape[0] == 0


### PR DESCRIPTION
**Describe your changes**
An empty mask input to pcv.visualize.obj_size_ecdf returns an error. This change returns and empty chart if the input mask is empty.

**Type of update**
Is this a:
* Bug fix

**Associated issues**
Avoid fatal errors and instead just pass an empty mask as return #1742 

**Additional context**
Add any other context about the problem here.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
