### PR TITLE
Lazy load color

### DIFF
--- a/docs/photosynthesis_read_cropreporter.md
+++ b/docs/photosynthesis_read_cropreporter.md
@@ -20,6 +20,7 @@ PSII_data instance containing [xarray DataArrays](http://xarray.pydata.org/en/st
     - Time-resolved PAM fluorescence measurements are stored in the attribute `pam_time`. Frames F0, Fm, Fp, Fmp, F0pp, and Fmpp are
       labeled according to the metadata in .INF, with measurement labels starting at 't0' (e.g. t0, t1, t2, ...).
     - Measurements from chlorophyll fluorescence are stored in the attribute `chl` and include a chlorophyll fluorescence frame (Chl) stored as NumPy array/ndarray access as `ps.chl.chlorophyll`. The Fdark frame, if collected, is not stored.
+    - Measurements from color are stored in the attribute `clr` and include a color image frame (CLR) stored as NumPy array/ndarray access as `ps.clr.color`.
     - Green fluorescence protein (GFP) measurements are stored in the attribute `gfp` and include frames for dark fluorescence (Fdark), GFP fluorescence (GFP, 525 nm), and autofluorescence (Auto, 585 nm).
     - Red fluorescence protein (RFP) measurements are stored in the attribute `rfp` and include frames for dark fluorescence (Fdark) and RFP fluorescence (585 nm).
     - Alpha light absorption coefficient (APH) measurements are stored in the attribute `aph` and include reflected light frames for red (640 nm) and far-red (732 nm) wavelengths. `ps.aph` contains the red and far-red frames, which are accessed as `ps.aph.red` and `ps.aph.farred`, respectively. The Fdark frame, if collected, is not stored. 

--- a/plantcv/plantcv/photosynthesis/read_cropreporter.py
+++ b/plantcv/plantcv/photosynthesis/read_cropreporter.py
@@ -48,6 +48,44 @@ class CHL:
         self._chlorophyll = img_cube[:, :, img_cube.shape[2] - 1]
 
 
+class CLR:
+    """Color dataset. Stores the file path at init; image data is loaded on first access."""
+
+    def __init__(self, filepath, height, width):
+        """Initialize CLR dataset with file path and image dimensions."""
+        self._filepath = filepath
+        self._height = height
+        self._width = width
+        self._color = None
+
+    def __bool__(self):
+        """The existence of the CLR class is true."""
+        return True
+
+    def __repr__(self):
+        """String representation of the CLR dataset, indicating whether the data has been loaded."""
+        loaded = self._color is not None
+        return f"CLR(filepath={self._filepath!r}, loaded={loaded})"
+
+    @property
+    def color(self):
+        """Return the color frame as a NumPy array."""
+        if self._color is None:
+            self._load()
+        return self._color
+
+    def _load(self):
+        """Load the color frames from the .DAT file."""
+        img_cube, _, _ = _read_dat_file(
+            dataset="CLR",
+            filename=str(self._filepath),
+            height=self._height,
+            width=self._width,
+        )
+        # Store the color data as BGR uint8
+        self._color = img_as_ubyte(img_cube[:, :, [2, 1, 0]])
+
+
 def read_cropreporter(filename):
     """Read datacubes from PhenoVation B.V. CropReporter or PlantExplorer cameras into a PSII_data instance.
 
@@ -86,6 +124,8 @@ def read_cropreporter(filename):
     dataset_classes = {
         # Chlorophyll fluorescence data
         "CHL": lambda fp: CHL(filepath=fp, height=height, width=width),
+        # Color data
+        "CLR": lambda fp: CLR(filepath=fp, height=height, width=width),
     }
 
     # Process datasets

--- a/tests/plantcv/photosynthesis/test_read_cropreporter.py
+++ b/tests/plantcv/photosynthesis/test_read_cropreporter.py
@@ -91,6 +91,27 @@ def test_read_cropreporter_chl_only(photosynthesis_test_data, tmpdir):
     assert isinstance(ps.chl.chlorophyll, np.ndarray)
 
 
+def test_read_cropreporter_clr_only(photosynthesis_test_data, tmpdir):
+    """Test CLR import."""
+    # Create a test tmp directory
+    cache_dir = tmpdir.mkdir("sub")
+    # Create dataset with only CLR
+    shutil.copyfile(photosynthesis_test_data.cropreporter,
+                    os.path.join(cache_dir,
+                                 os.path.basename(photosynthesis_test_data.cropreporter)))
+    clr_dat = photosynthesis_test_data.cropreporter.replace("HDR", "CLR")
+    clr_dat = clr_dat.replace("INF", "DAT")
+    shutil.copyfile(clr_dat, os.path.join(cache_dir, os.path.basename(clr_dat)))
+    fluor_filename = os.path.join(cache_dir, os.path.basename(photosynthesis_test_data.cropreporter))
+    ps = read_cropreporter(filename=fluor_filename)
+    assert isinstance(ps, PSII_data)
+    assert ps.clr
+    assert "loaded=False" in repr(ps.clr)
+    # Check for a 3D NumPy array (Height, Width, Channels)
+    assert len(ps.clr.color.shape) == 3
+    assert isinstance(ps.clr.color, np.ndarray)
+
+
 def test_read_cropreporter_gfp_only(photosynthesis_test_data, tmpdir):
     """Test GFP import."""
     # Create a test tmp directory


### PR DESCRIPTION
**Describe your changes**
PR adds a new class for color data `CLR` that is used with `PSII_data` to lazy load the color image on-demand.

```python
ps = pcv.photosynthesis.read_cropreporter("PSII_HDR_020321_WT_TOP_1.INF")
print(ps.clr)
# CLR(filepath='PSII_CLR_020321_WT_TOP_1.DAT', loaded=False)
pcv.plot_image(ps.clr.color)  # plot image
print(ps.clr)
# CLR(filepath='PSII_CLR_020321_WT_TOP_1.DAT', loaded=True)
```

**Type of update**
Is this a: New feature or feature enhancement

**Associated issues**
#1926

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
