### PR TITLE
Hsi support in new indices

### DIFF
--- a/docs/spectral_index.md
+++ b/docs/spectral_index.md
@@ -44,7 +44,7 @@ Index range: -1, 1
 **returns** calculated index array (instance of the `Spectral_data` class)
 
 - **Parameters:**
-    - img         - Color image as a numpy array.
+    - img         - Color image or hyperspectral image object, an instance of the `Spectral_data` class in plantcv (read in using [pcv.readimage](read_image.md) with `mode='envi'`)
 	- distance    - Amount of flexibility (in nanometers) regarding the bands used to calculate an index.
 
 
@@ -63,7 +63,7 @@ Index range: 0, ∞
 **returns** calculated index array (instance of the `Spectral_data` class)
 
 - **Parameters:**
-    - img         - Color image as a numpy array.
+    - img         - Color image or hyperspectral image object, an instance of the `Spectral_data` class in plantcv (read in using [pcv.readimage](read_image.md) with `mode='envi'`)
 	- distance    - Amount of flexibility (in nanometers) regarding the bands used to calculate an index.
 
 
@@ -587,7 +587,7 @@ Index range: -1, 1
 **returns** calculated index array (instance of the `Spectral_data` class)
 
 - **Parameters:**
-    - img         - Color image as a numpy array.
+    - img         - Color image or hyperspectral image object, an instance of the `Spectral_data` class in plantcv (read in using [pcv.readimage](read_image.md) with `mode='envi'`) 
 	- distance    - Amount of flexibility (in nanometers) regarding the bands used to calculate an index.
 
 

--- a/docs/spectral_index.md
+++ b/docs/spectral_index.md
@@ -39,12 +39,13 @@ BGI = (G - B) / (G + B)
 
 Index range: -1, 1
 
-**plantcv.spectral_index.bgi**(*img*)
+**plantcv.spectral_index.bgi**(*img, distance=40*)
 
 **returns** calculated index array (instance of the `Spectral_data` class)
 
 - **Parameters:**
     - img         - Color image as a numpy array.
+	- distance    - Amount of flexibility (in nanometers) regarding the bands used to calculate an index.
 
 
 ### BGR
@@ -57,12 +58,13 @@ BGR = B / G
 
 Index range: 0, ∞
 
-**plantcv.spectral_index.bgr**(*img*)
+**plantcv.spectral_index.bgr**(*img, distance=40*)
 
 **returns** calculated index array (instance of the `Spectral_data` class)
 
 - **Parameters:**
     - img         - Color image as a numpy array.
+	- distance    - Amount of flexibility (in nanometers) regarding the bands used to calculate an index.
 
 
 ### CI_REDEDGE
@@ -580,12 +582,13 @@ SCI = (R - G) / (R + G)
 
 Index range: -1, 1
 
-**plantcv.spectral_index.sci**(*img*)
+**plantcv.spectral_index.sci**(*img, distance=40*)
 
 **returns** calculated index array (instance of the `Spectral_data` class)
 
 - **Parameters:**
     - img         - Color image as a numpy array.
+	- distance    - Amount of flexibility (in nanometers) regarding the bands used to calculate an index.
 
 
 ### SIPI

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1204,11 +1204,11 @@ pages for more details on the input and output variable types.
 
 #### plantcv.spectral_index.bgi
 
-* post v5.0: array = **plantcv.spectral_index.ari**(*img*)
+* post v5.0: array = **plantcv.spectral_index.ari**(*img, distance=40*)
 
 #### plantcv.spectral_index.bgr
 
-* post v5.0: array = **plantcv.spectral_index.ari**(*img*)
+* post v5.0: array = **plantcv.spectral_index.ari**(*img, distance=40*)
 
 #### plantcv.spectral_index.ci_rededge
 
@@ -1310,7 +1310,7 @@ pages for more details on the input and output variable types.
 
 #### plantcv.spectral_index.sci
 
-* post v5.0: array = **plantcv.spectral_index.sci**(*img*)
+* post v5.0: array = **plantcv.spectral_index.sci**(*img, distance=40*)
 
 #### plantcv.spectral_index.sipi
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1204,11 +1204,11 @@ pages for more details on the input and output variable types.
 
 #### plantcv.spectral_index.bgi
 
-* post v5.0: array = **plantcv.spectral_index.ari**(*img, distance=40*)
+* post v5.0: array = **plantcv.spectral_index.bgi**(*img, distance=40*)
 
 #### plantcv.spectral_index.bgr
 
-* post v5.0: array = **plantcv.spectral_index.ari**(*img, distance=40*)
+* post v5.0: array = **plantcv.spectral_index.bgr**(*img, distance=40*)
 
 #### plantcv.spectral_index.ci_rededge
 

--- a/plantcv/plantcv/spectral_index/spectral_index.py
+++ b/plantcv/plantcv/spectral_index/spectral_index.py
@@ -268,15 +268,17 @@ def egi(img, distance=40):
 
     The theoretical range for EGI is (-1, 2).
 
-    Inputs:
-    img            = Color image (np.array) or hyperspectral image (PlantCV Spectral_data instance)
+    Parameters:
+    ----------
+    img       : np.array or plantcv.plantcv.Spectral_data
+        Color image (np.array) or hyperspectral image (PlantCV Spectral_data instance)
+    distance  : int
+        maximum acceptable distance from desired wavelengths to use.
 
     Returns:
-    index_array    = Index data as a Spectral_data instance
-
-    :param distance: int
-    :param img: np.array
-    :return index_array: np.array
+    --------
+    index_array    = plantcv.plantcv.Spectral_data
+        Index data
     """
     if type(img) is Spectral_data:
         # If the available wavelengths completely cover the required range of data
@@ -393,7 +395,7 @@ def gli(img, distance=20):
     return _package_index(hsi=hsi, raw_index=index_array_raw, method="GLI")
 
 
-def sci(img):
+def sci(img, distance=40):
     """Soil Color Index.
 
     SCI = (R - G) / (R + G)
@@ -402,20 +404,28 @@ def sci(img):
 
     Parameters
     ----------
-    img : np.ndarray
-        Color image
+    img : np.ndarray or plantcv.plantcv.Spectral_data
+        Color or hyperspectral image
 
     Returns
     -------
     index_array : plantcv.plantcv.Spectral_data
         Index data
     """
-    if type(img) is not np.ndarray:
-        warn("Input image type is not supported for SCI. Please use an RGB image.")
-        return None
-
-    # Split the RGB image into component channels
-    _, green, red = cv2.split(img)
+    if type(img) is Spectral_data:
+        # If the available wavelengths completely cover the required range of data
+        if (float(img.max_wavelength) + distance) >= 700 and (float(img.min_wavelength) - distance) <= 530:
+            r530_index = _find_closest(np.array([float(i) for i in img.wavelength_dict.keys()]), 530)
+            r700_index = _find_closest(np.array([float(i) for i in img.wavelength_dict.keys()]), 700)
+            green = (img.array_data[:, :, r530_index])
+            red = (img.array_data[:, :, r700_index])
+        # If the required range of data is outside the available wavelengths
+        else:
+            warn("Available wavelengths are not suitable for calculating SCI. Try increasing distance.")
+            return None
+    if type(img) is np.ndarray:
+        # Split the RGB image into component channels
+        _, green, red = cv2.split(img)
 
     with np.errstate(divide="ignore", invalid="ignore"):
         r = red.astype(np.float32)
@@ -429,7 +439,7 @@ def sci(img):
     return _package_index(hsi=hsi, raw_index=index_array_raw, method="SCI")
 
 
-def bgr(img):
+def bgr(img, distance=40):
     """Blue Green Ratio.
 
     BGR = B / G
@@ -440,18 +450,28 @@ def bgr(img):
     ----------
     img : np.ndarray
         Color image
+    distance : int
+        Maximum acceptable distance from desired wavelengths to use.
 
     Returns
     -------
     index_array : plantcv.plantcv.Spectral_data
         Index data
     """
-    if type(img) is not np.ndarray:
-        warn("Input image type is not supported for BGR. Please use an RGB image.")
-        return None
-
-    # Split the RGB image into component channels
-    blue, green, _ = cv2.split(img)
+    if type(img) is Spectral_data:
+        # If the available wavelengths completely cover the required range of data
+        if (float(img.max_wavelength) + distance) >= 530 and (float(img.min_wavelength) - distance) <= 460:
+            r460_index = _find_closest(np.array([float(i) for i in img.wavelength_dict.keys()]), 460)
+            r530_index = _find_closest(np.array([float(i) for i in img.wavelength_dict.keys()]), 530)
+            blue = (img.array_data[:, :, r460_index])
+            green = (img.array_data[:, :, r530_index])
+        # If the required range of data is outside the available wavelengths
+        else:
+            warn("Available wavelengths are not suitable for calculating BGR. Try increasing distance.")
+            return None
+    if type(img) is np.ndarray:
+        # Split the RGB image into component channels
+        blue, green, _ = cv2.split(img)
 
     with np.errstate(divide="ignore", invalid="ignore"):
         b = blue.astype(np.float32)
@@ -465,7 +485,7 @@ def bgr(img):
     return _package_index(hsi=hsi, raw_index=index_array_raw, method="BGR")
 
 
-def bgi(img):
+def bgi(img, distance=40):
     """Blue Green Index.
 
     BGI = (G - B) / (G + B)
@@ -476,18 +496,28 @@ def bgi(img):
     ----------
     img : np.ndarray
         Color image
+    distance : int
+        Maximum acceptable distance from desired wavelengths to use.
 
     Returns
     -------
     index_array : plantcv.plantcv.Spectral_data
         Index data
     """
-    if type(img) is not np.ndarray:
-        warn("Input image type is not supported for BGI. Please use an RGB image.")
-        return None
-
-    # Split the RGB image into component channels
-    blue, green, _ = cv2.split(img)
+    if type(img) is Spectral_data:
+        # If the available wavelengths completely cover the required range of data
+        if (float(img.max_wavelength) + distance) >= 530 and (float(img.min_wavelength) - distance) <= 460:
+            r460_index = _find_closest(np.array([float(i) for i in img.wavelength_dict.keys()]), 460)
+            r530_index = _find_closest(np.array([float(i) for i in img.wavelength_dict.keys()]), 530)
+            blue = (img.array_data[:, :, r460_index])
+            green = (img.array_data[:, :, r530_index])
+        # If the required range of data is outside the available wavelengths
+        else:
+            warn("Available wavelengths are not suitable for calculating BGI. Try increasing distance.")
+            return None
+    if type(img) is np.ndarray:
+        # Split the RGB image into component channels
+        blue, green, _ = cv2.split(img)
 
     with np.errstate(divide="ignore", invalid="ignore"):
         b = blue.astype(np.float32)

--- a/tests/plantcv/spectral_index/test_spectral_index.py
+++ b/tests/plantcv/spectral_index/test_spectral_index.py
@@ -156,9 +156,16 @@ def test_sci_rgb(spectral_index_test_data):
     assert np.shape(index_array.array_data) == (335, 400) and np.nanmax(index_array.pseudo_rgb) == 255
 
 
-def test_sci_bad_input(spectral_index_test_data):
+def test_sci_hsi(spectral_index_test_data):
     """Test for PlantCV."""
-    assert spectral_index.sci(img=spectral_index_test_data.load_hsi()) is None
+    index_array = spectral_index.sci(spectral_index_test_data.load_hsi(), distance=40)
+    assert np.shape(index_array.array_data) == (1, 1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+
+def test_sci_hsi_bad_input(spectral_index_test_data):
+    """Test for PlantCV."""
+    index_array = spectral_index.sci(spectral_index_test_data.load_hsi(), distance=40)
+    assert spectral_index.sci(img=index_array, distance=40) is None
 
 
 def test_bgr_rgb(spectral_index_test_data):
@@ -168,9 +175,16 @@ def test_bgr_rgb(spectral_index_test_data):
     assert np.shape(index_array.array_data) == (335, 400) and np.nanmax(index_array.pseudo_rgb) == 255
 
 
+def test_bgr_hsi(spectral_index_test_data):
+    """Test for PlantCV."""
+    index_array = spectral_index.bgr(spectral_index_test_data.load_hsi(), distance=40)
+    assert np.shape(index_array.array_data) == (1, 1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+
 def test_bgr_bad_input(spectral_index_test_data):
     """Test for PlantCV."""
-    assert spectral_index.bgr(img=spectral_index_test_data.load_hsi()) is None
+    index_array = spectral_index.bgr(spectral_index_test_data.load_hsi(), distance=40)
+    assert spectral_index.bgr(img=index_array, distance=40) is None
 
 
 def test_bgi_rgb(spectral_index_test_data):
@@ -180,9 +194,16 @@ def test_bgi_rgb(spectral_index_test_data):
     assert np.shape(index_array.array_data) == (335, 400) and np.nanmax(index_array.pseudo_rgb) == 255
 
 
+def test_bgi_hsi(spectral_index_test_data):
+    """Test for PlantCV."""
+    index_array = spectral_index.bgi(spectral_index_test_data.load_hsi(), distance=40)
+    assert np.shape(index_array.array_data) == (1, 1600) and np.nanmax(index_array.pseudo_rgb) == 255
+
+
 def test_bgi_bad_input(spectral_index_test_data):
     """Test for PlantCV."""
-    assert spectral_index.bgi(img=spectral_index_test_data.load_hsi()) is None
+    index_array = spectral_index.bgi(spectral_index_test_data.load_hsi(), distance=40)
+    assert spectral_index.bgi(img=index_array, distance=40) is None
 
 
 def test_mari(spectral_index_test_data):


### PR DESCRIPTION
**Describe your changes**
Three new indices (SCI, BGR, BGI) use RGB data by default but did not have the logic that EGI uses to handle either RGB images or `Spectral_data` objects. This applies similar logic as in EGI to the 3 new functions to support consistency here and in the geospatial add on package.

**Type of update**
This is a feature update.

**Associated issues**
Closes #1899 

**Additional context**
This is important for resolving some `plantcv.geospatial` issues.

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
