### PR TITLE
Conda only on unix like

### DIFF
--- a/plantcv/parallel/run_parallel.py
+++ b/plantcv/parallel/run_parallel.py
@@ -114,8 +114,9 @@ def _check_for_conda(config):
     config = plantcv.parallel.WorkflowConfig object
     """
     running_in_conda = re.search("conda|mamba|miniforge", sys.executable) is not None
+    unix_like = os.name == "posix"
     # if workflow is executed from a conda environment then activate that conda environment on workers
-    if "job_script_prologue" not in config.cluster_config.keys() and running_in_conda:
+    if "job_script_prologue" not in config.cluster_config.keys() and running_in_conda and unix_like:
         # find where the conda installation is, replace python with activate
         activation_path = re.sub("(.*conda|mamba|miniforge)(\\d)?.*$",
                                  os.path.join("\\1\\2", "bin", "activate"), sys.executable)


### PR DESCRIPTION
**Describe your changes**
Only changing job script prologue on unix-like systems since sourcing the activation script on Windows wouldn't work anyway.

**Type of update**
This is a bug fix (?)

**Associated issues**
None

**Additional context**
None

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
