### PR TITLE
for all metadata terms in length of meta list handle them the same way

### DIFF
--- a/plantcv/parallel/parsers.py
+++ b/plantcv/parallel/parsers.py
@@ -352,7 +352,7 @@ def _parse_filename(filename, config, metadata_index):
             if term in metadata_index:
                 mi_term = metadata_index[term]
                 img_meta[term] = None
-                if i <= len(meta_list) - 1:
+                if i <= len(meta_list):
                     img_meta[term] = meta_list[mi_term]
     img_meta["n_metadata_terms"] = len(meta_list)
     return img_meta

--- a/tests/parallel/test_inspect_config.py
+++ b/tests/parallel/test_inspect_config.py
@@ -14,7 +14,7 @@ def test_inspect_dataset(parallel_test_data):
     # inspect dataset
     sdf, df = inspect_dataset(config)
 
-    assert sdf.shape == (2, 10) and df.shape == (2, 12)
+    assert sdf.shape == (2, 11) and df.shape == (2, 13)
 
 
 def test_inspect_dataset_string(parallel_test_data):


### PR DESCRIPTION
**Describe your changes**
Removed a `- 1` on a check against the length of filename metadata on line 355 of parsers. I believe the reason I had added that was to try to account for any times that the metadata is variable lengths between different images. The way it works is that the metadata term is initialized as `None` (generally, could change with fancy term declaration in the config I guess) then `if length is below length(config.filename_metadata)` the `None` is overwritten with that value from the image name. This is working for me locally now with some dummy files shown below. This also required changing one of the tests for `inspect_dataset` because it changes the number of returned columns for one of those.

Example in case it helps with review:

```
  #+begin_src bash
    cd /home/josh/scripts/fahlgren_lab/pcv5/reiner_bug/images
    echo "" > img_name_01.png
    echo "" > img_name_02.png
    echo "" > img_name_03.png
    echo "" > img_name_04.png
    echo "" > img_name_05.png
    echo "" > img_name_06_additional.png
  #+end_src

  #+begin_src python
    from plantcv import parallel as pcvpar
    config = pcvpar.WorkflowConfig()
    config.input_dir = "/home/josh/scripts/fahlgren_lab/pcv5/reiner_bug/images"
    insp = pcvpar.inspect_dataset(config)
    print(insp[1].iloc[:, [1,2,3,4,5,6]])
    print(insp[0])
  #+end_src

  #+RESULTS:
  #+begin_example
  Images will be read from /home/josh/scripts/fahlgren_lab/pcv5/reiner_bug/images
  Warning: Creating config.filename_metadata based on file names.
  Filenames will be parsed into metadata_0, metadata_1, metadata_2, metadata_3
     n_metadata_terms timestamp metadata_0 metadata_1 metadata_2  metadata_3
  0                 3       NaN        img       name         04         NaN
  1                 3       NaN        img       name         05         NaN
  2                 3       NaN        img       name         02         NaN
  3                 4       NaN        img       name         06  additional
  4                 3       NaN        img       name         01         NaN
  5                 3       NaN        img       name         03         NaN
         filepath n_metadata_terms timestamp metadata_0  ... metadata_2      metadata_3 basename extension
  status                                                 ...                                              
  Kept    6 (...)         2 (3, 4)         0    1 (img)  ...    6 (...)  1 (additional)  6 (...)  1 (.png)

  [1 rows x 9 columns]
  #+end_example
```


**Type of update**
This is a bug fix

**Associated issues**
None

**Additional context**
None

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
