### PR TITLE
Lazy load chlorophyll

### DIFF
--- a/docs/photosynthesis_read_cropreporter.md
+++ b/docs/photosynthesis_read_cropreporter.md
@@ -19,7 +19,7 @@ PSII_data instance containing [xarray DataArrays](http://xarray.pydata.org/en/st
       labeled according to the metadata in .INF. The default measurement label is 't1'.
     - Time-resolved PAM fluorescence measurements are stored in the attribute `pam_time`. Frames F0, Fm, Fp, Fmp, F0pp, and Fmpp are
       labeled according to the metadata in .INF, with measurement labels starting at 't0' (e.g. t0, t1, t2, ...).
-    - Measurements from chlorophyll fluorescence are stored in the attribute `chlorophyll` and include a chlorophyll fluorescence frame (Chl) stored as NumPy array/ndarray. The Fdark frame, if collected, is not stored.
+    - Measurements from chlorophyll fluorescence are stored in the attribute `chl` and include a chlorophyll fluorescence frame (Chl) stored as NumPy array/ndarray access as `ps.chl.chlorophyll`. The Fdark frame, if collected, is not stored.
     - Green fluorescence protein (GFP) measurements are stored in the attribute `gfp` and include frames for dark fluorescence (Fdark), GFP fluorescence (GFP, 525 nm), and autofluorescence (Auto, 585 nm).
     - Red fluorescence protein (RFP) measurements are stored in the attribute `rfp` and include frames for dark fluorescence (Fdark) and RFP fluorescence (585 nm).
     - Alpha light absorption coefficient (APH) measurements are stored in the attribute `aph` and include reflected light frames for red (640 nm) and far-red (732 nm) wavelengths. `ps.aph` contains the red and far-red frames, which are accessed as `ps.aph.red` and `ps.aph.farred`, respectively. The Fdark frame, if collected, is not stored. 

--- a/plantcv/plantcv/classes.py
+++ b/plantcv/plantcv/classes.py
@@ -47,19 +47,24 @@ class Spectral_data:
 class PSII_data:
     """PSII data class"""
 
-    def __init__(self):
+    def __init__(self, metadata: dict = None):
+        self.metadata = metadata
+        if self.metadata is None:
+            self.metadata = {}
+        self.datapath = None
+        self.filename = None
+        # Dataset attributes: None = file not present, lazy-loaded object = file present
+        self.aph = None
+        self.chl = None
+        self.clr = None
         self.ojip_dark = None
         self.ojip_light = None
         self.pam_dark = None
         self.pam_light = None
         self.pam_time = None
         self.spectral = None
-        self.chlorophyll = None
         self.gfp = None
         self.rfp = None
-        self.aph = None
-        self.datapath = None
-        self.filename = None
 
     def __repr__(self):
         mvars = []

--- a/plantcv/plantcv/classes.py
+++ b/plantcv/plantcv/classes.py
@@ -66,19 +66,6 @@ class PSII_data:
         self.gfp = None
         self.rfp = None
 
-    def __repr__(self):
-        mvars = []
-        for k, v in self.__dict__.items():
-            if v is not None:
-                mvars.append(k)
-        return "PSII variables defined:\n" + '\n'.join(mvars)
-
-    def add_data(self, protocol):
-        """Input:
-        protocol: xr.DataArray with name equivalent to initialized attributes
-        """
-        self.__dict__[protocol.name] = protocol
-
 
 class Point:
     """Point annotation/collection class to use in Jupyter notebooks. It allows the user to

--- a/plantcv/plantcv/photosynthesis/read_cropreporter.py
+++ b/plantcv/plantcv/photosynthesis/read_cropreporter.py
@@ -14,25 +14,30 @@ class CHL:
     """Chlorophyll dataset. Stores the file path at init; image data is loaded on first access."""
 
     def __init__(self, filepath, height, width):
+        """Initialize CHL dataset with file path and image dimensions."""
         self._filepath = filepath
         self._height = height
         self._width = width
         self._chlorophyll = None
 
     def __bool__(self):
+        """The existence of the CHL class is true."""
         return True
 
     def __repr__(self):
+        """String representation of the CHL dataset, indicating whether the data has been loaded."""
         loaded = self._chlorophyll is not None
         return f"CHL(filepath={self._filepath!r}, loaded={loaded})"
 
     @property
     def chlorophyll(self):
+        """Return the chlorophyll frame as a NumPy array."""
         if self._chlorophyll is None:
             self._load()
         return self._chlorophyll
 
     def _load(self):
+        """Load the chlorophyll frame from the .DAT file."""
         img_cube, _, _ = _read_dat_file(
             dataset="CHL",
             filename=str(self._filepath),

--- a/plantcv/plantcv/photosynthesis/read_cropreporter.py
+++ b/plantcv/plantcv/photosynthesis/read_cropreporter.py
@@ -34,7 +34,7 @@ def read_cropreporter(filename):
                 metadata_dict[key] = value
 
     # Initialize PSII_data class
-    ps = PSII_data()
+    ps = PSII_data(metadata=metadata_dict)
 
     # INF file prefix and path
     ps.filename = os.path.split(filename)[-1]

--- a/plantcv/plantcv/photosynthesis/read_cropreporter.py
+++ b/plantcv/plantcv/photosynthesis/read_cropreporter.py
@@ -10,6 +10,39 @@ from plantcv.plantcv.classes import NamedImageCollection
 from skimage.util import img_as_ubyte
 
 
+class CHL:
+    """Chlorophyll dataset. Stores the file path at init; image data is loaded on first access."""
+
+    def __init__(self, filepath, height, width):
+        self._filepath = filepath
+        self._height = height
+        self._width = width
+        self._chlorophyll = None
+
+    def __bool__(self):
+        return True
+
+    def __repr__(self):
+        loaded = self._chlorophyll is not None
+        return f"CHL(filepath={self._filepath!r}, loaded={loaded})"
+
+    @property
+    def chlorophyll(self):
+        if self._chlorophyll is None:
+            self._load()
+        return self._chlorophyll
+
+    def _load(self):
+        img_cube, _, _ = _read_dat_file(
+            dataset="CHL",
+            filename=str(self._filepath),
+            height=self._height,
+            width=self._width,
+        )
+        # index 0 = Fdark (when present), last index = Chl
+        self._chlorophyll = img_cube[:, :, img_cube.shape[2] - 1]
+
+
 def read_cropreporter(filename):
     """Read datacubes from PhenoVation B.V. CropReporter or PlantExplorer cameras into a PSII_data instance.
 
@@ -40,6 +73,29 @@ def read_cropreporter(filename):
     ps.filename = os.path.split(filename)[-1]
     ps.datapath = os.path.dirname(filename)
 
+    # Image dimensions (assumed to be consistent across all datasets for a given acquisition)
+    height = int(ps.metadata["ImageRows"])
+    width = int(ps.metadata["ImageCols"])
+
+    # Dataset-specific processing functions. Class constructors for lazy loading.
+    dataset_classes = {
+        # Chlorophyll fluorescence data
+        "CHL": lambda fp: CHL(filepath=fp, height=height, width=width),
+    }
+
+    # Process datasets
+    for dataset in ["APH", "CHL", "CLR", "NPQ", "PMD", "PML", "PMT", "PSD", "PSL", "SPC"]:
+        # Construct the expected binary file path for the dataset
+        bin_filepath = _dat_filepath(dataset=dataset, datapath=ps.datapath, filename=ps.filename)
+        # Check if the file exists
+        if os.path.exists(bin_filepath):
+            key = dataset.lower()
+            # Get the class constructor
+            constructor = dataset_classes.get(dataset)
+            if constructor is not None:
+                # Set the attribute on the PSII_data instance to a lazy-loading object
+                setattr(ps, key, constructor(bin_filepath))
+
     # Dark-adapted measurements
     _process_psd_data(ps=ps, metadata=metadata_dict)
 
@@ -57,9 +113,6 @@ def read_cropreporter(filename):
 
     # PAM time (dark, light, and second dark adapted) measurements
     _process_pmt_data(ps=ps, metadata=metadata_dict)
-
-    # Chlorophyll fluorescence data
-    _process_chl_data(ps=ps, metadata=metadata_dict)
 
     # Spectral measurements
     _process_spc_data(ps=ps, metadata=metadata_dict)
@@ -394,42 +447,6 @@ def _process_pmt_data(ps, metadata):
             col="frame_label",
             col_wrap=int(np.ceil(len(frame_labels) / 4))
         )
-
-
-def _process_chl_data(ps, metadata):
-    """Read CHL dataset and keep only the Chlorophyll frame as a NumPy array.
-
-    Parameters
-    ----------
-    ps : plantcv.plantcv.classes.PSII_data
-        PSII_data instance.
-    metadata : dict
-        INF file metadata dictionary.
-    """
-    bin_filepath = _dat_filepath(dataset="CHL", datapath=ps.datapath, filename=ps.filename)
-
-    if os.path.exists(bin_filepath):
-        # Read the raw data cube (contains Fdark and Chl)
-        img_cube, _, _ = _read_dat_file(dataset="CHL", filename=bin_filepath,
-                                        height=int(metadata["ImageRows"]),
-                                        width=int(metadata["ImageCols"]))
-
-        # The CHL file typically has: index 0 = Fdark, index 1 = Chl.
-        # Some acquisitions may only contain a single frame (e.g. Chl only, no dark frame).
-        # Select the chlorophyll frame based on the number of frames present
-        num_frames = img_cube.shape[2]
-        # Use the last frame as the chlorophyll frame:
-        # - When there are two frames, indices are [0]=Fdark, [1]=Chl -> use index 1.
-        # - When there is one frame, index [0] is Chl -> use index 0.
-        chl_index = num_frames - 1
-        chl_frame = img_cube[:, :, chl_index]
-
-        # Store as a standard attribute
-        ps.chl = chl_frame
-
-        # Debugging (modified to handle NumPy array instead of xarray)
-        _debug(visual=ps.chl,
-               filename=os.path.join(params.debug_outdir, f"{str(params.device)}_CHL-frame.png"))
 
 
 def _process_spc_data(ps, metadata):

--- a/plantcv/plantcv/photosynthesis/read_cropreporter.py
+++ b/plantcv/plantcv/photosynthesis/read_cropreporter.py
@@ -117,7 +117,7 @@ def _process_psd_data(ps, metadata):
             name='ojip_dark'
         )
         psd.attrs["long_name"] = "OJIP dark-adapted measurements"
-        ps.add_data(psd)
+        ps.ojip_dark = psd
 
         _debug(visual=ps.ojip_dark.squeeze('measurement', drop=True),
                filename=os.path.join(params.debug_outdir, f"{str(params.device)}_PSD-frames.png"),
@@ -166,7 +166,7 @@ def _process_psl_data(ps, metadata):
             name='ojip_light'
         )
         psl.attrs["long_name"] = "OJIP light-adapted measurements"
-        ps.add_data(psl)
+        ps.ojip_light = psl
 
         _debug(visual=ps.ojip_light.squeeze('measurement', drop=True),
                filename=os.path.join(params.debug_outdir, f"{str(params.device)}_PSL-frames.png"),
@@ -203,7 +203,7 @@ def _process_npq_data(ps, metadata):
             name='ojip_dark'
         )
         psd.attrs["long_name"] = "OJIP dark-adapted measurements"
-        ps.add_data(psd)
+        ps.ojip_dark = psd
 
         _debug(visual=ps.ojip_dark.squeeze('measurement', drop=True),
                filename=os.path.join(params.debug_outdir, f"{str(params.device)}_PSD-frames.png"),
@@ -223,7 +223,7 @@ def _process_npq_data(ps, metadata):
             name='ojip_light'
         )
         psd.attrs["long_name"] = "OJIP light-adapted measurements"
-        ps.add_data(psd)
+        ps.ojip_light = psd
 
         _debug(visual=ps.ojip_light.squeeze('measurement', drop=True),
                filename=os.path.join(params.debug_outdir, f"{str(params.device)}_PSL-frames.png"),
@@ -257,7 +257,7 @@ def _process_pmd_data(ps, metadata):
             name='pam_dark'
         )
         pmd.attrs["long_name"] = "pam dark-adapted measurements"
-        ps.add_data(pmd)
+        ps.pam_dark = pmd
 
         _debug(visual=ps.pam_dark.squeeze('measurement', drop=True),
                filename=os.path.join(params.debug_outdir, f"{str(params.device)}_PMD-frames.png"),
@@ -291,7 +291,7 @@ def _process_pml_data(ps, metadata):
             name='pam_light'
         )
         pml.attrs["long_name"] = "pam light-adapted measurements"
-        ps.add_data(pml)
+        ps.pam_light = pml
 
         _debug(visual=ps.pam_light.squeeze('measurement', drop=True),
                filename=os.path.join(params.debug_outdir, f"{str(params.device)}_PML-frames.png"),
@@ -382,7 +382,7 @@ def _process_pmt_data(ps, metadata):
         )
 
         pmt.attrs["long_name"] = "pam time measurements"
-        ps.add_data(pmt)
+        ps.pam_time = pmt
 
         # debug visualization
         _debug(
@@ -425,10 +425,10 @@ def _process_chl_data(ps, metadata):
         chl_frame = img_cube[:, :, chl_index]
 
         # Store as a standard attribute
-        ps.chlorophyll = chl_frame
+        ps.chl = chl_frame
 
         # Debugging (modified to handle NumPy array instead of xarray)
-        _debug(visual=ps.chlorophyll,
+        _debug(visual=ps.chl,
                filename=os.path.join(params.debug_outdir, f"{str(params.device)}_CHL-frame.png"))
 
 
@@ -533,7 +533,7 @@ def _process_gfp_data(ps, metadata):
         gfp.attrs["calib_factor"] = float(metadata.get("GfpCalibFactor", metadata.get("GfpCalFactor", "nan")))
         gfp.attrs["meas_power"] = float(metadata.get("GfpMeasPower", "nan"))
         gfp.attrs["shutter"] = float(metadata.get("GfpShutter", metadata.get("GfpShutterFrames", "nan")))
-        ps.add_data(gfp)
+        ps.gfp = gfp
 
         _debug(visual=ps.gfp,
                filename=os.path.join(params.debug_outdir, f"{str(params.device)}_GFP-frames.png"),
@@ -571,7 +571,7 @@ def _process_rfp_data(ps, metadata):
         rfp.attrs["calib_factor"] = float(metadata.get("RfpCalibFactor", "nan"))
         rfp.attrs["meas_power"] = float(metadata.get("RfpMeasPower", "nan"))
         rfp.attrs["shutter"] = float(metadata.get("RfpShutter", metadata.get("RfpShutterFrames", "nan")))
-        ps.add_data(rfp)
+        ps.rfp = rfp
 
         _debug(visual=ps.rfp,
                filename=os.path.join(params.debug_outdir, f"{str(params.device)}_RFP-frames.png"),

--- a/tests/plantcv/photosynthesis/test_psii_data.py
+++ b/tests/plantcv/photosynthesis/test_psii_data.py
@@ -4,5 +4,5 @@ from plantcv.plantcv import PSII_data
 def test_psii_data(photosynthesis_test_data):
     """Test for PlantCV."""
     psii = PSII_data()
-    psii.add_data(photosynthesis_test_data.psii_cropreporter('ojip_dark'))
-    assert repr(psii) == "PSII variables defined:\nojip_dark"
+    psii.ojip_dark = photosynthesis_test_data.psii_cropreporter('ojip_dark')
+    assert psii.ojip_dark.shape == (10, 10, 4, 1)

--- a/tests/plantcv/photosynthesis/test_read_cropreporter.py
+++ b/tests/plantcv/photosynthesis/test_read_cropreporter.py
@@ -84,10 +84,11 @@ def test_read_cropreporter_chl_only(photosynthesis_test_data, tmpdir):
     fluor_filename = os.path.join(cache_dir, os.path.basename(photosynthesis_test_data.cropreporter))
     ps = read_cropreporter(filename=fluor_filename)
     assert isinstance(ps, PSII_data)
-    assert ps.chl is not None
+    assert ps.chl
+    assert "loaded=False" in repr(ps.chl)
     # Check for a 2D NumPy array (Height, Width)
-    assert len(ps.chl.shape) == 2
-    assert isinstance(ps.chl, np.ndarray)
+    assert len(ps.chl.chlorophyll.shape) == 2
+    assert isinstance(ps.chl.chlorophyll, np.ndarray)
 
 
 def test_read_cropreporter_gfp_only(photosynthesis_test_data, tmpdir):

--- a/tests/plantcv/photosynthesis/test_read_cropreporter.py
+++ b/tests/plantcv/photosynthesis/test_read_cropreporter.py
@@ -84,10 +84,10 @@ def test_read_cropreporter_chl_only(photosynthesis_test_data, tmpdir):
     fluor_filename = os.path.join(cache_dir, os.path.basename(photosynthesis_test_data.cropreporter))
     ps = read_cropreporter(filename=fluor_filename)
     assert isinstance(ps, PSII_data)
-    assert ps.chlorophyll is not None
+    assert ps.chl is not None
     # Check for a 2D NumPy array (Height, Width)
-    assert len(ps.chlorophyll.shape) == 2
-    assert isinstance(ps.chlorophyll, np.ndarray)
+    assert len(ps.chl.shape) == 2
+    assert isinstance(ps.chl, np.ndarray)
 
 
 def test_read_cropreporter_gfp_only(photosynthesis_test_data, tmpdir):


### PR DESCRIPTION
**Describe your changes**
PR simplifies the `PSII_data` class. It adds a new class for chlorophyll data `CHL` that is used with `PSII_data` to lazy load the chlorophyll fluorescence image on-demand.

```python
ps = pcv.photosynthesis.read_cropreporter("PSII_HDR_020321_WT_TOP_1.INF")
print(ps.chl)
# CHL(filepath='PSII_CHL_020321_WT_TOP_1.DAT', loaded=False)
pcv.plot_image(ps.chl.chlorophyll)  # plot image
print(ps.chl)
# CHL(filepath='PSII_CHL_020321_WT_TOP_1.DAT', loaded=True)
```

**Type of update**
Is this a: New feature or feature enhancement

**Associated issues**
#1926

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
