### PR TITLE
case insensitive extensions for imgformat

### DIFF
--- a/plantcv/parallel/parsers.py
+++ b/plantcv/parallel/parsers.py
@@ -483,7 +483,7 @@ def _read_filenames(config):
         fns = []
         for root, _, files in os.walk(config.input_dir):
             for file in files:
-                if file.lower().endswith(tuple(extensions)):
+                if file.lower().endswith(tuple(ext.lower() for ext in extensions)):
                     # Keep the files that end with the image extension
                     fns.append(os.path.join(root, file))
     # Create a dataset


### PR DESCRIPTION
**Describe your changes**
Coerce all extensions to lowercase to match with `ext.lower` in `pcv.parallel.parsers`

**Type of update**
This is a bug fix

**Associated issues**
None

**Additional context**
None

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
