### PR TITLE
Strip .json extension from CSV filenames in json2csv (Fixes #1679)

### DIFF
--- a/plantcv/utils/converters.py
+++ b/plantcv/utils/converters.py
@@ -36,6 +36,12 @@ def json2csv(json_file, csv_prefix):
     # Split up variables
     meta_vars, scalar_vars, multi_vars = _unpack_variables(data)
 
+    # Strip a trailing .json extension from the prefix so filenames do not end up
+    # as e.g. "results.json-single-value-traits.csv" (plantcv-run-workflow reuses
+    # the JSON results filename as the CSV prefix)
+    if csv_prefix.endswith(".json"):
+        csv_prefix = csv_prefix[:-len(".json")]
+
     # Output files
     scalar_file = csv_prefix + "-single-value-traits.csv"
     multi_file = csv_prefix + "-multi-value-traits.csv"

--- a/tests/utils/test_json2csv.py
+++ b/tests/utils/test_json2csv.py
@@ -11,6 +11,19 @@ def test_json2csv(utils_test_data, tmpdir):
     assert os.path.exists(os.path.join(str(tmp_dir), "exports-single-value-traits.csv"))
 
 
+def test_json2csv_json_prefix(utils_test_data, tmpdir):
+    """Test for PlantCV."""
+    # Create tmp directory
+    tmp_dir = tmpdir.mkdir("cache")
+    # Pass a csv_prefix that still carries the .json extension, as happens when
+    # plantcv-run-workflow reuses the JSON results filename as the CSV prefix
+    csv_prefix = os.path.join(str(tmp_dir), "exports.json")
+    json2csv(json_file=utils_test_data.plantcv_results_file, csv_prefix=csv_prefix)
+    # The .json extension should be stripped, not embedded in the CSV filename
+    assert os.path.exists(os.path.join(str(tmp_dir), "exports-single-value-traits.csv"))
+    assert not os.path.exists(os.path.join(str(tmp_dir), "exports.json-single-value-traits.csv"))
+
+
 def test_json2csv_no_json(utils_test_data, tmpdir):
     """Test for PlantCV."""
     # Create tmp directory


### PR DESCRIPTION
## Problem

Fixes #1679.

When running `plantcv-run-workflow`, the CSV files it generates from the JSON
results keep the `.json` extension embedded in their names. For example, with a
config pointing at `./results/output_control.json`, the workflow writes:

```
output_control.json-single-value-traits.csv
output_control.json-multi-value-traits.csv
```

instead of the expected `output_control-single-value-traits.csv`.

## Root cause

In `plantcv/parallel/cli.py`, the JSON results filename is passed directly as the
CSV prefix:

```python
plantcv.utils.json2csv(config.json, config.json)
```

`json2csv` then builds its outputs as `csv_prefix + "-single-value-traits.csv"`,
so the `.json` extension ends up glued in front of the `-single-value-traits.csv`
suffix. Anyone calling `json2csv` directly with a `.json`-suffixed prefix hits the
same thing.

## Fix

Strip a trailing `.json` extension from `csv_prefix` inside `json2csv` before the
output filenames are assembled. Doing it in `json2csv` covers both the automatic
workflow call and any direct call, so the whole bug class is handled in one place
rather than only patching the single reported call site.

```python
if csv_prefix.endswith(".json"):
    csv_prefix = csv_prefix[:-len(".json")]
```

## Testing

Added a regression test, `test_json2csv_json_prefix`, that calls `json2csv` with a
`.json`-suffixed prefix and asserts the output is `exports-single-value-traits.csv`
and *not* `exports.json-single-value-traits.csv`.

- The new test fails before the fix (writes `exports.json-single-value-traits.csv`)
  and passes after it.
- `pytest tests/utils/` — 17 passed.
- `pytest tests/parallel/` — 37 passed (this exercises the `run-workflow` →
  `json2csv` path).
- `flake8 --max-line-length=127` (the repo's configured limit from
  `.deepsource.toml`) is clean on both changed files.
