### PR TITLE
Update scikit-image version in environment.yml for v5

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pandas
   - python-dateutil
   - scipy<1.16
-  - scikit-image>=0.19
+  - scikit-image>=0.26
   - scikit-learn
   - dask
   - dask-jobqueue

--- a/plantcv/plantcv/fill.py
+++ b/plantcv/plantcv/fill.py
@@ -37,7 +37,7 @@ def fill(bin_img, size, roi=None):
     bool_img = _rect_filter(bool_img,
                             roi=roi,
                             function=remove_small_objects,
-                            **{"min_size" : size})
+                            **{"max_size" : size})
     # Cast boolean image to binary and make a copy of the binary image for returning
     filtered_img = np.copy(bool_img.astype(np.uint8) * 255)
     # slice the subset image back into full size binary image

--- a/plantcv/plantcv/fill.py
+++ b/plantcv/plantcv/fill.py
@@ -37,7 +37,7 @@ def fill(bin_img, size, roi=None):
     bool_img = _rect_filter(bool_img,
                             roi=roi,
                             function=remove_small_objects,
-                            **{"max_size" : size})
+                            **{"min_size" : size})
     # Cast boolean image to binary and make a copy of the binary image for returning
     filtered_img = np.copy(bool_img.astype(np.uint8) * 255)
     # slice the subset image back into full size binary image


### PR DESCRIPTION
**Describe your changes**
Fixes environment.yml file to build a newer version of scikit-image for v5 pcv.fill

**Type of update**
Is this a:
Bug fix

**Associated issues**
https://github.com/danforthcenter/plantcv/issues/1952#issue-4737082480

**Additional context**
scikit-image are depreciating max_size to min_size

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
