### PR TITLE
Reduce the number of open files during tests

### DIFF
--- a/plantcv/plantcv/naive_bayes_classifier.py
+++ b/plantcv/plantcv/naive_bayes_classifier.py
@@ -27,25 +27,25 @@ def naive_bayes_classifier(rgb_img, pdf_file):
     # Initialize PDF dictionary
     pdfs = {}
     # Read the PDF file
-    pf = open(pdf_file, "r")
-    # Read the first line (header)
-    pf.readline()
-    # Read each line of the file and parse the PDFs, store in the PDF dictionary
-    for row in pf:
-        # Remove newline character
-        row = row.rstrip("\n")
-        # Split the row into columns on tab characters
-        cols = row.split("\t")
-        # Make sure there are the correct number of columns (i.e. is this a valid PDF file?)
-        if len(cols) != 258:
-            fatal_error("Naive Bayes PDF file is not formatted correctly. Error on line:\n" + row)
-        # Store the PDFs. Column 0 is the class, Column 1 is the color channel, the rest are p at
-        # intensity values 0-255. Cast text p values as float
-        class_name = cols[0]
-        channel = cols[1]
-        if class_name not in pdfs:
-            pdfs[class_name] = {}
-        pdfs[class_name][channel] = np.array([float(i) for i in cols[2:]])
+    with open(pdf_file, "r") as pf:
+        # Read the first line (header)
+        pf.readline()
+        # Read each line of the file and parse the PDFs, store in the PDF dictionary
+        for row in pf:
+            # Remove newline character
+            row = row.rstrip("\n")
+            # Split the row into columns on tab characters
+            cols = row.split("\t")
+            # Make sure there are the correct number of columns (i.e. is this a valid PDF file?)
+            if len(cols) != 258:
+                fatal_error("Naive Bayes PDF file is not formatted correctly. Error on line:\n" + row)
+            # Store the PDFs. Column 0 is the class, Column 1 is the color channel, the rest are p at
+            # intensity values 0-255. Cast text p values as float
+            class_name = cols[0]
+            channel = cols[1]
+            if class_name not in pdfs:
+                pdfs[class_name] = {}
+            pdfs[class_name][channel] = np.array([float(i) for i in cols[2:]])
 
     # Split the input BGR image into component channels for BGR, HSV, and LAB colorspaces
     h, s, v = cv2.split(cv2.cvtColor(rgb_img, cv2.COLOR_BGR2HSV))

--- a/tests/parallel/test_multiprocess.py
+++ b/tests/parallel/test_multiprocess.py
@@ -14,8 +14,11 @@ def test_create_dask_cluster_local(tmpdir):
     # Set the temp directory for dask
     dask.config.set(temporary_directory=tmp_dir)
     client = create_dask_cluster(cluster="LocalCluster", cluster_config={})
-    status = client.status
-    assert status == "running"
+    try:
+        status = client.status
+        assert status == "running"
+    finally:
+        client.close()
 
 
 def test_create_dask_cluster():
@@ -48,8 +51,11 @@ def test_multiprocess(parallel_test_data, tmpdir):
              '--writeimg', '--other', 'on', image_path]]
     # Create a dask LocalCluster client
     client = Client(n_workers=1)
-    multiprocess(jobs, client=client)
-    assert os.path.exists(result_file)
+    try:
+        multiprocess(jobs, client=client)
+        assert os.path.exists(result_file)
+    finally:
+        client.close()
 
 
 def test_process_images_multiproc():


### PR DESCRIPTION
**Describe your changes**
Local testing was recently failing due to a too many open files error. This PR reduces the number of open files left orphaned during testing by 1) fixing an instance where a file is never closed by the naive Bayes classifier, and 2) closing dask clients after testing whether the tests pass or fail.

**Type of update**
Is this a: Bug fix

**For the reviewer**
See [this page](https://docs.plantcv.org/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
