### PR TITLE
Restores the time_lapse_video function

### DIFF
--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1625,7 +1625,7 @@ pages for more details on the input and output variable types.
 
 * pre v4.0: NA
 * post v4.0: frame_size = **pcv.visualize.time_lapse_video**(*img_list, out_filename='./time_lapse_video.mp4', fps=29.97, display=True*)
-* post v5.0: deprecated.
+* post v5.0: frame_size = **pcv.visualize.time_lapse_video**(*img_list, out_filename='./time_lapse_video.mp4', fps=29.97*)
 
 #### plantcv.watershed_segmentation
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1625,7 +1625,7 @@ pages for more details on the input and output variable types.
 
 * pre v4.0: NA
 * post v4.0: frame_size = **pcv.visualize.time_lapse_video**(*img_list, out_filename='./time_lapse_video.mp4', fps=29.97, display=True*)
-* post v5.0: frame_size = **pcv.visualize.time_lapse_video**(*img_list, out_filename='./time_lapse_video.mp4', fps=29.97*)
+* post v5.0: frame_size = **pcv.visualize.time_lapse_video**(*source, out_filename='./time_lapse_video.mp4', fps=29.97*)
 
 #### plantcv.watershed_segmentation
 

--- a/docs/visualize_time_lapse_video.md
+++ b/docs/visualize_time_lapse_video.md
@@ -2,18 +2,17 @@
 
 This function generates and saves the time-lapse video based on a list of paths to the images.
 
-**plantcv.visualize.time_lapse_video**(*img_list, out_filename='./time_lapse_video.mp4', fps=29.97*)
+**plantcv.visualize.time_lapse_video**(*source, out_filename='./time_lapse_video.mp4', fps=29.97*)
 
 **returns** frame_size
 
 - **Parameters:**
-    - list_img       - List of paths to the images to create the video.    
+    - list_img       - List of paths to the images to create the video or file path to a directory of images to use.
     - out_filename   - Name of file to save the generated video to.
-    - fps            - Frame rate (frames per second) By default fps=29.97. Commonly used values: 23.98, 24, 25, 29.97, 30, 50, 59.94, 60   
+    - fps            - Frame rate (frames per second) By default fps=29.97. Commonly used values: 23.98, 24, 25, 29.97, 30, 50, 59.94, 60
 
 - **Context:**
     - Used to generate time-lapse video given a list of images.
-    - List of image paths can be generated with [`plantcv.io.read_dataset`](io_read_dataset.md). 
 
 - **Example Use:**
     - Below
@@ -23,10 +22,9 @@ This function generates and saves the time-lapse video based on a list of paths 
 from plantcv import plantcv as pcv
 # Note you will have to change this part on your own path
 img_directory = './path_to_images_directory/'
-img_paths_list = pcv.io.read_dataset(source_path=img_directory, sort=True)
 
-frame_size = pcv.visualize.time_lapse_video(img_list=img_paths_list,
-                                                    out_filename='./eg_time_lapse.mp4')
+frame_size = pcv.visualize.time_lapse_video(source=img_directory,
+                                            out_filename='./eg_time_lapse.mp4')
 ```
 
 **Video generated**

--- a/docs/visualize_time_lapse_video.md
+++ b/docs/visualize_time_lapse_video.md
@@ -7,7 +7,7 @@ This function generates and saves the time-lapse video based on a list of paths 
 **returns** frame_size
 
 - **Parameters:**
-    - list_img       - List of paths to the images to create the video or file path to a directory of images to use.
+    - source         - List of paths to the images to create the video or file path to a directory of images to use.
     - out_filename   - Name of file to save the generated video to.
     - fps            - Frame rate (frames per second) By default fps=29.97. Commonly used values: 23.98, 24, 25, 29.97, 30, 50, 59.94, 60
 

--- a/docs/visualize_time_lapse_video.md
+++ b/docs/visualize_time_lapse_video.md
@@ -2,7 +2,7 @@
 
 This function generates and saves the time-lapse video based on a list of paths to the images.
 
-**plantcv.visualize.time_lapse_video**(*img_list, out_filename='./time_lapse_video.mp4', fps=29.97, display=True*)
+**plantcv.visualize.time_lapse_video**(*img_list, out_filename='./time_lapse_video.mp4', fps=29.97*)
 
 **returns** frame_size
 
@@ -10,7 +10,6 @@ This function generates and saves the time-lapse video based on a list of paths 
     - list_img       - List of paths to the images to create the video.    
     - out_filename   - Name of file to save the generated video to.
     - fps            - Frame rate (frames per second) By default fps=29.97. Commonly used values: 23.98, 24, 25, 29.97, 30, 50, 59.94, 60   
-    - display        - if True (default), displays the path to the generated video.
 
 - **Context:**
     - Used to generate time-lapse video given a list of images.
@@ -27,8 +26,7 @@ img_directory = './path_to_images_directory/'
 img_paths_list = pcv.io.read_dataset(source_path=img_directory, sort=True)
 
 frame_size = pcv.visualize.time_lapse_video(img_list=img_paths_list,
-                                                    out_filename='./eg_time_lapse.mp4',
-                                                    fps=29.97, display=True)
+                                                    out_filename='./eg_time_lapse.mp4')
 ```
 
 **Video generated**

--- a/docs/visualize_time_lapse_video.md
+++ b/docs/visualize_time_lapse_video.md
@@ -1,0 +1,40 @@
+## Automatically Generate a Time-Lapse Video given A Directory of Images
+
+This function generates and saves the time-lapse video based on a list of paths to the images.
+
+**plantcv.visualize.time_lapse_video**(*img_list, out_filename='./time_lapse_video.mp4', fps=29.97, display=True*)
+
+**returns** frame_size
+
+- **Parameters:**
+    - list_img       - List of paths to the images to create the video.    
+    - out_filename   - Name of file to save the generated video to.
+    - fps            - Frame rate (frames per second) By default fps=29.97. Commonly used values: 23.98, 24, 25, 29.97, 30, 50, 59.94, 60   
+    - display        - if True (default), displays the path to the generated video.
+
+- **Context:**
+    - Used to generate time-lapse video given a list of images.
+    - List of image paths can be generated with [`plantcv.io.read_dataset`](io_read_dataset.md). 
+
+- **Example Use:**
+    - Below
+
+
+```python
+from plantcv import plantcv as pcv
+# Note you will have to change this part on your own path
+img_directory = './path_to_images_directory/'
+img_paths_list = pcv.io.read_dataset(source_path=img_directory, sort=True)
+
+frame_size = pcv.visualize.time_lapse_video(img_list=img_paths_list,
+                                                    out_filename='./eg_time_lapse.mp4',
+                                                    fps=29.97, display=True)
+```
+
+**Video generated**
+
+The generated video should look similar to the one below:
+<iframe src="https://player.vimeo.com/video/436453444" width="640" height="640" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/visualize/time_lapse_video.py)

--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,8 @@ dependencies:
   - flyr
   - nbconvert
   - nbformat
+  - imageio >= 2.28
+  - imageio-ffmpeg
 
 channels:
   - conda-forge

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -225,6 +225,7 @@ nav:
           - 'Pixel Scatter Plot': 'visualize_pixel_scatter_vis.md'
           - 'Pseudocolor': visualize_pseudocolor.md
           - 'Tile': visualize_tile.md
+          - 'Time Lapse Video': visualize_time_lapse_video.md
       - 'Watershed Segmentation': watershed.md
       - 'White balance': white_balance.md
       - 'Within Frame': within_frame.md

--- a/plantcv/plantcv/visualize/__init__.py
+++ b/plantcv/plantcv/visualize/__init__.py
@@ -14,4 +14,4 @@ from plantcv.plantcv.visualize.tile import tile
 
 __all__ = ["pseudocolor", "colorize_masks", "histogram", "colorspaces", "auto_threshold_methods",
            "overlay_two_imgs", "colorize_label_img", "obj_size_ecdf", "obj_sizes", "hyper_histogram",
-           "pixel_scatter_plot", "chlorophyll_fluorescence", "tile"]
+           "pixel_scatter_plot", "chlorophyll_fluorescence", "tile", "time_lapse_video"]

--- a/plantcv/plantcv/visualize/__init__.py
+++ b/plantcv/plantcv/visualize/__init__.py
@@ -11,6 +11,7 @@ from plantcv.plantcv.visualize.hyper_histogram import hyper_histogram
 from plantcv.plantcv.visualize.pixel_scatter_vis import pixel_scatter_plot
 from plantcv.plantcv.visualize.chlorophyll_fluorescence import chlorophyll_fluorescence
 from plantcv.plantcv.visualize.tile import tile
+from plantcv.plantcv.visualize.time_lapse_video import time_lapse_video
 
 __all__ = ["pseudocolor", "colorize_masks", "histogram", "colorspaces", "auto_threshold_methods",
            "overlay_two_imgs", "colorize_label_img", "obj_size_ecdf", "obj_sizes", "hyper_histogram",

--- a/plantcv/plantcv/visualize/time_lapse_video.py
+++ b/plantcv/plantcv/visualize/time_lapse_video.py
@@ -1,0 +1,60 @@
+# Create time-lapse videos with input directory of images
+
+import os
+import imageio.v3 as iio
+import numpy as np
+from plantcv.plantcv import params
+from plantcv.plantcv.transform import resize
+from plantcv.plantcv import warn
+
+
+def time_lapse_video(img_list, out_filename='./time_lapse_video.mp4', fps=29.97, display=True):
+    """Generate time-lapse video given a list of paths to the images
+
+    Inputs:
+    img_list       = the desired list of paths to the images to create the video
+    out_filename   = name of file to save the generated video to
+    fps            = frame rate (frames per second)
+    display        = if True (default), displays the path to the generated video
+
+    Outputs:
+    frame_size     = the frame size of the generated video
+
+    :param img_list: list
+    :param fps: float
+    :param out_filename: string
+    :param display: boolean
+    :return frame_size: tuple
+    """
+    params.debug = None
+
+    imgs = []
+    list_r = []
+    list_c = []
+    for file in img_list:
+        img = iio.imread(file)
+        # if img is None:
+        #     fatal_error(f"Unable to read {file}")
+        list_r.append(img.shape[0])
+        list_c.append(img.shape[1])
+        imgs.append(img)
+    max_c, max_r = np.max(list_c), np.max(list_r)
+
+    # use the largest size of the images as the frame size
+    # frame_size = frame_size or (max_c, max_r)
+    frame_size = (max_c, max_r)
+
+    if not (len(np.unique(list_r)) == 1 and len(np.unique(list_c)) == 1):
+        warn("The sizes of images are not the same, an image resizing (cropping or zero-padding) will be done "
+             f"to make all images the same size ({frame_size[0]}x{frame_size[1]}) before creating the video! ")
+
+    out_path, _ = os.path.splitext(out_filename)
+    out_filename = out_path + '.mp4'
+
+    frames = [resize(img, frame_size, interpolation=None) for img in imgs]
+    iio.imwrite(out_filename, frames, fps=fps, codec="libx264")
+
+    if display is True:
+        print(f'Path to generated video: \n{out_filename}')
+
+    return frame_size

--- a/plantcv/plantcv/visualize/time_lapse_video.py
+++ b/plantcv/plantcv/visualize/time_lapse_video.py
@@ -31,8 +31,6 @@ def time_lapse_video(img_list, out_filename='./time_lapse_video.mp4', fps=29.97)
     list_c = []
     for file in img_list:
         img = iio.imread(file)
-        # if img is None:
-        #     fatal_error(f"Unable to read {file}")
         list_r.append(img.shape[0])
         list_c.append(img.shape[1])
         imgs.append(img)

--- a/plantcv/plantcv/visualize/time_lapse_video.py
+++ b/plantcv/plantcv/visualize/time_lapse_video.py
@@ -3,18 +3,19 @@
 import os
 import imageio.v3 as iio
 import numpy as np
-from plantcv.plantcv import params
-from plantcv.plantcv.transform import resize
-from plantcv.plantcv import warn
+from plantcv.plantcv._globals import params
+from plantcv.plantcv.transform.resize import resize
+from plantcv.plantcv.io.read_dataset import read_dataset
+from plantcv.plantcv.warn import warn
 
 
-def time_lapse_video(img_list, out_filename='./time_lapse_video.mp4', fps=29.97):
+def time_lapse_video(source, out_filename='./time_lapse_video.mp4', fps=29.97):
     """Generate time-lapse video given a list of paths to the images
 
     Parameters:
     -----------
-    img_list       = list,
-        the desired list of paths to the images to create the video
+    source         = string or list,
+        Path to a folder of images to use or list of paths to the images to create the video
     out_filename   = string,
         name of file to save the generated video to
     fps            = float,
@@ -26,6 +27,9 @@ def time_lapse_video(img_list, out_filename='./time_lapse_video.mp4', fps=29.97)
         the frame size of the generated video
     """
     params.debug = None
+    img_list = source
+    if isinstance(source, str):
+        img_list = read_dataset(source, sort=True)
 
     imgs = []
     list_r = []

--- a/plantcv/plantcv/visualize/time_lapse_video.py
+++ b/plantcv/plantcv/visualize/time_lapse_video.py
@@ -11,18 +11,19 @@ from plantcv.plantcv import warn
 def time_lapse_video(img_list, out_filename='./time_lapse_video.mp4', fps=29.97):
     """Generate time-lapse video given a list of paths to the images
 
-    Inputs:
-    img_list       = the desired list of paths to the images to create the video
-    out_filename   = name of file to save the generated video to
-    fps            = frame rate (frames per second)
+    Parameters:
+    -----------
+    img_list       = list,
+        the desired list of paths to the images to create the video
+    out_filename   = string,
+        name of file to save the generated video to
+    fps            = float,
+        frame rate (frames per second)
 
-    Outputs:
-    frame_size     = the frame size of the generated video
-
-    :param img_list: list
-    :param fps: float
-    :param out_filename: string
-    :return frame_size: tuple
+    Returns:
+    --------
+    frame_size     = tuple,
+        the frame size of the generated video
     """
     params.debug = None
 
@@ -48,6 +49,6 @@ def time_lapse_video(img_list, out_filename='./time_lapse_video.mp4', fps=29.97)
     out_filename = out_path + '.mp4'
 
     frames = [resize(img, frame_size, interpolation=None) for img in imgs]
-    iio.imwrite(out_filename, frames, fps=fps, codec="libx264")
+    iio.imwrite(out_filename, frames, plugin="FFMPEG", fps=fps, codec="libx264")
 
     return frame_size

--- a/plantcv/plantcv/visualize/time_lapse_video.py
+++ b/plantcv/plantcv/visualize/time_lapse_video.py
@@ -8,14 +8,13 @@ from plantcv.plantcv.transform import resize
 from plantcv.plantcv import warn
 
 
-def time_lapse_video(img_list, out_filename='./time_lapse_video.mp4', fps=29.97, display=True):
+def time_lapse_video(img_list, out_filename='./time_lapse_video.mp4', fps=29.97):
     """Generate time-lapse video given a list of paths to the images
 
     Inputs:
     img_list       = the desired list of paths to the images to create the video
     out_filename   = name of file to save the generated video to
     fps            = frame rate (frames per second)
-    display        = if True (default), displays the path to the generated video
 
     Outputs:
     frame_size     = the frame size of the generated video
@@ -23,7 +22,6 @@ def time_lapse_video(img_list, out_filename='./time_lapse_video.mp4', fps=29.97,
     :param img_list: list
     :param fps: float
     :param out_filename: string
-    :param display: boolean
     :return frame_size: tuple
     """
     params.debug = None
@@ -53,8 +51,5 @@ def time_lapse_video(img_list, out_filename='./time_lapse_video.mp4', fps=29.97,
 
     frames = [resize(img, frame_size, interpolation=None) for img in imgs]
     iio.imwrite(out_filename, frames, fps=fps, codec="libx264")
-
-    if display is True:
-        print(f'Path to generated video: \n{out_filename}')
 
     return frame_size

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,9 @@ dependencies = [
     "nd2",
     "flyr",
     "nbconvert",
-    "nbformat"
+    "nbformat",
+    "imageio >= 2.28",
+    "imageio-ffmpeg"
 ]
 requires-python = ">=3.8"
 authors = [

--- a/tests/plantcv/visualize/test_time_lapse_video.py
+++ b/tests/plantcv/visualize/test_time_lapse_video.py
@@ -4,7 +4,7 @@ import numpy as np
 from plantcv.plantcv.visualize.time_lapse_video import time_lapse_video
 
 
-def test_plantcv_visualize_time_lapse_video_passes(tmpdir):
+def test_plantcv_visualize_time_lapse_video_list_input(tmpdir):
     """Test for PlantCV."""
     # Generate 3 test images and saved in tmpdir
     list_im = []
@@ -17,7 +17,22 @@ def test_plantcv_visualize_time_lapse_video_passes(tmpdir):
         list_im.append(img_i_path)
 
     vid_name = os.path.join(tmpdir, 'test_time_lapse_video.mp4')
-    _ = time_lapse_video(img_list=list_im, out_filename=vid_name, fps=29.97)
+    _ = time_lapse_video(source=list_im, out_filename=vid_name, fps=29.97)
+    assert os.path.exists(vid_name) and os.path.getsize(vid_name) > 100
+
+
+def test_plantcv_visualize_time_lapse_video_str_input(tmpdir):
+    """Test for PlantCV."""
+    # Generate 3 test images and saved in tmpdir
+    for i in range(3):
+        temp_img = np.random.rand(3, 3)
+        min_, max_ = np.nanmin(temp_img), np.nanmax(temp_img)
+        temp_img = np.interp(temp_img, (min_, max_), (0, 255)).astype('uint8')
+        img_i_path = os.path.join(tmpdir, f"img{i}.png")
+        cv2.imwrite(img_i_path, temp_img)
+
+    vid_name = os.path.join(tmpdir, 'test_time_lapse_video.mp4')
+    _ = time_lapse_video(source=str(tmpdir), out_filename=vid_name, fps=29.97)
     assert os.path.exists(vid_name) and os.path.getsize(vid_name) > 100
 
 
@@ -35,7 +50,7 @@ def test_plantcv_visualize_time_lapse_video_different_img_sizes_warns(tmpdir, ca
         list_im.append(img_i_path)
 
     vid_name = os.path.join(tmpdir, 'test_time_lapse_video.mp4')
-    _ = time_lapse_video(img_list=list_im, out_filename=vid_name, fps=29.97)
+    _ = time_lapse_video(source=list_im, out_filename=vid_name, fps=29.97)
     _, err = capsys.readouterr()
 
     assert "Warning" in err and os.path.exists(vid_name)

--- a/tests/plantcv/visualize/test_time_lapse_video.py
+++ b/tests/plantcv/visualize/test_time_lapse_video.py
@@ -1,12 +1,10 @@
-import pytest
 import os
 import cv2
 import numpy as np
 from plantcv.plantcv.visualize.time_lapse_video import time_lapse_video
 
 
-@pytest.mark.parametrize("display", [False, True])
-def test_plantcv_visualize_time_lapse_video_passes(display, tmpdir):
+def test_plantcv_visualize_time_lapse_video_passes(tmpdir):
     """Test for PlantCV."""
     # Generate 3 test images and saved in tmpdir
     list_im = []
@@ -19,7 +17,7 @@ def test_plantcv_visualize_time_lapse_video_passes(display, tmpdir):
         list_im.append(img_i_path)
 
     vid_name = os.path.join(tmpdir, 'test_time_lapse_video.mp4')
-    _ = time_lapse_video(img_list=list_im, out_filename=vid_name, fps=29.97, display=display)
+    _ = time_lapse_video(img_list=list_im, out_filename=vid_name, fps=29.97)
     assert os.path.exists(vid_name)
 
 
@@ -37,7 +35,7 @@ def test_plantcv_visualize_time_lapse_video_different_img_sizes_warns(tmpdir, ca
         list_im.append(img_i_path)
 
     vid_name = os.path.join(tmpdir, 'test_time_lapse_video.mp4')
-    _ = time_lapse_video(img_list=list_im, out_filename=vid_name, fps=29.97, display=True)
+    _ = time_lapse_video(img_list=list_im, out_filename=vid_name, fps=29.97)
     _, err = capsys.readouterr()
 
     assert "Warning" in err and os.path.exists(vid_name)

--- a/tests/plantcv/visualize/test_time_lapse_video.py
+++ b/tests/plantcv/visualize/test_time_lapse_video.py
@@ -18,7 +18,7 @@ def test_plantcv_visualize_time_lapse_video_passes(tmpdir):
 
     vid_name = os.path.join(tmpdir, 'test_time_lapse_video.mp4')
     _ = time_lapse_video(img_list=list_im, out_filename=vid_name, fps=29.97)
-    assert os.path.exists(vid_name)
+    assert os.path.exists(vid_name) and os.path.getsize(vid_name) > 100
 
 
 # not all images have the same size (essential to generate a video)

--- a/tests/plantcv/visualize/test_time_lapse_video.py
+++ b/tests/plantcv/visualize/test_time_lapse_video.py
@@ -1,0 +1,43 @@
+import pytest
+import os
+import cv2
+import numpy as np
+from plantcv.plantcv.visualize.time_lapse_video import time_lapse_video
+
+
+@pytest.mark.parametrize("display", [False, True])
+def test_plantcv_visualize_time_lapse_video_passes(display, tmpdir):
+    """Test for PlantCV."""
+    # Generate 3 test images and saved in tmpdir
+    list_im = []
+    for i in range(3):
+        temp_img = np.random.rand(3, 3)
+        min_, max_ = np.nanmin(temp_img), np.nanmax(temp_img)
+        temp_img = np.interp(temp_img, (min_, max_), (0, 255)).astype('uint8')
+        img_i_path = os.path.join(tmpdir, f"img{i}.png")
+        cv2.imwrite(img_i_path, temp_img)
+        list_im.append(img_i_path)
+
+    vid_name = os.path.join(tmpdir, 'test_time_lapse_video.mp4')
+    _ = time_lapse_video(img_list=list_im, out_filename=vid_name, fps=29.97, display=display)
+    assert os.path.exists(vid_name)
+
+
+# not all images have the same size (essential to generate a video)
+def test_plantcv_visualize_time_lapse_video_different_img_sizes_warns(tmpdir, capsys):
+    """Test for PlantCV."""
+    # Generate 3 test images of different size and save in tmpdir
+    list_im = []
+    for i in range(2):
+        temp_img = np.random.rand(i+2, 3)
+        min_, max_ = np.nanmin(temp_img), np.nanmax(temp_img)
+        temp_img = np.interp(temp_img, (min_, max_), (0, 255)).astype('uint8')
+        img_i_path = os.path.join(tmpdir, f"img{i}.png")
+        cv2.imwrite(img_i_path, temp_img)
+        list_im.append(img_i_path)
+
+    vid_name = os.path.join(tmpdir, 'test_time_lapse_video.mp4')
+    _ = time_lapse_video(img_list=list_im, out_filename=vid_name, fps=29.97, display=True)
+    _, err = capsys.readouterr()
+
+    assert "Warning" in err and os.path.exists(vid_name)


### PR DESCRIPTION
**Describe your changes**
Our plan was to deprecate the `pcv.visualize.time_lapse_video` function because it required QT and that created conflicts with PlantCV add-on tools. Instead we were able to refactor the function to use `imageio` instead of OpenCV and restore the functionality without QT. This PR also updates the function inputs to remove the `display` parameter, which only prints out the filepath of the video but is provided by the user. 

We might consider changing the output value. The function returns the frame size but I think it could instead not return anything, like `pcv.print_image`.

**Type of update**
Is this a: New feature or feature enhancement

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
