### PR TITLE
Mcc detectors

### DIFF
--- a/docs/transform_detect_color_card.md
+++ b/docs/transform_detect_color_card.md
@@ -8,7 +8,6 @@ Automatically detects a Macbeth ColorChecker or Astrobotany.com Calibration Stic
 
 - **Parameters**
     - rgb_img          - Input RGB image data containing a color card.
-    - label            - Optional label parameter, modifies the variable name of observations recorded. (default = `pcv.params.sample_label`)
     - color_chip_size - Type of color card to be detected, ("classic", "passport", "nano", "mini", "cameratrax", or "astro", by default `None`) or a tuple of the `(width, height)` dimensions of the color card chips in millimeters. If set then size scalings parameters `pcv.params.unit`, `pcv.params.px_width`, and `pcv.params.px_height`
             are automatically set, and utilized throughout linear and area type measurements stored to `Outputs`. 
     - roi              - Optional rectangular ROI as returned by [`pcv.roi.rectangle`](roi_rectangle.md) within which to look for the color card. (default = None)

--- a/docs/transform_mcc_detect.md
+++ b/docs/transform_mcc_detect.md
@@ -1,0 +1,48 @@
+## Automatically Detect a Color Card with cv2.mcc tools
+
+Automatically detects a Macbeth ColorChecker and creates a labeled mask.
+
+**plantcv.transform.mcc_detect**(*rgb_img, color_chip_size=None, roi=None, delta_E=True, \*\*kwargs*)
+
+**returns** color_matrix
+
+- **Parameters**
+    - rgb_img          - Input RGB image data containing a color card.
+    - roi              - Optional rectangular ROI as returned by [`pcv.roi.rectangle`](roi_rectangle.md) within which to look for the color card. (default = None)
+	- delta_E          - Boolean, should Delta E be calculated between the observed and expected color card values? This will add delta E values to `outputs.metadata`. See [`pcv.transform.deltaE`](transform_deltaE.md)
+	- **kwargs         - Other keyword arguments passed to `cv2.mcc.CheckerDetector.process`.
+	    - chartType    - int, code for type of chart (defaults to `cv2.mcc.MCC24`, which is 0)
+		- nc           - int, number of charts to detect (defaults to 1)
+		- useNet       - bool, should a neural network be used to detect the chart? (defaults to False)
+		- params       - `cv2.mcc.DetectorParameters` object describing parameters for card detection (defaults to `cv2.mcc.DetectorParameters.create()`)
+
+- **Returns**
+    - color_matrix     - Detected color values as a matrix, the same format as output from [`pcv.transform.get_color_matrix`](get_color_matrix.md)).
+
+- **Context**
+	- In general we advocate for using [`pcv.transform.auto_correct_color`](transform_auto_correct_color.md) for simple color correction rather than `mcc_detect` or [`pcv.transform.detect_color_card`](transform_detect_color_card.md).
+	- One setting where this function is a better option is if there are multiple color cards or color card like objects, since `cv2.mcc` detectors will find all matching regions then attempt to pick the best color card from avaiable options. This may be useful for some images where there are multiple color cards or other potentially confounding objects present.
+	- If either this function or [`pcv.transform.detect_color_card`](transform_detect_color_card.md) are proving difficult to implement then we suggest at least trying the other function since they will work in slightly different ways to return the same output.
+	- Debug images similar to those from [`pcv.transform.detect_color_card`](transform_detect_color_card.md) are generated
+
+!!! note
+    Unlike [`pcv.transform.detect_color_card`](transform_detect_color_card.md) this function does not support astrobotany color cards or size scaling based on color chips. `cv2.mcc` does not return the dimensions of color chips so this function does not serve the dual-purpose that other detection methods will allow for.
+
+
+```python
+
+from plantcv import plantcv as pcv
+rgb_img, path, filename = pcv.readimage("target_img.png")
+
+# Detecting a color card
+cc_matrix = pcv.transform.mcc_detect(rgb_img=rgb_img)
+
+# When using mcc_detect, as with detect_color_card, you will always set pos=3
+tgt_matrix = pcv.transform.std_color_matrix(pos=3)
+corrected_img = pcv.transform.affine_color_correction(rgb_img=rgb_img,
+                                                      source_matrix=cc_matrix,
+                                                      target_matrix=tgt_matrix)
+
+```
+
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/main/plantcv/plantcv/transform/mcc_detect.py)

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - scikit-learn
   - dask
   - dask-jobqueue
-  - opencv<=4.12.0=*headless*
+  - opencv-contrib<=4.12.0=*headless*
   - statsmodels
   - xarray>=2022.11.0
   - mkdocs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -185,6 +185,7 @@ nav:
         - 'Texture Threshold': texture_threshold.md
       - 'Transformation Methods':
           - 'Auto-Detect Color Card': transform_detect_color_card.md
+          - 'Detect Color Card using cv2.mcc': transform_mcc_detect.md
           - 'Auto Correct Color': transform_auto_correct_color.md
           - 'Auto Correct Color (non-linear)': transform_auto_correct_color_nonlinear.md
           - 'Calibrate Camera': transform_calibrate_camera.md

--- a/plantcv/plantcv/transform/__init__.py
+++ b/plantcv/plantcv/transform/__init__.py
@@ -22,10 +22,11 @@ from plantcv.plantcv.transform.checkerboard_calib import checkerboard_calib, cal
 from plantcv.plantcv.transform.merge_images import merge_images
 from plantcv.plantcv.transform.auto_correct_color import auto_correct_color
 from plantcv.plantcv.transform.auto_correct_color import auto_correct_color_nonlinear
+from plantcv.plantcv.transform.mcc_detect import mcc_detect
 
 __all__ = ["get_color_matrix", "get_matrix_m", "calc_transformation_matrix", "apply_transformation_matrix",
            "save_matrix", "load_matrix", "correct_color", "create_color_card_mask",
            "std_color_matrix", "affine_color_correction", "rescale", "nonuniform_illumination", "resize",
            "resize_factor", "warp", "rotate", "warp", "warp_align", "gamma_correct", "deltaE",
            "detect_color_card", "checkerboard_calib", "calibrate_camera", "merge_images", "auto_correct_color",
-           "mask_color_card", "auto_correct_color_nonlinear", "astro_color_matrix"]
+           "mask_color_card", "auto_correct_color_nonlinear", "astro_color_matrix", "mcc_detect"]

--- a/plantcv/plantcv/transform/mcc_detect.py
+++ b/plantcv/plantcv/transform/mcc_detect.py
@@ -55,16 +55,15 @@ def mcc_detect(rgb_img, roi=None, delta_E=True, **kwargs):
 
 def _mcc_detection(rgb_img, **kwargs):
     """Internal worker to detect a macbeth color card using cv2.mcc tools"""
-    
     # Make a detector object
     detector = cv2.mcc.CCheckerDetector_create()
     # get parameters from kwargs
     chart_type = kwargs.get("chartType", cv2.mcc.MCC24)
     nc = kwargs.get("nc", 1)
     useNet = kwargs.get("useNet", False)
-    params = kwargs.get("params", cv2.mcc.DetectorParameters.create())
+    pars = kwargs.get("params", cv2.mcc.DetectorParameters.create())
     # give the detector the image to process
-    detector.process(rgb_img, chart_type, nc, useNet, params)
+    detector.process(rgb_img, chart_type, nc, useNet, pars)
     # Get a list of the checkers (cards)
     checkers = detector.getListColorChecker()
     # make an empty mask
@@ -105,4 +104,3 @@ def _mcc_detection(rgb_img, **kwargs):
     _, color_matrix = get_color_matrix(rgb_img=rgb_img, mask=labeled_mask)
 
     return color_matrix, debug_img, marea, mheight, mwidth
-    

--- a/plantcv/plantcv/transform/mcc_detect.py
+++ b/plantcv/plantcv/transform/mcc_detect.py
@@ -5,10 +5,9 @@ import numpy as np
 from plantcv.plantcv._debug import _debug
 from plantcv.plantcv._helpers import _rect_filter
 from plantcv.plantcv.fatal_error import fatal_error
-from plantcv.plantcv._globals import params, outputs
+from plantcv.plantcv._globals import params
 from plantcv.plantcv.transform.delta_e import _delta_e
 from plantcv.plantcv.transform.get_color_matrix import get_color_matrix
-from plantcv.plantcv.transform.detect_color_card import _set_size_scale_from_chip
 
 
 def mcc_detect(rgb_img, roi=None, delta_E=True, **kwargs):

--- a/plantcv/plantcv/transform/mcc_detect.py
+++ b/plantcv/plantcv/transform/mcc_detect.py
@@ -1,0 +1,91 @@
+"""Wrap cv2.mcc functions for color card detection"""
+
+import cv2
+from plantcv.plantcv._globals import params
+from plantcv.plantcv.helpers import _rect_filter
+from plantcv.plantcv.fatal_error import fatal_error
+from plantcv.plantcv.transform.delta_e import _delta_e
+from plantcv.plantcv.transform.get_color_matrix import get_color_matrix
+
+
+def mcc_detect(rgb_img, color_chip_size=None, roi=None, delta_E=True, **kwargs):
+    """Detect a macbeth color card using cv2.mcc tools
+
+    Parameters:
+    -----------
+
+    Returns
+    -------
+    
+    """
+    color_matrix, debug_img, marea, mheight, mwidth = _rect_filter(rgb_img,
+                                                                    roi,
+                                                                    function=_mcc_detection,
+                                                                    **kwargs)
+    # Create dataframe for easy summary stats
+    chip_size = np.median(marea)
+    chip_height = np.median(mheight)
+    chip_width = np.median(mwidth)
+
+    # Save out size of aruco tags in pixels (measured) and mm (known value)
+    outputs.add_metadata(term="mean_color_chip_size", datatype=float, value=chip_size)
+    outputs.add_metadata(term="mean_color_chip_width", datatype=float, value=chip_width)
+    outputs.add_metadata(term="mean_color_chip_height", datatype=float, value=chip_height)
+
+    # Set size scaling factor if color chip size is provided
+    _set_size_scale_from_chip(color_chip_height=chip_height, color_chip_width=chip_width,
+                              color_chip_size=color_chip_size)
+
+    # Save or plot debug image of color card transformed to standard size
+    _debug(visual=debug_img, filename=os.path.join(params.debug_outdir,
+                                                   f'{params.device}_aligned_color_card.png'))
+
+    return color_matrix
+
+
+def _mcc_detection(rgb_img, **kwargs):
+    """Internal worker to detect a macbeth color card using cv2.mcc tools"""
+    
+    # Make a detector object
+    detector = cv2.mcc.CCheckerDetector_create()
+    # give the detector the image to process
+    detector.process(rgb_img, cv2.mcc.MCC24, nc=1)
+    # Get a list of the checkers (cards)
+    checkers = detector.getListColorChecker()
+    # make an empty mask
+    labeled_mask = np.zeros((rgb_img.shape[0], rgb_img.shape[1]), dtype=np.uint8)
+    # Checkers is a list of matches, sorted by "best", take the first ones
+    # and get the color charts from it, those are the chips as a list of corners
+    if len(checkers) < 1:
+        fatal_error("No color card detected, consider trying pcv.transform.detect_color_card")
+    chips = checkers[0].getColorCharts()
+    mheight = []
+    mwidth = []
+    marea = []
+    # For each starting corner in the 24 square chips:
+    for i in range(0,96,4):
+        # select the 4 points of this square
+        pts = chips[i:i+4, :]
+        # make a bounding box
+        x, y, w, h = cv2.boundingRect(pts)
+        # draw the box on the mask as a bunch of i+1's.
+        cv2.rectangle(labeled_mask, (x, y), (x + w, y + h), i+1, -1)
+        mheight.append(h)
+        mwidth.append(w)
+        marea.append(w * h)
+        # now the mask is a labeled mask of color chips.
+        # order is something I should check for consistency.
+
+    # to make a debug we can use the CCheckerDraw function:
+    for checker in checkers:
+        # Visualize the detection
+        cdraw = cv2.mcc.CCheckerDraw_create(checker)
+        debug_img = rgb_img.copy()
+        cdraw.draw(debug_img)
+    # now img_annotated is a reasonable debug.
+    # NOTE mcc reads "Dark Skin" to "Black", across rows left to right (teal towards black) then up rows (white towards black)], aka pos=0
+    # but get_color_matrix works on it.
+    color_matrix = get_color_matrix(rgb_img=rgb_img, mask=labeled_mask)
+
+    return color_matrix, debug_img, marea, mheight, mwidth
+    

--- a/plantcv/plantcv/transform/mcc_detect.py
+++ b/plantcv/plantcv/transform/mcc_detect.py
@@ -1,44 +1,55 @@
 """Wrap cv2.mcc functions for color card detection"""
-
+import os
 import cv2
-from plantcv.plantcv._globals import params
-from plantcv.plantcv.helpers import _rect_filter
+import numpy as np
+from plantcv.plantcv._debug import _debug
+from plantcv.plantcv._helpers import _rect_filter
 from plantcv.plantcv.fatal_error import fatal_error
+from plantcv.plantcv._globals import params, outputs
 from plantcv.plantcv.transform.delta_e import _delta_e
 from plantcv.plantcv.transform.get_color_matrix import get_color_matrix
+from plantcv.plantcv.transform.detect_color_card import _set_size_scale_from_chip
 
 
-def mcc_detect(rgb_img, color_chip_size=None, roi=None, delta_E=True, **kwargs):
+def mcc_detect(rgb_img, roi=None, delta_E=True, **kwargs):
     """Detect a macbeth color card using cv2.mcc tools
 
     Parameters:
     -----------
+    rgb_img : numpy.ndarray
+        Input RGB image data containing a color card.
+    roi : plantcv.plantcv.Objects, optional
+        A rectangular ROI as returned from pcv.roi.rectangle to detect a color card only in that region.
+    delta_E : Boolean, optional
+        Should DeltaE be calculated between the observed vs expected color card? Defaults to True.
+    **kwargs
+        Other keyword arguments passed to cv2.mcc.CCheckerDetector.process
+
+        Valid keyword arguments:
+        chartType: int (default = cv2.mcc.MCC24, which is 0), code for type of chart
+        nc: int (default = 1), number of cards to detect
+        useNet: bool (default = False), use a neural network for finding the color card?
+        params: cv2.mcc.DetectorParameters, should generally not be set manually without famililarity with these objects.
 
     Returns
     -------
-    
+    color matrix
+        Matrix containing the average red value, average green value, and average blue value for each color chip
     """
-    color_matrix, debug_img, marea, mheight, mwidth = _rect_filter(rgb_img,
-                                                                    roi,
-                                                                    function=_mcc_detection,
-                                                                    **kwargs)
-    # Create dataframe for easy summary stats
-    chip_size = np.median(marea)
-    chip_height = np.median(mheight)
-    chip_width = np.median(mwidth)
-
-    # Save out size of aruco tags in pixels (measured) and mm (known value)
-    outputs.add_metadata(term="mean_color_chip_size", datatype=float, value=chip_size)
-    outputs.add_metadata(term="mean_color_chip_width", datatype=float, value=chip_width)
-    outputs.add_metadata(term="mean_color_chip_height", datatype=float, value=chip_height)
-
-    # Set size scaling factor if color chip size is provided
-    _set_size_scale_from_chip(color_chip_height=chip_height, color_chip_width=chip_width,
-                              color_chip_size=color_chip_size)
+    color_matrix, debug_img, _, _, _ = _rect_filter(rgb_img,
+                                                    roi,
+                                                    function=_mcc_detection,
+                                                    **kwargs)
 
     # Save or plot debug image of color card transformed to standard size
     _debug(visual=debug_img, filename=os.path.join(params.debug_outdir,
                                                    f'{params.device}_aligned_color_card.png'))
+
+    # Calculate delta E
+    if delta_E:
+        params.function_args["mcc_detect"] = {"roi": roi,
+                                              "kwargs": kwargs}
+        _ = _delta_e(color_matrix)
 
     return color_matrix
 
@@ -48,8 +59,13 @@ def _mcc_detection(rgb_img, **kwargs):
     
     # Make a detector object
     detector = cv2.mcc.CCheckerDetector_create()
+    # get parameters from kwargs
+    chart_type = kwargs.get("chartType", cv2.mcc.MCC24)
+    nc = kwargs.get("nc", 1)
+    useNet = kwargs.get("useNet", False)
+    params = kwargs.get("params", cv2.mcc.DetectorParameters.create())
     # give the detector the image to process
-    detector.process(rgb_img, cv2.mcc.MCC24, nc=1)
+    detector.process(rgb_img, chart_type, nc, useNet, params)
     # Get a list of the checkers (cards)
     checkers = detector.getListColorChecker()
     # make an empty mask
@@ -62,19 +78,23 @@ def _mcc_detection(rgb_img, **kwargs):
     mheight = []
     mwidth = []
     marea = []
+    # reorder chips to pos=3 order from cv2's "Dark Skin" to "Black" order, long dim major
+    lst = [i + o for o in [0, 1, 2, 3, 4, 5] for i in [18, 12, 6, 0]]
+    cv2_order_to_pos3_order = [item * 4 for item in lst]
     # For each starting corner in the 24 square chips:
-    for i in range(0,96,4):
+    for i, c in enumerate(cv2_order_to_pos3_order):
         # select the 4 points of this square
-        pts = chips[i:i+4, :]
+        pts = chips[c:c+4, :]
         # make a bounding box
         x, y, w, h = cv2.boundingRect(pts)
         # draw the box on the mask as a bunch of i+1's.
-        cv2.rectangle(labeled_mask, (x, y), (x + w, y + h), i+1, -1)
+        # NOTE here we match the (i + 1) * 10 values from _draw_color_chips in detect
+        cv2.rectangle(labeled_mask, (x, y), (x + w, y + h), (i + 1) * 10, -1)
+        # NOTE, these h, w values are not useful for rescaling units because they are
+        # the size of the masked region, not of the chip itself.
         mheight.append(h)
         mwidth.append(w)
         marea.append(w * h)
-        # now the mask is a labeled mask of color chips.
-        # order is something I should check for consistency.
 
     # to make a debug we can use the CCheckerDraw function:
     for checker in checkers:
@@ -82,10 +102,8 @@ def _mcc_detection(rgb_img, **kwargs):
         cdraw = cv2.mcc.CCheckerDraw_create(checker)
         debug_img = rgb_img.copy()
         cdraw.draw(debug_img)
-    # now img_annotated is a reasonable debug.
-    # NOTE mcc reads "Dark Skin" to "Black", across rows left to right (teal towards black) then up rows (white towards black)], aka pos=0
-    # but get_color_matrix works on it.
-    color_matrix = get_color_matrix(rgb_img=rgb_img, mask=labeled_mask)
+
+    _, color_matrix = get_color_matrix(rgb_img=rgb_img, mask=labeled_mask)
 
     return color_matrix, debug_img, marea, mheight, mwidth
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "scikit-learn",
     "dask",
     "dask-jobqueue",
-    "opencv-python-headless <= 4.12",
+    "opencv-contrib-python-headless <= 4.12",
     "xarray >= 2022.11.0",
     "statsmodels",
     "altair < 6",

--- a/tests/plantcv/transform/test_mcc_detect.py
+++ b/tests/plantcv/transform/test_mcc_detect.py
@@ -2,7 +2,7 @@
 import cv2
 import pytest
 import numpy as np
-from plantcv.plantcv._globals import params, outputs
+from plantcv.plantcv._globals import params
 from plantcv.plantcv.transform.mcc_detect import mcc_detect
 
 

--- a/tests/plantcv/transform/test_mcc_detect.py
+++ b/tests/plantcv/transform/test_mcc_detect.py
@@ -1,0 +1,23 @@
+"""Test pcv.transform.mcc_detect"""
+import cv2
+import pytest
+import numpy as np
+from plantcv.plantcv._globals import params, outputs
+from plantcv.plantcv.transform.mcc_detect import mcc_detect
+
+
+def test_mcc_detect(transform_test_data):
+    """Test for PlantCV."""
+    # Load rgb image
+    rgb_img = cv2.imread(transform_test_data.colorcard_img)
+    color_matrix = mcc_detect(rgb_img=rgb_img, color_chip_size="classic")
+    assert np.shape(color_matrix) == (24, 4)
+    assert "mcc_detect" in params.function_args
+
+
+def test_mcc_detect_no_color_card(transform_test_data):
+    """Test for PlantCV."""
+    # Load rgb image
+    rgb_img = np.random.randint(0, 255, (1000, 1000, 3)).astype(np.uint8)
+    with pytest.raises(RuntimeError):
+        _ = mcc_detect(rgb_img=rgb_img, color_chip_size="classic")


### PR DESCRIPTION
**Describe your changes**
Adds a function to use `cv2.mcc` detectors in color card detection for times where there are multiple color-cards/similar objects or our other tools are unfamiliar to more `cv2` inclined users.

**Type of update**
This is a new feature.

**Associated issues**
None

**Additional context**
This does not support some of the quality of life stuff that `pcv.transform.detect_color_card` does, namely the size scaling, but I don't see a way around that with how `cv2.mcc` returns information on the chips.
This also apparently requires `opencv-contrib` instead of just `opencv` since only that version has `cv2.mcc`.

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
