### PR TITLE
Update analyze npq

### DIFF
--- a/docs/analyze_npq.md
+++ b/docs/analyze_npq.md
@@ -4,20 +4,19 @@ Extract estimates of the nonphotochemical quenching (NPQ) of Photosystem II (PSI
 Calculates (Fm/Fm') - 1 data from a masked region. The photosynthesis subpackage is dependent on a PSII_Data instance file
 structure as created by photosynthesis.read_* files.
 
-**plantcv.analyze.npq**(*ps_da_light, ps_da_dark, labeled_mask, n_labels=1, auto_fm=False, min_bin=0, max_bin="auto",
+**plantcv.analyze.npq**(*ps, labeled_mask, n_labels=1, auto_fm=False, min_bin=0, max_bin="auto",
 measurement_labels=None, label=None*)
 
 **returns** NPQ DataArray and Histograms of NPQ values
 
 - **Parameters:**
-    - ps_da_light - photosynthesis xarray DataArray for which to compute npq
-    - ps_da_dark - photosynthesis xarray DataArray that contains frame_label `Fm`
+    - ps - PSII Data object containing `ojip_dark` and `ojip_light` data from `npq` or `psl` and `psd` images.
     - labeled_mask - Labeled mask of objects (32-bit).
     - n_labels - Total number expected individual objects (default = 1).
     - auto_fm - Automatically calculate the frame with maximum fluorescence per label, otherwise use a fixed frame for all labels (default = False).
     - min_bin - minimum bin value ("auto" or user input minimum value - must be an integer). (default `min_bin=0`)
     - max_bin - maximum bin value ("auto" or user input maximum value - must be an integer). (default `max_bin="auto"`)
-    - measurement_labels - list of label(s) for each measurement in `ps_da_light`, modifies the variable name of observations recorded
+    - measurement_labels - list of label(s) for each measurement in `ojip_light` data, modifies the variable name of observations recorded
     - label - Optional label parameter, modifies the variable name of observations recorded. Can be a prefix or list (default = pcv.params.sample_label).
 - **Context:**
     - Used to extract NPQ per identified plant pixel.
@@ -39,7 +38,7 @@ pcv.params.debug = "plot"
 pcv.params.sample_label = "plant"
 
 # Analyze NPQ   
-npq, npq_hist = pcv.analyze.npq(ps_da_light=ps.npq.ojip_light, ps_da_dark=ps.npq.ojip_dark, labeled_mask=kept_mask)
+npq, npq_hist = pcv.analyze.npq(ps=ps, labeled_mask=kept_mask)
 
 # Access the NPQ median value
 # the default measurement label for cropreporter data is t1

--- a/docs/photosynthesis_read_cropreporter.md
+++ b/docs/photosynthesis_read_cropreporter.md
@@ -15,10 +15,12 @@ PSII_data instance containing [xarray DataArrays](http://xarray.pydata.org/en/st
       file.
     - Measurements from dark-adapted plant state are stored in the attribute `psd` (ojip) which has an `ojip_dark` attribute holding an xarray or `pam_dark`,
 	  depending on the measurement protocol. Frames F0 and Fm are
-      labeled according to the metadata in .INF. The default measurement label is 't0'.
+      labeled according to the metadata in .INF. The default measurement label is 't0'. These measurements are also accessible in the `ojip_dark` attribute
+	  if `psd` or `npq` data is available.
     - Measurements from light-adapted plant state are stored in the attribute `psl` (ojip) which has an `ojip_light` attribute holding an xarray or `pam_light`,
 	  depending on the measurement protocol. Frames Fp and Fmp are
-      labeled according to the metadata in .INF. The default measurement label is 't1'.
+      labeled according to the metadata in .INF. The default measurement label is 't1'. These measurements are also accessible in the `ojip_light` attribute
+	  if `psl` or `npq` data is available.
     - Time-resolved PAM fluorescence measurements are stored in the attribute `pam_time`. Frames F0, Fm, Fp, Fmp, F0pp, and Fmpp are
       labeled according to the metadata in .INF, with measurement labels starting at 't0' (e.g. t0, t1, t2, ...).
     - Measurements from chlorophyll fluorescence are stored in the attribute `chl` and include a chlorophyll fluorescence frame (Chl) stored as NumPy array/ndarray access as `ps.chl.chlorophyll`. The Fdark frame, if collected, is not stored.

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -59,6 +59,10 @@ automatically. Alternatively, you can run `pip install -e .` to reinstall the pa
 
 ### Breaking changes between v4 and v5 <a name="breaking-changes"></a>
 
+#### plantcv.analyze.npq
+
+Removed `ps_da_light` and `ps_da_dark` arguments in favor of `ps` argument that takes the entire `PSII_data` object.
+
 #### plantcv.analyze.yii
 
 Renamed parameter `ps_da` to `ps` to reflect that it now takes a `PSII_data` object instead of a single frame from that object.
@@ -375,6 +379,7 @@ pages for more details on the input and output variable types.
 
 * pre v4.0: NA
 * post v4.0: npq, npq_hist = **plantcv.analyze.npq**(*ps_da_light, ps_da_dark, labeled_mask, n_labels=1, auto_fm=False, min_bin=0, max_bin="auto", measurement_labels=None, label=None*)
+* post v5.0: npq, npq_hist = **plantcv.analyze.npq**(*ps, labeled_mask, n_labels=1, auto_fm=False, min_bin=0, max_bin="auto", measurement_labels=None, label=None*)
 
 #### plantcv.analyze.size
 

--- a/plantcv/plantcv/analyze/npq.py
+++ b/plantcv/plantcv/analyze/npq.py
@@ -9,54 +9,53 @@ from plantcv.plantcv._debug import _debug
 from plantcv.plantcv.photosynthesis import reassign_frame_labels
 
 
-def npq(ps_da_light, ps_da_dark, labeled_mask, n_labels=1, auto_fm=False, min_bin=0, max_bin="auto",
+def npq(ps, labeled_mask, n_labels=1, auto_fm=False, min_bin=0, max_bin="auto",
         measurement_labels=None, label=None):
     """
     Calculate and analyze non-photochemical quenching estimates from fluorescence image data.
 
-    Inputs:
-    ps_da_light        = Photosynthesis xarray DataArray that contains frame_label `Fmp` (ojip_light)
-    ps_da_dark         = Photosynthesis xarray DataArray that contains frame_label `Fm` (ojip_dark)
-    labeled_mask       = Labeled mask of objects (32-bit).
-    n_labels           = Total number expected individual objects (default = 1).
-    auto_fm            = Automatically calculate the frame with maximum fluorescence per label, otherwise
-                         use a fixed frame for all labels (default = False).
-    min_bin            = minimum bin value ("auto" or user input minimum value - must be an integer)
-    max_bin            = maximum bin value ("auto" or user input maximum value - must be an integer)
-    measurement_labels = labels for each measurement in ps_da_light, modifies the variable name of observations recorded
-    label              = Optional label parameter, modifies the variable name of
-                         observations recorded (default = pcv.params.sample_label).
+    Parameters:
+    -----------
+    ps                 = plantcv.plantcv.classes.PSII_Data,
+        Object containing ojip_light and ojip_dark data from NPQ or PSL and PSD data.
+    labeled_mask       = numpy.ndarray,
+        Labeled mask of objects (32-bit).
+    n_labels           = int,
+        Total number expected individual objects (default = 1).
+    auto_fm            = bool,
+        Automatically calculate the frame with maximum fluorescence per label, otherwise
+        use a fixed frame for all labels (default = False).
+    min_bin            = int, str
+        minimum bin value ("auto" or user input minimum value - must be an integer)
+    max_bin            = int, str
+        maximum bin value ("auto" or user input maximum value - must be an integer)
+    measurement_labels = list,
+        labels for each measurement in ps, modifies the variable name of observations recorded
+    label              = str,
+        Optional label parameter, modifies the variable name of
+        observations recorded (default = pcv.params.sample_label).
 
     Returns:
-    npq_global         = DataArray of NPQ values
-    npq_chart          = Histograms of NPQ estimates
-
-    :param ps_da_light: xarray.core.dataarray.DataArray
-    :param ps_da_dark: xarray.core.dataarray.DataArray
-    :param labeled_mask: numpy.ndarray
-    :param n_labels: int
-    :param auto_fm: bool
-    :param min_bin: int, str
-    :param max_bin: int, str
-    :param measurement_labels: list
-    :param label: str
-    :return npq_global: xarray.core.dataarray.DataArray
-    :return npq_chart: altair.vegalite.v4.api.FacetChart
+    --------
+    npq_global         = xarray.core.dataarray.DataArray,
+        NPQ values
+    npq_chart          = altair.vegalite.v4.api.FacetChart,
+        Histograms of NPQ estimates
     """
     # Set labels
     labels = _set_labels(label, n_labels)
+
+    if hasattr(ps, "npq") or (hasattr(ps, "psl") and hasattr(ps, "psd")):
+        ps_da_light = ps.ojip_light
+        ps_da_dark = ps.ojip_dark
+    else:
+        fatal_error("ps must have ojip_light and ojip_dark DataArrays from psl/psd or npq images")
 
     if labeled_mask.shape != ps_da_light.shape[:2] or labeled_mask.shape != ps_da_dark.shape[:2]:
         fatal_error(f"Mask needs to have shape {ps_da_dark.shape[:2]}")
 
     if (measurement_labels is not None) and (len(measurement_labels) != ps_da_light.coords['measurement'].shape[0]):
         fatal_error('measurement_labels must be the same length as the number of measurements in `ps_da_light`')
-
-    if ps_da_light.name.lower() != 'ojip_light' or ps_da_dark.name.lower() != 'ojip_dark':
-        fatal_error(f"ps_da_light and ps_da_dark must be DataArrays with names 'ojip_light' and 'ojip_dark', "
-                    f"respectively. Instead the inputs are: "
-                    f"ps_da_light: {ps_da_light.name}, ps_da_dark: {ps_da_dark.name}"
-                    )
 
     # Make an zeroed array of the same shape as the input DataArray
     npq_global = xr.zeros_like(ps_da_light, dtype=float)

--- a/plantcv/plantcv/classes.py
+++ b/plantcv/plantcv/classes.py
@@ -51,13 +51,15 @@ class PSII_data:
         self.metadata = metadata
         if self.metadata is None:
             self.metadata = {}
-        self.datapath = None
-        self.filename = None
-        # Dataset attributes: None = file not present, lazy-loaded object = file present
+            self.datapath = None
+            self.filename = None
+            # Dataset attributes: None = file not present, lazy-loaded object = file present
         self.aph = None
         self.chl = None
         self.clr = None
-        self.ojip = None
+        self.npq = None
+        self._ojip_dark = None
+        self._ojip_light = None
         self.psd = None
         self.psl = None
         self.pam_dark = None
@@ -66,6 +68,26 @@ class PSII_data:
         self.spectral = None
         self.gfp = None
         self.rfp = None
+
+    @property
+    def ojip_dark(self):
+        if isinstance(self._ojip_dark, str):
+            self._ojip_dark = getattr(self.__dict__[self._ojip_dark], "ojip_dark")
+        return self._ojip_dark
+
+    @ojip_dark.setter
+    def ojip_dark(self, value):
+        self._ojip_dark = value
+
+    @property
+    def ojip_light(self):
+        if isinstance(self._ojip_light, str):
+            self._ojip_light = getattr(self.__dict__[self._ojip_light], "ojip_light")
+        return self._ojip_light
+
+    @ojip_light.setter
+    def ojip_light(self, value):
+        self._ojip_light = value
 
 
 class Point:

--- a/plantcv/plantcv/classes.py
+++ b/plantcv/plantcv/classes.py
@@ -72,7 +72,7 @@ class PSII_data:
     @property
     def ojip_dark(self):
         if isinstance(self._ojip_dark, str):
-            self._ojip_dark = getattr(self.__dict__[self._ojip_dark], "ojip_dark")
+            self._ojip_dark = getattr(self.__dict__[self._ojip_dark], "ojip_dark", None)
         return self._ojip_dark
 
     @ojip_dark.setter
@@ -82,7 +82,7 @@ class PSII_data:
     @property
     def ojip_light(self):
         if isinstance(self._ojip_light, str):
-            self._ojip_light = getattr(self.__dict__[self._ojip_light], "ojip_light")
+            self._ojip_light = getattr(self.__dict__[self._ojip_light], "ojip_light", None)
         return self._ojip_light
 
     @ojip_light.setter

--- a/plantcv/plantcv/photosynthesis/read_cropreporter.py
+++ b/plantcv/plantcv/photosynthesis/read_cropreporter.py
@@ -377,7 +377,7 @@ def read_cropreporter(filename):
     }
 
     # Process datasets
-    for dataset in ["APH", "CHL", "CLR", "NPQ", "PMD", "PML", "PMT", "PSD", "PSL", "SPC"]:
+    for dataset in ["APH", "CHL", "CLR", "PMD", "PML", "PMT", "PSD", "PSL", "SPC", "NPQ"]:
         # Construct the expected binary file path for the dataset
         bin_filepath = _dat_filepath(dataset=dataset, datapath=ps.datapath, filename=ps.filename)
         # Check if the file exists
@@ -387,6 +387,10 @@ def read_cropreporter(filename):
             constructor = dataset_classes.get(dataset)
             if constructor is not None:
                 setattr(ps, key, constructor(bin_filepath))
+            if dataset in ["PSL", "NPQ"]:
+                setattr(ps, "ojip_light", key)
+            if dataset in ["PSD", "NPQ"]:
+                setattr(ps, "ojip_dark", key)
 
     # Dark-adapted PAM measurements
     _process_pmd_data(ps=ps, metadata=metadata_dict)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,10 +239,10 @@ class TestData:
             frame_labels = ['Fdark', 'Fp', '2', 'Fmp']
             measurements = ['t1']
             keyname = "bad"
+            other_keyname = "also_bad"
         elif var == "ojip_both":
             ps = self._make_dummy_npq(f0, f1, f2, f3)
             return ps
-            other_keyname = "also_bad"
 
         # Create DataArray
         da = xr.DataArray(data=np.dstack([f0, f1, f2, f3])[..., None],
@@ -345,6 +345,7 @@ class TestData:
                         "ImageCols": 10
                     },
                     keyname: sub_ps,
+                    other_keyname: None,
                     var: ps_dad
                 })
                 return ps
@@ -387,6 +388,7 @@ class TestData:
                         "ImageCols": 10
                     },
                     keyname: sub_ps,
+                    other_keyname: None,
                     var: ps_dal
                 })
                 return ps

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,7 +178,41 @@ class TestData:
                           coords={'frame_label': frame_labels, 'frame_num': ('frame_label', [0, 1, 2, 3]),
                                   'measurement': measurements}, name=var)
         return da
-    
+
+    def _make_dummy_npq(self, f0, f1, f2, f3):
+        """Create PSII data with two frames"""
+        # Create DataArray
+        ojip_dark = xr.DataArray(data=np.dstack([f0, f1, f2, f3])[..., None],
+                                 dims=('x', 'y', 'frame_label', 'measurement'),
+                                 coords={'frame_label': ['Fdark', 'F0', 'Fm', '3'],
+                                         'frame_num': ('frame_label', [0, 1, 2, 3]),
+                                         'measurement': ['t0']}, name="ojip_dark")
+        ojip_light = xr.DataArray(data=np.dstack([f0, f1, f2, f3])[..., None],
+                                  dims=('x', 'y', 'frame_label', 'measurement'),
+                                  coords={'frame_label': ['Fdark', 'Fp', '2', 'Fmp'],
+                                          'frame_num': ('frame_label', [0, 1, 2, 3]),
+                                          'measurement': ['t1']}, name="ojip_light")
+
+        sub_psd = type("subpsdata", (object,), {
+            "ojip_dark": ojip_dark
+        })
+        sub_psl = type("subpsdata2", (object,), {
+            "ojip_light": ojip_light
+        })
+
+        ps = type("psdata", (object,), {
+            'metadata': {
+                "ImageRows": 10,
+                "ImageCols": 10
+            },
+            "psl": sub_psl,
+            "psd": sub_psd,
+            "ojip_dark": ojip_dark,
+            "ojip_light": ojip_light
+        })
+        return ps
+
+
     def psii_cropreporter_new(self, var):
         """Create simple data for PSII"""
         # sample images
@@ -204,6 +238,9 @@ class TestData:
             frame_labels = ['Fdark', 'Fp', '2', 'Fmp']
             measurements = ['t1']
             keyname = "bad"
+        elif var == "ojip_both":
+            ps = self._make_dummy_npq(f0, f1, f2, f3)
+            return ps
 
         # Create DataArray
         da = xr.DataArray(data=np.dstack([f0, f1, f2, f3])[..., None],
@@ -220,7 +257,8 @@ class TestData:
                 "ImageRows": 10,
                 "ImageCols": 10
             },
-            keyname: sub_ps
+            keyname: sub_ps,
+            var: da
         })
         return ps
 
@@ -278,7 +316,7 @@ class TestData:
     def psii_walz_new(var):
         """Create and return synthetic psii dataarrays from walz"""
         # create darkadapted
-        if var == 'ojip_dark':
+        if var in ['ojip_dark', 'ojip_both']:
             keyname = "psd"
             i = 0
             fmin = np.ones((10, 10), dtype='uint8') * ((i+15)*2)
@@ -287,7 +325,7 @@ class TestData:
 
             frame_nums = range(0, 2)
             indf = ['F0', 'Fm']
-            ps_da = xr.DataArray(
+            ps_dad = xr.DataArray(
                 data=data[..., None],
                 dims=('x', 'y', 'frame_label', 'measurement'),
                 coords={'frame_label': indf,
@@ -296,8 +334,22 @@ class TestData:
                 name='ojip_dark'
             )
 
+            if var == "ojip_dark":
+                sub_ps = type("subpsdata", (object,), {
+                    var: ps_dad
+                })
+                ps = type("psdata", (object,), {
+                    'metadata': {
+                        "ImageRows": 10,
+                        "ImageCols": 10
+                    },
+                    keyname: sub_ps,
+                    var: ps_dad
+                })
+                return ps
+
         # create lightadapted
-        elif var == 'ojip_light':
+        if var in ['ojip_light', 'ojip_both']:
             da_list = []
             measurement = []
             keyname = "psl"
@@ -319,71 +371,44 @@ class TestData:
                 da_list.append(lightadapted)
 
             prop_idx = pd.Index(measurement)
-            ps_da = xr.concat(da_list, 'measurement')
-            ps_da.name = 'ojip_light'
-            ps_da.coords['measurement'] = prop_idx
+            ps_dal = xr.concat(da_list, 'measurement')
+            ps_dal.name = 'ojip_light'
+            ps_dal.coords['measurement'] = prop_idx
 
-        sub_ps = type("subpsdata", (object,), {
-            var: ps_da
-        })
+            if var == 'ojip_light':
+                sub_ps = type("subpsdata", (object,), {
+                    var: ps_dal
+                })
 
-        ps = type("psdata", (object,), {
-            'metadata': {
-                "ImageRows": 10,
-                "ImageCols": 10
-            },
-            keyname: sub_ps
-        })
-        return ps
+                ps = type("psdata", (object,), {
+                    'metadata': {
+                        "ImageRows": 10,
+                        "ImageCols": 10
+                    },
+                    keyname: sub_ps,
+                    var: ps_dal
+                })
+                return ps
+    
+        if var == "ojip_both":
+            sub_psd = type("subpsdata", (object,), {
+                "ojip_dark": ps_dad
+            })
+            sub_psl = type("subpsdata", (object,), {
+                "ojip_light": ps_dal
+            })
 
-    @staticmethod
-    def psii_walz(var):
-        """Create and return synthetic psii dataarrays from walz"""
-        # create darkadapted
-        if var == 'ojip_dark':
-            i = 0
-            fmin = np.ones((10, 10), dtype='uint8') * ((i+15)*2)
-            fmax = np.ones((10, 10), dtype='uint8') * (200-i*15)
-            data = np.stack([fmin, fmax], axis=2)
-
-            frame_nums = range(0, 2)
-            indf = ['F0', 'Fm']
-            ps_da = xr.DataArray(
-                data=data[..., None],
-                dims=('x', 'y', 'frame_label', 'measurement'),
-                coords={'frame_label': indf,
-                        'frame_num': ('frame_label', frame_nums),
-                        'measurement': ['t0']},
-                name='ojip_dark'
-            )
-
-        # create lightadapted
-        elif var == 'ojip_light':
-            da_list = []
-            measurement = []
-
-            for i in np.arange(1, 3):
-                indf = ['Fp', 'Fmp']
-                fmin = np.ones((10, 10), dtype='uint8') * ((i+15)*2)
-                fmax = np.ones((10, 10), dtype='uint8') * (200-i*15)
-                data = np.stack([fmin, fmax], axis=2)
-
-                lightadapted = xr.DataArray(
-                    data=data[..., None],
-                    dims=('x', 'y', 'frame_label', 'measurement'),
-                    coords={'frame_label': indf,
-                            'frame_num': ('frame_label', range(0, 2))}
-                )
-
-                measurement.append((f't{i*40}'))
-                da_list.append(lightadapted)
-
-            prop_idx = pd.Index(measurement)
-            ps_da = xr.concat(da_list, 'measurement')
-            ps_da.name = 'ojip_light'
-            ps_da.coords['measurement'] = prop_idx
-
-        return ps_da
+            ps = type("psdata", (object,), {
+                'metadata': {
+                    "ImageRows": 10,
+                    "ImageCols": 10
+                },
+                "psd": sub_psd,
+                "psl": sub_psl,
+                "ojip_light": ps_dal,
+                "ojip_dark": ps_dad
+            })
+            return ps
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -392,7 +392,7 @@ class TestData:
                     var: ps_dal
                 })
                 return ps
-    
+
         if var == "ojip_both":
             sub_psd = type("subpsdata", (object,), {
                 "ojip_dark": ps_dad
@@ -412,6 +412,7 @@ class TestData:
                 "ojip_dark": ps_dad
             })
             return ps
+
 
 @pytest.fixture(scope="session")
 def test_data():

--- a/tests/plantcv/analyze/test_npq.py
+++ b/tests/plantcv/analyze/test_npq.py
@@ -10,7 +10,7 @@ def test_npq_cropreporter(test_data):
     # Clear results
     outputs.clear()
     psdata = test_data.psii_cropreporter_new('ojip_both')
-    _ = analyze_npq(ps = psdata, labeled_mask=test_data.create_ps_mask(),
+    _ = analyze_npq(ps=psdata, labeled_mask=test_data.create_ps_mask(),
                     auto_fm=False,
                     measurement_labels=["Fq/Fm"], label="prefix", min_bin="auto", max_bin="auto")
     assert np.isclose(outputs.observations["prefix_1"]["npq_median_Fq/Fm"]["value"], 0.25)

--- a/tests/plantcv/analyze/test_npq.py
+++ b/tests/plantcv/analyze/test_npq.py
@@ -9,9 +9,8 @@ def test_npq_cropreporter(test_data):
     """Test for PlantCV."""
     # Clear results
     outputs.clear()
-    da_dark = test_data.psii_cropreporter('ojip_dark')
-    da_light = test_data.psii_cropreporter('ojip_light')
-    _ = analyze_npq(ps_da_light=da_light, ps_da_dark=da_dark, labeled_mask=test_data.create_ps_mask(),
+    psdata = test_data.psii_cropreporter_new('ojip_both')
+    _ = analyze_npq(ps = psdata, labeled_mask=test_data.create_ps_mask(),
                     auto_fm=False,
                     measurement_labels=["Fq/Fm"], label="prefix", min_bin="auto", max_bin="auto")
     assert np.isclose(outputs.observations["prefix_1"]["npq_median_Fq/Fm"]["value"], 0.25)
@@ -21,9 +20,8 @@ def test_npq_waltz(test_data):
     """Test for PlantCV."""
     # Clear results
     outputs.clear()
-    da_dark = test_data.psii_walz('ojip_dark')
-    da_light = test_data.psii_walz('ojip_light')
-    _ = analyze_npq(ps_da_light=da_light, ps_da_dark=da_dark, labeled_mask=test_data.create_ps_mask(), auto_fm=True,
+    psdata = test_data.psii_walz_new('ojip_both')
+    _ = analyze_npq(ps=psdata, labeled_mask=test_data.create_ps_mask(), auto_fm=True,
                     measurement_labels=None, label="prefix", min_bin="auto", max_bin="auto")
     assert np.isclose(outputs.observations["prefix_1"]["npq_median_t40"]["value"], float((200 / 185) - 1))
 
@@ -37,16 +35,15 @@ def test_npq_fatalerror(mlabels, tmask, test_data):
     """Test for PlantCV."""
     tmask[0, 0] = 255
     with pytest.raises(RuntimeError):
-        _ = analyze_npq(ps_da_dark=test_data.psii_cropreporter('ojip_dark'),
-                        ps_da_light=test_data.psii_cropreporter('ojip_light'), labeled_mask=tmask,
+        _ = analyze_npq(ps=test_data.psii_cropreporter_new('ojip_both'),
+                        labeled_mask=tmask,
                         measurement_labels=mlabels, label="default")
 
 
 def test_npq_bad_var(test_data):
     """Test for PlantCV."""
     with pytest.raises(RuntimeError):
-        _ = analyze_npq(ps_da_dark=test_data.psii_cropreporter('ojip_light'),
-                        ps_da_light=test_data.psii_cropreporter('ojip_dark'),
+        _ = analyze_npq(ps=test_data.psii_cropreporter_new('ojip_bad'),
                         labeled_mask=test_data.create_ps_mask(),
                         measurement_labels=None)
 
@@ -54,7 +51,6 @@ def test_npq_bad_var(test_data):
 def test_npq_wrong_num_labels(test_data):
     """Test for PlantCV."""
     with pytest.raises(RuntimeError):
-        _ = analyze_npq(ps_da_dark=test_data.psii_cropreporter('ojip_dark'),
-                        ps_da_light=test_data.psii_cropreporter('ojip_light'),
+        _ = analyze_npq(ps=test_data.psii_cropreporter_new('ojip_both'),
                         labeled_mask=test_data.create_ps_mask(),
                         measurement_labels=None, label=["prefix", "prefix"])

--- a/tests/plantcv/photosynthesis/test_read_cropreporter.py
+++ b/tests/plantcv/photosynthesis/test_read_cropreporter.py
@@ -107,6 +107,10 @@ def test_read_cropreporter_npq(photosynthesis_test_data):
     ps = read_cropreporter(filename=photosynthesis_test_data.cropreporter_npq)
     assert isinstance(ps, PSII_data) and ps.npq.ojip_light.shape == (966, 1296, 3, 1)
     assert isinstance(ps, PSII_data) and ps.npq.ojip_dark.shape == (966, 1296, 3, 1)
+    # check shortcut
+    ps = read_cropreporter(filename=photosynthesis_test_data.cropreporter_npq)
+    assert isinstance(ps, PSII_data) and ps.ojip_light.shape == (966, 1296, 3, 1)
+    assert isinstance(ps, PSII_data) and ps.ojip_dark.shape == (966, 1296, 3, 1)
     # check class traits
     assert ps.npq
     assert "NPQ" in repr(ps.npq)


### PR DESCRIPTION
**Describe your changes**
Updated `analyze.npq` for new class structure and changed `PSII_Data` class to have `ojip_light` and `ojip_dark` attributes available if psl/psd/npq data was used.

**Type of update**
This is a feature update.

**Associated issues**
Part of #1926 

**Additional context**
Follows after #1973 , this time strictly.


**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
