### PR TITLE
Fix segment_insertion_angle crash on near-vertical stems (int32 overflow in stem line drawing)

### DIFF
--- a/plantcv/plantcv/morphology/segment_insertion_angle.py
+++ b/plantcv/plantcv/morphology/segment_insertion_angle.py
@@ -106,9 +106,7 @@ def segment_insertion_angle(skel_img, segmented_img, leaf_objects, stem_objects,
     [vx, vy, x, y] = cv2.fitLine(combined_stem[0], cv2.DIST_L2, 0, 0.01, 0.01)
     stem_slope = -vy / vx
     stem_slope = stem_slope[0]
-    lefty = int(np.array((-x * vy / vx) + y).item())
-    righty = int(np.array(((cols - x) * vy / vx) + y).item())
-    cv2.line(labeled_img, (cols - 1, righty), (0, lefty), (150, 150, 150), 3)
+    _plot_stem_line(labeled_img, vx, vy, x, y, cols)
 
     for t, segment in enumerate(insertion_segments):
         # Find line fit to each segment
@@ -202,3 +200,19 @@ def _combine_stem(segmented_img, stem_objects, maxiter=50):
     if len(combined_stem) > 1:
         fatal_error('Unable to combine stem objects.')
     return combined_stem
+
+
+def _plot_stem_line(labeled_img, vx, vy, x, y, cols):
+    """Draw the fitted stem line, guarding against overflow for near-vertical stems.
+
+    A nearly vertical stem extrapolates to y-intercepts beyond the 32-bit range
+    that cv2.line accepts (abs(value) < 2 ** 31 is False for inf and nan too), so
+    draw the stem line vertically at the fitted x position in that case instead.
+    """
+    lefty = np.array((-x * vy / vx) + y).item()
+    righty = np.array(((cols - x) * vy / vx) + y).item()
+    if np.all(np.abs([lefty, righty]) < 2 ** 31):
+        cv2.line(labeled_img, (cols - 1, int(righty)), (0, int(lefty)), (150, 150, 150), 3)
+    else:
+        stem_x = int(np.array(x).item())
+        cv2.line(labeled_img, (stem_x, 0), (stem_x, labeled_img.shape[0] - 1), (150, 150, 150), 3)

--- a/tests/plantcv/morphology/test_segment_insertion_angle.py
+++ b/tests/plantcv/morphology/test_segment_insertion_angle.py
@@ -39,3 +39,47 @@ def test_segment_insertion_angle_overflow():
                                                                 [[8, 4]], [[8, 3]], [[8, 2]], [[8, 1]]], dtype=np.int32)]
     with pytest.raises(IndexError):
         _ = segment_insertion_angle(skel_img=skel, segmented_img=skel, leaf_objects=leaf_obj, stem_objects=stem_obj, size=3)
+
+
+def test_segment_insertion_angle_vertical_stem():
+    """Test for PlantCV."""
+    # Clear previous outputs
+    outputs.clear()
+    # A perfectly vertical stem fits with vx ~ 0; extrapolating the stem line to the
+    # image edges then overflows the 32-bit coordinates cv2.line accepts
+    from plantcv.plantcv._helpers import _cv2_findcontours
+    stem_img = np.zeros((500, 500), dtype=np.uint8)
+    cv2.line(stem_img, (250, 50), (250, 450), 255, 1)
+    leaf_img = np.zeros((500, 500), dtype=np.uint8)
+    cv2.line(leaf_img, (251, 149), (330, 70), 255, 1)
+    skel = stem_img | leaf_img
+    stem_obj, _ = _cv2_findcontours(bin_img=stem_img)
+    leaf_obj, _ = _cv2_findcontours(bin_img=leaf_img)
+    labeled_img = segment_insertion_angle(skel_img=skel, segmented_img=skel, leaf_objects=leaf_obj,
+                                          stem_objects=stem_obj, size=20)
+    angles = outputs.observations['default']['segment_insertion_angle']['value']
+    assert len(angles) == 1
+    assert abs(angles[0] - 45) < 5
+    # The stem line is still drawn, as a vertical line
+    assert (labeled_img[:, 250] == 150).any()
+
+
+def test_segment_insertion_angle_slanted_stem(morphology_test_data):
+    """Test for PlantCV."""
+    # Clear previous outputs
+    outputs.clear()
+    # A slanted stem keeps the extrapolated stem line, drawn to the image edges
+    from plantcv.plantcv._helpers import _cv2_findcontours
+    stem_img = np.zeros((500, 500), dtype=np.uint8)
+    cv2.line(stem_img, (100, 100), (400, 400), 255, 1)
+    leaf_img = np.zeros((500, 500), dtype=np.uint8)
+    cv2.line(leaf_img, (151, 149), (220, 80), 255, 1)
+    skel = stem_img | leaf_img
+    stem_obj, _ = _cv2_findcontours(bin_img=stem_img)
+    leaf_obj, _ = _cv2_findcontours(bin_img=leaf_img)
+    labeled_img = segment_insertion_angle(skel_img=skel, segmented_img=skel, leaf_objects=leaf_obj,
+                                          stem_objects=stem_obj, size=20)
+    assert len(outputs.observations['default']['segment_insertion_angle']['value']) == 1
+    # The stem line is extrapolated beyond the stem segment itself
+    assert (labeled_img[440:500, 440:500] == 150).any()
+    assert not (labeled_img[:, 250] == 150).all()


### PR DESCRIPTION
**Describe your changes**

`segment_insertion_angle` crashes on a perfectly (or nearly) vertical stem. `cv2.fitLine` on a vertical stem contour returns `vx ~ 0` (about 1e-8 in practice), so extrapolating the fitted stem line to the image edges produces y-intercepts on the order of 1e9 or larger. Those exceed the 32-bit coordinate range `cv2.line` accepts, and the call raises:

```
cv2.error: OpenCV(4.11.0) :-1: error: (-5:Bad argument) in function 'line'
> Overload resolution failed:
>  - Can't parse 'pt1'. Sequence item with index 1 has a wrong type
```

An upright stem is a common case for plant images, and whether it crashes depends on image size (the extrapolated intercepts scale with image width), so the same skeleton can work on a small image and crash on a larger one.

The per-segment drawing loop a few lines below already guards against this exact failure for leaf segments (`if abs(slope) > 1000000: ... cannot be plotted`). This PR applies the equivalent protection to the stem line: if the extrapolated intercepts are not finite 32-bit values, the stem line is drawn as a vertical line at the fitted x position instead, so the debug image keeps its stem line rather than losing it. The guard checks the computed intercepts directly rather than a slope threshold because the overflow point depends on image width as well as slope.

Angle measurements are unchanged in all cases; the change only affects drawing of the debug image. No function signatures change.

Previously: vertical stem -> crash. Now: vertical stem -> same angles as before, stem line drawn vertically.

**Type of update**

* Bug fix

**Associated issues**

Related but distinct: #2002 describes a separate bookkeeping bug in the same function (this PR does not close it). The two touch different lines and do not conflict.

**Additional context**

Two regression tests are included:

* `test_segment_insertion_angle_vertical_stem`: vertical stem plus a 45 degree leaf; crashes with the `cv2.error` above on current `main`, passes with this change, and asserts the stem line is still drawn and the measured angle is ~45 degrees.
* `test_segment_insertion_angle_slanted_stem`: a slanted stem, asserting the extrapolated edge-to-edge stem line still comes from the original code path (this pins that the fallback only fires for the overflow case).

Coverage of `segment_insertion_angle.py` remains 100% (both branches of the new guard are exercised).
