### PR TITLE
Update for OpenCV 5 compatibility

### DIFF
--- a/plantcv/learn/naive_bayes.py
+++ b/plantcv/learn/naive_bayes.py
@@ -128,7 +128,8 @@ def naive_bayes_multiclass(samples_file, outfile, mkplots=False):
     # For each class
     for cls in class_list:
         # Create a blue, green, red-formatted image ndarray with the class RGB values
-        bgr_img = cv2.merge((np.asarray(sample_points[cls]["blue"], dtype=np.uint8),
+        # Use np.dstack rather than cv2.merge so the array keeps an explicit channel dimension across OpenCV versions
+        bgr_img = np.dstack((np.asarray(sample_points[cls]["blue"], dtype=np.uint8),
                              np.asarray(sample_points[cls]["green"], dtype=np.uint8),
                              np.asarray(sample_points[cls]["red"], dtype=np.uint8)))
         # Convert the BGR ndarray to an HSV ndarray


### PR DESCRIPTION
**Describe your changes**
This pull request makes a minor but important update to the `naive_bayes_multiclass` function in `plantcv/learn/naive_bayes.py` to improve compatibility across different OpenCV versions.

- Replaced `cv2.merge` with `np.dstack` when creating the `bgr_img` array, ensuring the resulting array maintains an explicit channel dimension regardless of the OpenCV version.

**Type of update**
Is this a: Bug fix

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
