### PR TITLE
Rename analyze yii to ojip

### DIFF
--- a/docs/analysis_approach.md
+++ b/docs/analysis_approach.md
@@ -107,7 +107,7 @@ These are the general categories of object analysis that are available in PlantC
 and [analyze.bound_vertical](analyze_bound_vertical2.md) functions.
 *  Object color or other signal intensity values: see the [analyze.color](analyze_color2.md), 
 [analyze.grayscale](analyze_grayscale.md), [analyze.thermal](analyze_thermal.md),
-and [analyze.yii](analyze_yii.md) functions.
+and [analyze.yii_ojip](analyze_yii_ojip.md) functions.
 *  Object classification (For example, classification of disease symptoms, identification of organ structures 
 [naive-bayesian multiclass mode](naive_bayes_multiclass.md)).
 *  Object hyperspectral parameters: see the [analyze.spectral_reflectance](analyze_spectral_reflectance.md) and [analyze.spectral_index](analyze_spectral_index.md) functions.

--- a/docs/analyze_yii_ojip.md
+++ b/docs/analyze_yii_ojip.md
@@ -2,7 +2,7 @@
 
 Extract estimates of the efficiency (YII) of Photosystem II (PSII).
 
-The photosynthesis subpackage is dependent on a PSII_Data instance file structure as created by photosynthesis.read_* files.
+The photosynthesis subpackage is dependent on a PSII_data instance file structure as created by photosynthesis.read_* files.
 
 **plantcv.analyze.yii_ojip**(*ps, labeled_mask, n_labels=1, auto_fm=False, measurement_labels=None, label=None*)
 

--- a/docs/analyze_yii_ojip.md
+++ b/docs/analyze_yii_ojip.md
@@ -3,7 +3,7 @@
 Extract estimates of the efficiency (YII) of Photosystem II (PSII).
 The photosynthesis subpackage is dependent on a PSII_Data instance file structure as created by photosynthesis.read_* files.
 
-**plantcv.analyze.yii**(*ps, labeled_mask, n_labels=1, auto_fm=False, measurement_labels=None, label=None*)
+**plantcv.analyze.yii_ojip**(*ps, labeled_mask, n_labels=1, auto_fm=False, measurement_labels=None, label=None*)
 
 **returns** list of YII DataArray, list of YII histograms (one for each of the `psd` or `psl` arrays)
 
@@ -46,7 +46,7 @@ pcv.params.sample_label = "plant"
 ps = pcv.photosynthesis.read_cropreporter(filename="mydata.inf")
 
 # Analyze Fv/Fm    
-fvfm, fvfm_hist = pcv.analyze.yii(ps_da=ps.ojip_dark, labeled_mask=kept_mask)
+fvfm, fvfm_hist = pcv.analyze.yii_ojip(ps_da=ps.ojip_dark, labeled_mask=kept_mask)
 
 # Access Fv/Fm median value
 fvfm_median = pcv.outputs.observations['plant_1']['yii_median_t0']['value']
@@ -78,7 +78,7 @@ pcv.params.debug = "plot"
 pcv.params.sample_label = "plant"
 
 # Analyze Fq'/Fm'    
-fqfm, fqfm_hist = pcv.analyze.yii(ps=ps.ojip_light, labeled_mask=kept_mask)
+fqfm, fqfm_hist = pcv.analyze.yii_ojip(ps=ps.ojip_light, labeled_mask=kept_mask)
 
 # Access Fq'/Fm' median value
 fqfm_median = pcv.outputs.observations['plant_1']["yii_median_t1"]['value']
@@ -102,4 +102,4 @@ fqfm.plot(col_wrap='measurement')
 The grayscale YII images can be used with the [pcv.visualize.pseudocolor](visualize_pseudocolor.md) function 
 which allows the user to pick a colormap for plotting.
 
-**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/analyze/yii.py)
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/analyze/yii_ojip.py)

--- a/docs/output_measurements.md
+++ b/docs/output_measurements.md
@@ -154,7 +154,7 @@ Functions that automatically store data to the [`Outputs` class](outputs.md) are
 [analyze.spectral_index](analyze_spectral_index.md), 
 [analyze.spectral_reflectance](analyze_spectral_reflectance.md), 
 [analyze.thermal](analyze_thermal.md), 
-[analyze.yii](analyze_yii.md), 
+[analyze.yii_ojip](analyze_yii_ojip.md), 
 [analyze.npq](analyze_npq.md), 
 [homology.acute](homology_acute.md), 
 [homology.landmark_reference_pt_dist](homology_landmark_reference_pt_dist.md), 

--- a/docs/print_image.md
+++ b/docs/print_image.md
@@ -4,7 +4,7 @@ Write image to the file specified. This is a wrapper for the OpenCV function [im
 for numpy arrays (like the images that get returned by most PlantCV functions), and can handle matplotlib Figures (like the one returned by [pcv.visualize.pseudocolor](visualize_pseudocolor.md)) 
 and altair charts (like the histograms returned in [pcv.analyze.grayscale](analyze_grayscale.md), 
 [pcv.analyze.color](analyze_color2.md), [pcv.visualize.histogram](visualize_histogram.md),
- and [pcv.analyze.yii](analyze_yii.md)).
+ and [pcv.analyze.yii_ojip](analyze_yii_ojip.md)).
 
 **plantcv.print_image**(*img, filename*)
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -65,7 +65,7 @@ Removed `ps_da_light` and `ps_da_dark` arguments in favor of `ps` argument that 
 
 #### plantcv.analyze.yii
 
-Renamed parameter `ps_da` to `ps` to reflect that it now takes a `PSII_data` object instead of a single frame from that object.
+Renamed to `plantcv.analyze.yii_ojip` parameter `ps_da` to `ps` to reflect that it now takes a `PSII_data` object instead of a single frame from that object.
 
 #### plantcv.utils
 
@@ -411,7 +411,11 @@ pages for more details on the input and output variable types.
 
 * pre v4.0: NA
 * post v4.0: yii, yii_hist = **plantcv.analyze.yii**(*ps_da, labeled_mask, n_labels=1, auto_fm=False, measurement_labels=None, label=None*)
-* post v4.0: list_of_yii, list_of_yii_hist = **plantcv.analyze.yii**(*ps, labeled_mask, n_labels=1, auto_fm=False, measurement_labels=None, label=None*)
+* post v5.0: NA
+
+#### plantcv.analyze.yii_ojip
+
+* post v5.0: list_of_yii, list_of_yii_hist = **plantcv.analyze.yii_ojip**(*ps, labeled_mask, n_labels=1, auto_fm=False, measurement_labels=None, label=None*)
 
 #### plantcv.apply_mask
 

--- a/docs/visualize_chlorophyll_fluorescence.md
+++ b/docs/visualize_chlorophyll_fluorescence.md
@@ -3,7 +3,7 @@
 Creates a chart of chlorophyll fluorescence induction curves from a PSII_Data instance. The photosynthesis subpackage is
 dependent on a PSII_Data instance file structure as created by `photosynthesis.read_cropreporter`. Plots the mean level
 of fluorescence per object/label per frame/timepoint. The PSII_Data Fm and Fm' frames are labeled and the chart can be used
-to decide whether to use `auto_fm` in [pcv.analyze.yii](analyze_yii.md) and [pcv.analyze.npq](analyze_npq.md).
+to decide whether to use `auto_fm` in [pcv.analyze.yii_ojip](analyze_yii_ojip.md) and [pcv.analyze.npq](analyze_npq.md).
 
 **plantcv.visualize.chlorophyll_fluorescence**(*ps_da, labeled_mask, n_labels=1, label="object"*)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,7 @@ nav:
         - 'Analyze Thermal': analyze_thermal.md
         - 'Analyze Spectral Reflectance': analyze_spectral_reflectance.md
         - 'Analyze Spectral Index': analyze_spectral_index.md
-        - 'Analyze YII': analyze_yii.md
+        - 'Analyze YII (OJIP)': analyze_yii_ojip.md
         - 'Analyze NPQ': analyze_npq.md
       - 'Annotation Tools':
           - 'Points': Points.md
@@ -138,7 +138,7 @@ nav:
       - 'Photosynthesis Functions':
           - 'Read CropReporter Data': photosynthesis_read_cropreporter.md
           - 'Reassign Frame Labels': photosynthesis_reassign_frame_labels.md
-          - 'Analyze YII': analyze_yii.md
+          - 'Analyze YII (OJIP)': analyze_yii_ojip.md
           - 'Analyze NPQ': analyze_npq.md
           - 'Visualize chlorophyll Fluorescence': visualize_chlorophyll_fluorescence.md
       - 'Params (Debugging)': params.md

--- a/plantcv/plantcv/analyze/__init__.py
+++ b/plantcv/plantcv/analyze/__init__.py
@@ -6,10 +6,10 @@ from plantcv.plantcv.analyze.grayscale import grayscale
 from plantcv.plantcv.analyze.thermal import thermal
 from plantcv.plantcv.analyze.spectral_reflectance import spectral_reflectance
 from plantcv.plantcv.analyze.spectral_index import spectral_index
-from plantcv.plantcv.analyze.yii import yii
+from plantcv.plantcv.analyze.yii_ojip import yii_ojip
 from plantcv.plantcv.analyze.npq import npq
 from plantcv.plantcv.analyze.distribution import distribution
 from plantcv.plantcv.analyze.texture import texture
 
 __all__ = ["color", "bound_horizontal", "bound_vertical", "grayscale", "size", "thermal", "spectral_reflectance",
-           "spectral_index", "yii", "npq", "distribution", "texture"]
+           "spectral_index", "yii_ojip", "npq", "distribution", "texture"]

--- a/plantcv/plantcv/analyze/yii_ojip.py
+++ b/plantcv/plantcv/analyze/yii_ojip.py
@@ -8,7 +8,7 @@ from plantcv.plantcv import params, outputs, fatal_error
 from plantcv.plantcv.photosynthesis import reassign_frame_labels
 
 
-def yii(ps, labeled_mask, n_labels=1, auto_fm=False, measurement_labels=None, label=None):
+def yii_ojip(ps, labeled_mask, n_labels=1, auto_fm=False, measurement_labels=None, label=None):
     """Calculate and analyze PSII efficiency estimates from fluorescence image data.
 
     Parameters

--- a/tests/plantcv/analyze/test_yii_ojip.py
+++ b/tests/plantcv/analyze/test_yii_ojip.py
@@ -2,7 +2,7 @@
 import pytest
 import numpy as np
 from plantcv.plantcv import outputs
-from plantcv.plantcv.analyze import yii as analyze_yii
+from plantcv.plantcv.analyze import yii_ojip as analyze_yii
 
 
 @pytest.mark.parametrize("prot,mlabels,exp", [


### PR DESCRIPTION
**Describe your changes**
Renaming `analyze.yii` to `analyze.yii_ojip` in preparation for having another analysis function for pam time.

**Type of update**
This is a feature update (renaming)

**Associated issues**
Part of #1926

**Additional context**
Merge after #1974

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
