### PR TITLE
Ports change to json2csv from v4 to v5

### DIFF
--- a/plantcv/parallel/run_parallel.py
+++ b/plantcv/parallel/run_parallel.py
@@ -92,7 +92,7 @@ def run_parallel(config):
     # Convert results start time
     convert_results_start_time = time.time()
     print("Converting json to csv... ", file=sys.stderr)
-    json2csv(config.results, os.path.splitext(config.results)[0])
+    json2csv(config.results, config.results)
     convert_results_clock_time = time.time() - convert_results_start_time
     parallel_print(f"Processing results took {convert_results_clock_time} seconds.", file=sys.stderr, verbose=verbose)
     ###########################################

--- a/plantcv/plantcv/json2csv.py
+++ b/plantcv/plantcv/json2csv.py
@@ -35,6 +35,12 @@ def json2csv(json_file, csv_prefix):
     # Split up variables
     meta_vars, scalar_vars, multi_vars = _unpack_variables(data)
 
+    # Strip a trailing .json extension from the prefix so filenames do not end up
+    # as e.g. "results.json-single-value-traits.csv" (plantcv-run-workflow reuses
+    # the JSON results filename as the CSV prefix)
+    if csv_prefix.endswith(".json"):
+        csv_prefix = csv_prefix[:-len(".json")]
+
     # Output files
     scalar_file = csv_prefix + "-single-value-traits.csv"
     multi_file = csv_prefix + "-multi-value-traits.csv"

--- a/tests/plantcv/test_json2csv.py
+++ b/tests/plantcv/test_json2csv.py
@@ -11,6 +11,19 @@ def test_json2csv(test_data, tmpdir):
     assert os.path.exists(os.path.join(str(tmp_dir), "exports-single-value-traits.csv"))
 
 
+def test_json2csv_json_prefix(test_data, tmpdir):
+    """Test for PlantCV."""
+    # Create tmp directory
+    tmp_dir = tmpdir.mkdir("cache")
+    # Pass a csv_prefix that still carries the .json extension, as happens when
+    # plantcv-run-workflow reuses the JSON results filename as the CSV prefix
+    csv_prefix = os.path.join(str(tmp_dir), "exports.json")
+    json2csv(json_file=test_data.plantcv_results_file, csv_prefix=csv_prefix)
+    # The .json extension should be stripped, not embedded in the CSV filename
+    assert os.path.exists(os.path.join(str(tmp_dir), "exports-single-value-traits.csv"))
+    assert not os.path.exists(os.path.join(str(tmp_dir), "exports.json-single-value-traits.csv"))
+
+
 def test_json2csv_no_json(test_data, tmpdir):
     """Test for PlantCV."""
     # Create tmp directory


### PR DESCRIPTION
**Describe your changes**
In the v5 development branch, `json2csv` moved from the deprecated `utils` subpackage to the `plantcv` core package. This PR ports changes introduce in #1967 to the v5 branch.

**Type of update**
Is this a: update

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
