### PR TITLE
Parallel inf images

### DIFF
--- a/docs/parallel_config.md
+++ b/docs/parallel_config.md
@@ -79,10 +79,10 @@ current working directory.
 
 
 * **imgformat**: (str, default = "all"): image file format/extension in lowercase. The string "all" can be used
-as shorthand to match all file extensions readable by `cv2.imread` and `INF` for compatibility with the
-photosynthesis submodule.
+as shorthand to match all file extensions readable by `cv2.imread`.
 This can accept a list if multiple extensions should be combined (if using phenofront data this must be length 1
 and "png" is the default).
+You can use other file types such as `INF` or `data` but they are not included in the default list.
 
 
 * **delimiter**: (str, default = "_"): image filename metadata term delimiter character. Alternatively, a regular 

--- a/docs/parallel_config.md
+++ b/docs/parallel_config.md
@@ -79,8 +79,10 @@ current working directory.
 
 
 * **imgformat**: (str, default = "all"): image file format/extension in lowercase. The string "all" can be used
-as shorthand to match all file extensions readable by `cv2.imread`. This can accept a list if multiple
-extensions should be combined (if using phenofront data this must be length 1 and "png" is the default).
+as shorthand to match all file extensions readable by `cv2.imread` and `INF` for compatibility with the
+photosynthesis submodule.
+This can accept a list if multiple extensions should be combined (if using phenofront data this must be length 1
+and "png" is the default).
 
 
 * **delimiter**: (str, default = "_"): image filename metadata term delimiter character. Alternatively, a regular 

--- a/plantcv/parallel/parsers.py
+++ b/plantcv/parallel/parsers.py
@@ -532,7 +532,7 @@ def _read_filenames(config):
         for root, _, files in os.walk(config.input_dir):
             for file in files:
                 if (
-                    file.lower().endswith(tuple([ext.lower() for ext in extensions])) and
+                    file.lower().endswith(tuple(ext.lower() for ext in extensions)) and
                     re.search(os.sep+r"[.]{1}(\w)", os.path.join(root, file)) is None
                 ):
                     # Keep the files that end with the image extension

--- a/plantcv/parallel/parsers.py
+++ b/plantcv/parallel/parsers.py
@@ -635,6 +635,6 @@ def _replace_string_extension(imgformat):
     """
     extensions = [imgformat]
     if imgformat == "all":
-        extensions = ['bmp', 'dib', 'jpeg', 'jpg', 'jpe', 'jp2', 'png', 'ppm', 'pgm', 'ppm', 'sr', 'ras', 'tiff', 'tif', 'INF']
+        extensions = ['bmp', 'dib', 'jpeg', 'jpg', 'jpe', 'jp2', 'png', 'ppm', 'pgm', 'ppm', 'sr', 'ras', 'tiff', 'tif']
     return extensions
 ###########################################

--- a/plantcv/parallel/parsers.py
+++ b/plantcv/parallel/parsers.py
@@ -532,7 +532,7 @@ def _read_filenames(config):
         for root, _, files in os.walk(config.input_dir):
             for file in files:
                 if (
-                    file.lower().endswith(tuple(extensions)) and
+                    file.lower().endswith(tuple([ext.lower() for ext in extensions])) and
                     re.search(os.sep+r"[.]{1}(\w)", os.path.join(root, file)) is None
                 ):
                     # Keep the files that end with the image extension
@@ -635,6 +635,6 @@ def _replace_string_extension(imgformat):
     """
     extensions = [imgformat]
     if imgformat == "all":
-        extensions = ['bmp', 'dib', 'jpeg', 'jpg', 'jpe', 'jp2', 'png', 'ppm', 'pgm', 'ppm', 'sr', 'ras', 'tiff', 'tif']
+        extensions = ['bmp', 'dib', 'jpeg', 'jpg', 'jpe', 'jp2', 'png', 'ppm', 'pgm', 'ppm', 'sr', 'ras', 'tiff', 'tif', 'INF']
     return extensions
 ###########################################


### PR DESCRIPTION
**Describe your changes**
Allows for INF files to be found by parallel ~by default~ when requested with uppercase. Previously they could be found if you specified the `imgformat` AND turned `include_all_subdirs` to `False`, which is a little buggy.

**Type of update**
This is a feature enhancement.

**Associated issues**
None

**Additional context**
Came up working with jupyterconfig on a photosynthesis workflow, which might be the only use case for this.

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
