### PR TITLE
Roi to labeled mask

### DIFF
--- a/docs/roi2mask.md
+++ b/docs/roi2mask.md
@@ -1,6 +1,6 @@
 ## Region of interest to mask
 
-Convert a region of interest/object contour to a binary mask of the same shape
+Convert a region of interest/object contour to a labeled or binary mask of the same shape
 
 **plantcv.roi.roi2mask**(*img, roi*)
 
@@ -12,6 +12,7 @@ Convert a region of interest/object contour to a binary mask of the same shape
 
 - **Context:**
     - `img` parameter is only used to determine the size of the mask getting created.
+	- If `roi` contains multiple contours then a labeled mask (0, 1, 2, ..., n) is returned, otherwise a binary (0, 255) mask is returned.
 - **Example use:**
     - below
 

--- a/docs/roi2mask.md
+++ b/docs/roi2mask.md
@@ -12,7 +12,7 @@ Convert a region of interest/object contour to a labeled or binary mask of the s
 
 - **Context:**
     - `img` parameter is only used to determine the size of the mask getting created.
-	- If `roi` contains multiple contours then a labeled mask (0, 1, 2, ..., n) is returned, otherwise a binary (0, 255) mask is returned.
+    - If `roi` contains multiple contours then a labeled mask (0, 1, 2, ..., n) is returned, otherwise a binary (0, 255) mask is returned.
 - **Example use:**
     - below
 

--- a/plantcv/plantcv/roi/quick_filter.py
+++ b/plantcv/plantcv/roi/quick_filter.py
@@ -48,7 +48,7 @@ def quick_filter(mask, roi, roi_type="partial"):
     labels = labels.astype(float)
 
     # Set the ROI mask value to 0.5
-    roi_mask[np.where(roi_mask == 255)] = 0.5
+    roi_mask[np.where(roi_mask > 0)] = 0.5
 
     # Add the labeled mask and ROI mask together
     summed = roi_mask + labels

--- a/plantcv/plantcv/roi/roi2mask.py
+++ b/plantcv/plantcv/roi/roi2mask.py
@@ -33,6 +33,6 @@ def roi2mask(img, roi):
         cv2.drawContours(labeled_mask, obj.contours[0], -1, (i+1), -1)
 
     if num_labels == 1:
-        labeled_mask = labeled_mask * 255
+        labeled_mask = (labeled_mask * 255).astype(np.uint8)
 
     return labeled_mask

--- a/plantcv/plantcv/roi/roi2mask.py
+++ b/plantcv/plantcv/roi/roi2mask.py
@@ -3,9 +3,9 @@
 import os
 import cv2
 import numpy as np
+from skimage.color import label2rgb
 from plantcv.plantcv._globals import params
 from plantcv.plantcv._debug import _debug
-from plantcv.plantcv.create_labels import create_labels
 
 
 def roi2mask(img, roi):
@@ -32,7 +32,14 @@ def roi2mask(img, roi):
         # Pixel intensity of (i+1) such that the first object has value 1
         cv2.drawContours(labeled_mask, obj.contours[0], -1, (i+1), -1)
 
+    colorful = label2rgb(labeled_mask)
+    colorful2 = (255*colorful).astype(np.uint8)
+
     if num_labels == 1:
-        labeled_mask = (labeled_mask * 255).astype(np.uint8)
+        labeled_mask = (labeled_mask*255).astype(np.uint8)
+
+    _debug(visual=colorful2,
+           filename=os.path.join(params.debug_outdir,
+                                 f"{params.device}_roi2mask.png"))
 
     return labeled_mask

--- a/plantcv/plantcv/roi/roi2mask.py
+++ b/plantcv/plantcv/roi/roi2mask.py
@@ -5,31 +5,34 @@ import cv2
 import numpy as np
 from plantcv.plantcv._globals import params
 from plantcv.plantcv._debug import _debug
+from plantcv.plantcv.create_labels import create_labels
 
 
 def roi2mask(img, roi):
     """
     Create a binary mask from an ROI contour
-    Inputs:
-    img                  = RGB or grayscale image data
-    roi                  = A region of interest as an instance of the class Objects
+
+    Parameters:
+    -----------
+    img = numpy.ndarray,
+        RGB or grayscale image data
+    roi = plantcv.plantcv.classes.Objects,
+        A region of interest as an instance of the class Objects
 
     Returns:
-    mask   = Binary mask
-
-    :param img: numpy.ndarray
-    :param roi: plantcv.plantcv.classes.Objects
-    :return mask: numpy.ndarray
+    --------
+    mask   = numpy.ndarray,
+        Labeled mask or binary mask if only one ROI is given
     """
     # create a blank image of same size
-    shape_info = np.shape(img)
-    mask = np.zeros((shape_info[0], shape_info[1]), dtype=np.uint8)
+    labeled_mask = np.zeros(img.shape[:2], dtype=np.int32)
+    # get number of labels
+    num_labels = len(roi.contours)
+    for i, obj in enumerate(roi):
+        # Pixel intensity of (i+1) such that the first object has value 1
+        cv2.drawContours(labeled_mask, obj.contours[0], -1, (i+1), -1)
 
-    for single_roi_cnt in roi:
-        _ = cv2.drawContours(mask, single_roi_cnt.contours[0], 0, 255, -1)
+    if num_labels == 1:
+        labeled_mask = labeled_mask * 255
 
-    _debug(visual=mask,
-           filename=os.path.join(params.debug_outdir, str(params.device) + '_roi_mask.png'),
-           cmap='gray')
-
-    return mask
+    return labeled_mask

--- a/plantcv/plantcv/roi/roi2mask.py
+++ b/plantcv/plantcv/roi/roi2mask.py
@@ -1,4 +1,4 @@
-# Helper function to take an ROI and turn it into a binary mask
+# Helper function to take an ROI and turn it into a binary or labeled mask
 
 import os
 import cv2
@@ -10,7 +10,7 @@ from plantcv.plantcv._debug import _debug
 
 def roi2mask(img, roi):
     """
-    Create a binary mask from an ROI contour
+    Create a labeled or binary mask from an ROI contour
 
     Parameters:
     -----------

--- a/tests/plantcv/roi/test_roi2mask.py
+++ b/tests/plantcv/roi/test_roi2mask.py
@@ -1,6 +1,6 @@
 import cv2
 import numpy as np
-from plantcv.plantcv.roi import roi2mask
+from plantcv.plantcv.roi import roi2mask, multi_rect
 from plantcv.plantcv import Objects
 
 
@@ -12,3 +12,12 @@ def test_roi2mask(roi_test_data):
     roi = Objects(contours=[roi_cnt], hierarchy=[roi_h])
     mask = roi2mask(img=img, roi=roi)
     assert np.shape(mask)[0:2] == np.shape(img)[0:2] and np.array_equal(np.unique(mask), np.array([0, 255]))
+
+
+def test_roi2labeledmask(test_data):
+    """Test for PlantCV."""
+    img = cv2.imread(test_data.small_rgb_img)
+    roi_objects = multi_rect(img=img, coord=(25, 25), h=5, w=5,
+                             spacing=(10, 10), nrows=2, ncols=2)
+    m = roi2mask(img, roi_objects)
+    assert np.array_equal(np.unique(m), np.array([0, 1, 2, 3, 4]))


### PR DESCRIPTION
**Describe your changes**
Changes `pcv.roi.roi2mask` to return a labeled mask when the `roi` has multiple contours. If a single contour is provided then a `uint8` [0, 255] binary mask is returned

**Type of update**
Is this a feature enhancement.

**Associated issues**
None

**Additional context**
None

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
