### PR TITLE
Lazy load alpha

### DIFF
--- a/plantcv/plantcv/classes.py
+++ b/plantcv/plantcv/classes.py
@@ -140,11 +140,3 @@ class Objects:
         file = np.load(filename)
         obj = Objects(file['contours'].tolist(), file['hierarchy'])
         return obj
-
-
-class NamedImageCollection:
-    """Class for managing a collection of images with associated names."""
-
-    def __init__(self, **images):
-        for name, img in images.items():
-            setattr(self, name, img)

--- a/plantcv/plantcv/photosynthesis/read_cropreporter.py
+++ b/plantcv/plantcv/photosynthesis/read_cropreporter.py
@@ -6,8 +6,54 @@ from plantcv.plantcv._globals import params
 from plantcv.plantcv._debug import _debug
 from plantcv.plantcv import PSII_data
 from plantcv.plantcv import Spectral_data
-from plantcv.plantcv.classes import NamedImageCollection
 from skimage.util import img_as_ubyte
+
+
+class APH:
+    """Alpha light absorption coefficient (APH) dataset. Stores the file path at init; image data is loaded on first access."""
+
+    def __init__(self, filepath, height, width):
+        """Initialize APH dataset with file path and image dimensions."""
+        self._filepath = filepath
+        self._height = height
+        self._width = width
+        self._red = None
+        self._farred = None
+
+    def __bool__(self):
+        """The existence of the APH class is true."""
+        return True
+
+    def __repr__(self):
+        """String representation of the APH dataset, indicating whether the data has been loaded."""
+        loaded = self._red is not None and self._farred is not None
+        return f"APH(filepath={self._filepath!r}, loaded={loaded})"
+
+    @property
+    def red(self):
+        """Return the red frame as a NumPy array."""
+        if self._red is None:
+            self._load()
+        return self._red
+
+    @property
+    def farred(self):
+        """Return the far-red frame as a NumPy array."""
+        if self._farred is None:
+            self._load()
+        return self._farred
+
+    def _load(self):
+        """Load the APH frames from the .DAT file."""
+        img_cube, _, _ = _read_dat_file(
+            dataset="APH",
+            filename=str(self._filepath),
+            height=self._height,
+            width=self._width,
+        )
+        # red = second to last frame, far-red = last frame. Fdark frame, if collected, is not stored.
+        self._red = img_cube[:, :, -2]
+        self._farred = img_cube[:, :, -1]
 
 
 class CHL:
@@ -122,6 +168,8 @@ def read_cropreporter(filename):
 
     # Dataset-specific processing functions. Class constructors for lazy loading.
     dataset_classes = {
+        # Alpha light absorption coefficient (APH) data
+        "APH": lambda fp: APH(filepath=fp, height=height, width=width),
         # Chlorophyll fluorescence data
         "CHL": lambda fp: CHL(filepath=fp, height=height, width=width),
         # Color data
@@ -169,7 +217,7 @@ def read_cropreporter(filename):
     _process_rfp_data(ps=ps, metadata=metadata_dict)
 
     # APH reflectance data
-    _process_aph_data(ps=ps, metadata=metadata_dict)
+    # _process_aph_data(ps=ps, metadata=metadata_dict)
 
     return ps
 
@@ -639,50 +687,6 @@ def _process_rfp_data(ps, metadata):
                filename=os.path.join(params.debug_outdir, f"{str(params.device)}_RFP-frames.png"),
                col='frame_label',
                col_wrap=int(np.ceil(ps.rfp.frame_label.size / 4)))
-
-
-def _process_aph_data(ps, metadata):
-    """Read APH dataset and keep the Red and FarRed frames as a NumPy array.
-
-    Parameters
-    ----------
-    ps : plantcv.plantcv.classes.PSII_data
-        PSII_data instance.
-    metadata : dict
-        INF file metadata dictionary.
-    """
-    bin_filepath = _dat_filepath(dataset="APH", datapath=ps.datapath, filename=ps.filename)
-
-    if os.path.exists(bin_filepath):
-        # Read the raw data cube (contains Fdark, Red, and FarRed or just Red and FarRed)
-        img_cube, _, _ = _read_dat_file(dataset="APH", filename=bin_filepath,
-                                        height=int(metadata["ImageRows"]),
-                                        width=int(metadata["ImageCols"]))
-
-        # The APH file typically has: index 0 = Fdark, index 1 = Red, index 2 = FarRed.
-        # Some acquisitions may only contain two frames (e.g. no dark frame).
-        # Select the Red and FarRed frames based on the number of frames present.
-        # Use the last 2 frames as Red and FarRed:
-        # - When there are 3 frames, indices are [0]=Fdark, [1]=Red, [2]=FarRed -> use indices 1 and 2.
-        # - When there are 2 frames, indices are [0]=Red, [1]=FarRed -> use indices 0 and 1.
-        num_frames = img_cube.shape[2]
-        if num_frames < 2:
-            raise RuntimeError(f"APH DAT file contains {num_frames} frame(s); expected at least 2 (Red and FarRed).")
-        aph_frames = img_cube[:, :, num_frames - 2:num_frames]
-
-        # Store as a standard attribute
-        ps.aph = NamedImageCollection(red=aph_frames[:, :, 0], farred=aph_frames[:, :, 1])
-
-        # Debugging — wrap in a temporary DataArray so frame labels appear in the plot
-        aph_debug = xr.DataArray(
-            data=aph_frames,
-            dims=('x', 'y', 'frame_label'),
-            coords={'frame_label': ['Red', 'FarRed']}
-        )
-        _debug(visual=aph_debug,
-               filename=os.path.join(params.debug_outdir, f"{str(params.device)}_APH-frames.png"),
-               col='frame_label',
-               col_wrap=2)
 
 
 def _dat_filepath(dataset, datapath, filename):

--- a/tests/plantcv/photosynthesis/test_read_cropreporter.py
+++ b/tests/plantcv/photosynthesis/test_read_cropreporter.py
@@ -158,31 +158,25 @@ def test_read_cropreporter_aph_only(photosynthesis_test_data, tmpdir):
     fluor_filename = os.path.join(cache_dir, "HDR_2025-12-12_tob1_20251212205712029.INF")
     ps = read_cropreporter(filename=fluor_filename)
     assert isinstance(ps, PSII_data)
-    assert ps.aph is not None
+    assert ps.aph
+    assert "loaded=False" in repr(ps.aph)
     assert hasattr(ps.aph, "red")
     assert hasattr(ps.aph, "farred")
 
 
-def test_read_cropreporter_aph_insufficient_frames(photosynthesis_test_data, tmpdir, monkeypatch):
-    """Test that APH import raises RuntimeError when DAT file contains fewer than 2 frames."""
-    cache_dir = tmpdir.mkdir("sub_aph_err")
-    inf_dest = os.path.join(cache_dir, "HDR_2025-12-12_tob1_20251212205712029.INF")
-    dat_dest = os.path.join(cache_dir, "APH_2025-12-12_tob1_20251212205712029.DAT")
-    shutil.copyfile(photosynthesis_test_data.cropreporter_aph, inf_dest)
-    aph_dat = photosynthesis_test_data.cropreporter_aph.replace("HDR", "APH").replace("INF", "DAT")
-    shutil.copyfile(aph_dat, dat_dest)
-    # Override image dimensions so monkeypatched data is the right size
-    with open(inf_dest, "a") as f:
-        f.write("\nImageRows=10")
-        f.write("\nImageCols=10")
-    # Return only 1 frame worth of data (10 * 10 * 1 = 100) to trigger the error
-    monkeypatch.setattr(np, "fromfile", lambda *args, **kwargs: np.ones(100, dtype=np.uint16))
-    error_raised = False
-    try:
-        read_cropreporter(filename=inf_dest)
-    except RuntimeError:
-        error_raised = True
-    assert error_raised
+def test_read_cropreporter_aph_farred(photosynthesis_test_data, tmpdir):
+    """Test APH (Red / FarRed reflectance) import."""
+    # Create a test tmp directory
+    cache_dir = tmpdir.mkdir("sub")
+    # Create dataset with only APH
+    shutil.copyfile(photosynthesis_test_data.cropreporter_aph, os.path.join(cache_dir,
+                                                                            "HDR_2025-12-12_tob1_20251212205712029.INF"))
+    aph_dat = photosynthesis_test_data.cropreporter_aph.replace("HDR", "APH")
+    aph_dat = aph_dat.replace("INF", "DAT")
+    shutil.copyfile(aph_dat, os.path.join(cache_dir, "APH_2025-12-12_tob1_20251212205712029.DAT"))
+    fluor_filename = os.path.join(cache_dir, "HDR_2025-12-12_tob1_20251212205712029.INF")
+    ps = read_cropreporter(filename=fluor_filename)
+    assert hasattr(ps.aph, "farred")
 
 
 def test_read_cropreporter_pmt_only_9_labels(photosynthesis_test_data, tmpdir):


### PR DESCRIPTION
**Describe your changes**
PR adds a new class for alpha light absorption data `APH` that is used with `PSII_data` to lazy load the color image on-demand.

```python
ps = pcv.photosynthesis.read_cropreporter("PSII_HDR_020321_WT_TOP_1.INF")
print(ps.aph)
# APH(filepath='PSII_APH_020321_WT_TOP_1.DAT', loaded=False)
pcv.plot_image(ps.aph.red)  # plot image
pcv.plot_image(ps.aph.farred)  # plot image
print(ps.aph)
# APH(filepath='PSII_APH_020321_WT_TOP_1.DAT', loaded=True)
```

**Type of update**
Is this a: New feature or feature enhancement

**Associated issues**
#1926

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
