### PR TITLE
fix _find_closest in hyperspectral

### DIFF
--- a/plantcv/plantcv/hyperspectral/read_data.py
+++ b/plantcv/plantcv/hyperspectral/read_data.py
@@ -25,13 +25,7 @@ def _find_closest(spectral_array, target):
     :param target: float
     :return spectral_array: __main__.Spectral_data
     """
-    # Array must be sorted
-    idx = spectral_array.searchsorted(target)
-    idx = np.clip(idx, 1, len(spectral_array) - 1)
-    left = spectral_array[idx - 1]
-    right = spectral_array[idx]
-    idx -= target - left < right - target
-    return idx
+    return np.argmin(np.abs(spectral_array - target))
 
 
 def _make_pseudo_rgb(spectral_array):


### PR DESCRIPTION
**Describe your changes**
The helper function `plantcv.hyperspectral._find_closest` previously required an input spectral array to be sorted, which can be expected for some data types. But, it was causing problems when trying to calculate spectral indices using geospatial subclass objects as input. This PR replaces the previous function with a simpler version that should be more robust to unsorted inputs.

**Type of update**
* Bug fix

**Associated issues**
Closes #1907 

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
