### PR TITLE
1902 skimage change min size

### DIFF
--- a/plantcv/plantcv/fill.py
+++ b/plantcv/plantcv/fill.py
@@ -37,7 +37,7 @@ def fill(bin_img, size, roi=None):
     bool_img = _rect_filter(bool_img,
                             roi=roi,
                             function=remove_small_objects,
-                            **{"min_size" : size})
+                            **{"max_size" : size})
     # Cast boolean image to binary and make a copy of the binary image for returning
     filtered_img = np.copy(bool_img.astype(np.uint8) * 255)
     # slice the subset image back into full size binary image


### PR DESCRIPTION
**Describe your changes**
A new warning when using pcv.fill suggested that scikit-image had deprecated and would soon change the min_size parameter in morphology.remove_small_objects to max_size instead. This PR changes the kwarg assignment in pcv.fill to max_size. It doesn't change the behavior as it is now referencing the maximum size of objects to remove.

**Type of update**
* Bug fix (for future bug)

**Associated issues**
Closes #1902 

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
