### PR TITLE
Use min_size or max_size depending on scikit-image version

### DIFF
--- a/plantcv/plantcv/fill.py
+++ b/plantcv/plantcv/fill.py
@@ -1,5 +1,6 @@
 # Object fill device
 
+import inspect
 import numpy as np
 import os
 from plantcv.plantcv import fatal_error
@@ -7,6 +8,8 @@ from plantcv.plantcv import params
 from plantcv.plantcv._debug import _debug
 from plantcv.plantcv._helpers import _rect_filter, _rect_replace
 from skimage.morphology import remove_small_objects
+
+_SKIMAGE_USE_MAX_SIZE = "max_size" in inspect.signature(remove_small_objects).parameters
 
 
 def fill(bin_img, size, roi=None):
@@ -34,10 +37,11 @@ def fill(bin_img, size, roi=None):
     bool_img = bin_img.astype(bool)
 
     # Find and fill contours, possibly within bounding rectangle
+    _size_kwarg = {"max_size": size} if _SKIMAGE_USE_MAX_SIZE else {"min_size": size}
     bool_img = _rect_filter(bool_img,
                             roi=roi,
                             function=remove_small_objects,
-                            **{"min_size" : size})
+                            **_size_kwarg)
     # Cast boolean image to binary and make a copy of the binary image for returning
     filtered_img = np.copy(bool_img.astype(np.uint8) * 255)
     # slice the subset image back into full size binary image


### PR DESCRIPTION
**Describe your changes**
Scikit-image deprecated min_size from remove_small_objects and replaced the argument with max_size. This PR updates `pcv.fill` to use either keyword argument depending on the function signature of the installed version of scikit-image. This allows us to be more flexible with scikit-image across multiple versions of PlantCV.

**Type of update**
Is this a: Bug fix

**Associated issues**
Closes #1952 

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
