### PR TITLE
Add request timeout

### DIFF
--- a/tests/plantcv/io/test_open_url.py
+++ b/tests/plantcv/io/test_open_url.py
@@ -1,10 +1,13 @@
 """Tests for the open_url function."""
+import os
 import pytest
 from plantcv.plantcv.io import open_url
 
 
 def test_open_url():
     """PlantCV Test"""
+    # Set the timeout for requests to 10 seconds to avoid hanging tests, default is 5 seconds
+    os.environ["IMAGEIO_REQUESTS_TIMEOUT"] = "10"
     url = ("https://datasci.danforthcenter.org/test.jpg")
     rgb_img = open_url(url=url)
     assert rgb_img.shape == (2464, 3280, 3)


### PR DESCRIPTION
**Describe your changes**
The test for `pcv.io.open_url` fails intermittently due to a timeout. The default timeout for `imageio` is 5 seconds, this PR increases it to 10 seconds for the test.

**Type of update**
Is this a: enhancement

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
