### PR TITLE
Only test conda prologue on unix

### DIFF
--- a/docs/parallel_config.md
+++ b/docs/parallel_config.md
@@ -193,7 +193,7 @@ of key-value pairs (e.g. `{"getenv": "true"}`).
 !!! note
     The fields available in `job_extra_directives` vary by cluster type. For example, `{"getenv": "true"}` will work to start
     the active conda environment on each worker in an HTCondor cluster but not on a PBS cluster.
-    `plantcv.parallel.run_parallel` and `JupyterConfig.run()` will check for an active conda environment
+    `plantcv.parallel.run_parallel` and `JupyterConfig.run()` will check for an active conda environment on a unix-like OS
     and attempt to start that environment on each worker if the `cluster_config` does not have a `job_script_prologue` already.
 
 ### Example

--- a/tests/parallel/test_run_parallel.py
+++ b/tests/parallel/test_run_parallel.py
@@ -13,8 +13,6 @@ def test_checking_conda_env(parallel_test_data, monkeypatch, tmpdir):
     config = _check_for_conda(config)
     if os.name == "posix":
         assert config.cluster_config["job_script_prologue"][0] == "source /my/Xconda3/bin/activate"
-    else:
-        assert True
 
 
 def test_checking_conda_base_env(monkeypatch):
@@ -26,5 +24,3 @@ def test_checking_conda_base_env(monkeypatch):
     config = _check_for_conda(config)
     if os.name == "posix":
         assert config.cluster_config["job_script_prologue"] == ["source /my/Xconda4/bin/activate"]
-    else:
-        assert True

--- a/tests/parallel/test_run_parallel.py
+++ b/tests/parallel/test_run_parallel.py
@@ -11,7 +11,10 @@ def test_checking_conda_env(parallel_test_data, monkeypatch, tmpdir):
     config = WorkflowConfig()
     # check for conda
     config = _check_for_conda(config)
-    assert config.cluster_config["job_script_prologue"][0] == "source /my/Xconda3/bin/activate"
+    if os.name == "posix":
+        assert config.cluster_config["job_script_prologue"][0] == "source /my/Xconda3/bin/activate"
+    else:
+        assert True
 
 
 def test_checking_conda_base_env(monkeypatch):

--- a/tests/parallel/test_run_parallel.py
+++ b/tests/parallel/test_run_parallel.py
@@ -1,4 +1,5 @@
 import sys
+import os
 from plantcv.parallel import WorkflowConfig
 from plantcv.parallel.run_parallel import _check_for_conda
 
@@ -20,4 +21,7 @@ def test_checking_conda_base_env(monkeypatch):
     config = WorkflowConfig()
     # This should not raise and should produce an activation line for the base env
     config = _check_for_conda(config)
-    assert config.cluster_config["job_script_prologue"] == ["source /my/Xconda4/bin/activate"]
+    if os.name == "posix":
+        assert config.cluster_config["job_script_prologue"] == ["source /my/Xconda4/bin/activate"]
+    else:
+        assert True


### PR DESCRIPTION
**Describe your changes**
Change test for job script prologue generation to account for windows vs unix change

**Type of update**
This is a bug fix.

**Associated issues**
None

**Additional context**
None

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
