### PR TITLE
Cap opencv version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - scikit-learn
   - dask
   - dask-jobqueue
-  - opencv
+  - opencv<=4.12.0
   - statsmodels
   - xarray>=2022.11.0
   - mkdocs


### PR DESCRIPTION
**Describe your changes**
New installations of PlantCV will get `opencv 4.13` which breaks automatic color card detection. We have a fix in v5.0 but until that is ready for release it seems simplest to cap the opencv version at `4.12.0`.

**Type of update**
This is a stopgap solution to a potential problem until v5 is released.

**Associated issues**
None, but see [tripsicum seed head tutorial](https://github.com/danforthcenter/plantcv-tutorial-tripsacum-seedhead/actions) for error from opencv 4.13.0

**Additional context**
Had a fix in [1871](https://github.com/danforthcenter/plantcv/pull/1871) pointed at v5 but may need to revisit.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
