### PR TITLE
Lazy load psd psl

### DIFF
--- a/docs/photosynthesis_read_cropreporter.md
+++ b/docs/photosynthesis_read_cropreporter.md
@@ -13,9 +13,11 @@ PSII_data instance containing [xarray DataArrays](http://xarray.pydata.org/en/st
 - **Context:**
     - Reads in binary image files to be processed and does so using the metadata contained within a corresponding .INF
       file.
-    - Measurements from dark-adapted plant state are stored in the attribute `psd` (ojip) or `pam_dark`, depending on the measurement protocol. Frames F0 and Fm are
+    - Measurements from dark-adapted plant state are stored in the attribute `psd` (ojip) which has an `ojip_dark` attribute holding an xarray or `pam_dark`,
+	  depending on the measurement protocol. Frames F0 and Fm are
       labeled according to the metadata in .INF. The default measurement label is 't0'.
-    - Measurements from light-adapted plant state are stored in the attribute `psl` (ojip) or `pam_light`, depending on the measurement protocol. Frames Fp and Fmp are
+    - Measurements from light-adapted plant state are stored in the attribute `psl` (ojip) which has an `ojip_light` attribute holding an xarray or `pam_light`,
+	  depending on the measurement protocol. Frames Fp and Fmp are
       labeled according to the metadata in .INF. The default measurement label is 't1'.
     - Time-resolved PAM fluorescence measurements are stored in the attribute `pam_time`. Frames F0, Fm, Fp, Fmp, F0pp, and Fmpp are
       labeled according to the metadata in .INF, with measurement labels starting at 't0' (e.g. t0, t1, t2, ...).

--- a/plantcv/plantcv/analyze/yii.py
+++ b/plantcv/plantcv/analyze/yii.py
@@ -54,11 +54,15 @@ def yii(ps, labeled_mask, n_labels=1, auto_fm=False, measurement_labels=None, la
         "psl": _psl_calc_fqfm,
         "psd": _psd_calc_fvfm
     }
+    frame_properties = {
+        "psl": "ojip_light",
+        "psd": "ojip_dark"
+    }
 
     for frame in ["psl", "psd"]:
         if hasattr(ps, frame):
             ps_da_loader = getattr(ps, frame)
-            ps_da = ps_da_loader.load()
+            ps_da = getattr(ps_da_loader, frame_properties.get(frame))
             # Validate that the input measurement_labels is the same length as the number of measurements in the DataArray
             # this is going to the inside of the if/for loop I think.
             if (measurement_labels is not None) and (len(measurement_labels) != ps_da.coords['measurement'].shape[0]):

--- a/plantcv/plantcv/photosynthesis/read_cropreporter.py
+++ b/plantcv/plantcv/photosynthesis/read_cropreporter.py
@@ -141,6 +141,7 @@ class PSD:
         self._height = height
         self._width = width
         self._metadata = metadata
+        self._ojip_dark = None
 
     def __bool__(self):
         """The existence of the PSD class is true."""
@@ -150,8 +151,15 @@ class PSD:
         """String representation of the PSD dataset, indicating whether the data has been loaded."""
         return f"PSD(filepath={self._filepath!r})"
 
-    def load(self):
-        """Load the OJIP dark-adapted measurements from the .DAT file."""
+    @property
+    def ojip_dark(self):
+        """Return the ojip dark data"""
+        if self._ojip_dark is None:
+            self._load()
+        return self._ojip_dark
+
+    def _load(self):
+        """Load the ojip dark frames from the .DAT file."""
         img_cube, frame_labels, frame_nums = _read_dat_file(
             dataset="PSD",
             filename=str(self._filepath),
@@ -176,7 +184,8 @@ class PSD:
         # Replace frame_num with time, skip timepoint 0
         for i in range(len(frame_nums) - 1):
             frame_nums[i + 1] = int(self._metadata.get(f"FvFmTimePoint{i}", frame_nums[i + 1]))
-        return xr.DataArray(
+
+        self._ojip_dark = xr.DataArray(
             data=img_cube[..., None],
             dims=('x', 'y', 'frame_label', 'measurement'),
             coords={'frame_label': frame_labels,
@@ -195,6 +204,7 @@ class PSL:
         self._height = height
         self._width = width
         self._metadata = metadata
+        self._ojip_light = None
 
     def __bool__(self):
         """The existence of the PSL class is true."""
@@ -204,7 +214,14 @@ class PSL:
         """String representation of the PSL dataset, indicating whether the data has been loaded."""
         return f"PSL(filepath={self._filepath!r})"
 
-    def load(self):
+    @property
+    def ojip_light(self):
+        """Return the ojip light data"""
+        if self._ojip_light is None:
+            self._load()
+        return self._ojip_light
+
+    def _load(self):
         """Load the OJIP light-adapted measurements from the .DAT file."""
         img_cube, frame_labels, frame_nums = _read_dat_file(
             dataset="PSL",
@@ -230,7 +247,8 @@ class PSL:
         # Replace frame_num with time, skip timepoint 0
         for i in range(len(frame_nums) - 1):
             frame_nums[i + 1] = int(self._metadata.get(f"FqFmTimePoint{i}", frame_nums[i + 1]))
-        return xr.DataArray(
+
+        self._ojip_light = xr.DataArray(
             data=img_cube[..., None],
             dims=('x', 'y', 'frame_label', 'measurement'),
             coords={'frame_label': frame_labels,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,13 +213,16 @@ class TestData:
                           dims=('x', 'y', 'frame_label', 'measurement'),
                           coords={'frame_label': frame_labels, 'frame_num': ('frame_label', [0, 1, 2, 3]),
                                   'measurement': measurements}, name=var)
+        sub_ps = type("subpsdata", (object,), {
+            var: da
+        })
 
         ps = type("psdata", (object,), {
             'metadata': {
                 "ImageRows": 10,
                 "ImageCols": 10
             },
-            keyname: da,
+            keyname: sub_ps,
             other_keyname: None
         })
         return ps
@@ -324,12 +327,16 @@ class TestData:
             ps_da.name = 'ojip_light'
             ps_da.coords['measurement'] = prop_idx
 
+        sub_ps = type("subpsdata", (object,), {
+            var: ps_da
+        })
+
         ps = type("psdata", (object,), {
             'metadata': {
                 "ImageRows": 10,
                 "ImageCols": 10
             },
-            keyname: ps_da,
+            keyname: sub_ps,
             other_keyname: None
         })
         return ps

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -210,14 +210,20 @@ class TestData:
                           dims=('x', 'y', 'frame_label', 'measurement'),
                           coords={'frame_label': frame_labels, 'frame_num': ('frame_label', [0, 1, 2, 3]),
                                   'measurement': measurements}, name=var)
+
+        sub_ps = type("subpsdata", (object,), {
+            var: da
+        })
+
         ps = type("psdata", (object,), {
             'metadata': {
                 "ImageRows": 10,
                 "ImageCols": 10
             },
-            keyname: da
+            keyname: sub_ps
         })
         return ps
+
 
     @staticmethod
     def psii_walz(var):
@@ -316,15 +322,68 @@ class TestData:
             ps_da = xr.concat(da_list, 'measurement')
             ps_da.name = 'ojip_light'
             ps_da.coords['measurement'] = prop_idx
-        
+
+        sub_ps = type("subpsdata", (object,), {
+            var: ps_da
+        })
+
         ps = type("psdata", (object,), {
             'metadata': {
                 "ImageRows": 10,
                 "ImageCols": 10
             },
-            keyname: ps_da
+            keyname: sub_ps
         })
         return ps
+
+    @staticmethod
+    def psii_walz(var):
+        """Create and return synthetic psii dataarrays from walz"""
+        # create darkadapted
+        if var == 'ojip_dark':
+            i = 0
+            fmin = np.ones((10, 10), dtype='uint8') * ((i+15)*2)
+            fmax = np.ones((10, 10), dtype='uint8') * (200-i*15)
+            data = np.stack([fmin, fmax], axis=2)
+
+            frame_nums = range(0, 2)
+            indf = ['F0', 'Fm']
+            ps_da = xr.DataArray(
+                data=data[..., None],
+                dims=('x', 'y', 'frame_label', 'measurement'),
+                coords={'frame_label': indf,
+                        'frame_num': ('frame_label', frame_nums),
+                        'measurement': ['t0']},
+                name='ojip_dark'
+            )
+
+        # create lightadapted
+        elif var == 'ojip_light':
+            da_list = []
+            measurement = []
+
+            for i in np.arange(1, 3):
+                indf = ['Fp', 'Fmp']
+                fmin = np.ones((10, 10), dtype='uint8') * ((i+15)*2)
+                fmax = np.ones((10, 10), dtype='uint8') * (200-i*15)
+                data = np.stack([fmin, fmax], axis=2)
+
+                lightadapted = xr.DataArray(
+                    data=data[..., None],
+                    dims=('x', 'y', 'frame_label', 'measurement'),
+                    coords={'frame_label': indf,
+                            'frame_num': ('frame_label', range(0, 2))}
+                )
+
+                measurement.append((f't{i*40}'))
+                da_list.append(lightadapted)
+
+            prop_idx = pd.Index(measurement)
+            ps_da = xr.concat(da_list, 'measurement')
+            ps_da.name = 'ojip_light'
+            ps_da.coords['measurement'] = prop_idx
+
+        return ps_da
 
 
 @pytest.fixture(scope="session")

--- a/tests/plantcv/photosynthesis/test_read_cropreporter.py
+++ b/tests/plantcv/photosynthesis/test_read_cropreporter.py
@@ -20,7 +20,7 @@ def test_read_cropreporter_psd(photosynthesis_test_data, tmpdir):
     # Run the test
     ps = read_cropreporter(filename=filename)
     assert isinstance(ps, PSII_data)
-    assert ps.psd.load().shape == (966, 1296, 21, 1)
+    assert ps.psd.ojip_dark.shape == (966, 1296, 21, 1)
     assert ps.psd
     assert "PSD" in repr(ps.psd)
 
@@ -39,7 +39,7 @@ def test_read_cropreporter_psl(photosynthesis_test_data, tmpdir):
     # Run the test
     ps = read_cropreporter(filename=filename)
     assert isinstance(ps, PSII_data)
-    assert ps.psl.load().shape == (966, 1296, 21, 1)
+    assert ps.psl.ojip_light.shape == (966, 1296, 21, 1)
     assert ps.psl
     assert "PSL" in repr(ps.psl)
 


### PR DESCRIPTION
**Describe your changes**
Lazy Loads psl/psd data putting xarray in an attribute: `ps.psd.ojip_dark` and `ps.psl.ojip_light`.

**Type of update**
This is a feature update.

**Associated issues**
Part of #1926 

**Additional context**
Applies the same logic from @nfahlgren 's PRs lazy loading APH/CHL/CLR to PSL and PSD.
Follows after PR #1971

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
