### PR TITLE
Add CameraTrax color card reference matrix and update X-Rite standard matrix to post-2014 values

### DIFF
--- a/docs/cameratrax_color_matrix.md
+++ b/docs/cameratrax_color_matrix.md
@@ -1,0 +1,72 @@
+## CameraTrax 24ColorCard Standard Color Matrix
+
+Returns a color matrix with the standard *R*, *G*, *B* values compatible with the CameraTrax
+24ColorCard color cards.
+
+The CameraTrax 24ColorCard has the same chip layout as the X-Rite ColorChecker targets but uses its
+own color formulation, so it requires its own reference matrix. The sRGB values are the
+print-measured values printed on each card below the color chips.
+
+Source: [https://www.cameratrax.com/color_balance_4x6.php](https://www.cameratrax.com/color_balance_4x6.php)
+
+**plantcv.transform.cameratrax_color_matrix**(*pos=0*)
+
+**returns** color_matrix
+
+- **Parameters**
+    - pos - reference value indicating orientation of the color card. The reference
+    is based on the position of the white chip:
+
+        - pos = 0: bottom-left corner  
+        - pos = 1: bottom-right corner
+        - pos = 2: top-right corner
+        - pos = 3: top-left corner
+
+- **Context**
+    - A standard matrix can be used most readily while doing [affine](transform_affine_color_correction.md) color correction. 
+    Where possible it's recommended to use [`pcv.transform.detect_color_card`](transform_detect_color_card.md) which orders the color card mask as if the white chip were in the top-left corner, or `pos = 3`. 
+
+- **Returns**
+    - color_matrix - a *n* x 4 matrix containing the standard red, green, and blue
+    values for each color chip
+
+- **Example use below:**
+
+```python
+
+from plantcv import plantcv as pcv
+
+cameratrax_color_matrix = pcv.transform.cameratrax_color_matrix(pos=0)
+
+# use fixed point notation for printing the matrix
+np.set_printoptions(precision=2, suppress=True)
+
+print(cameratrax_color_matrix)
+
+        [[ 10.     0.45   0.35   0.3 ]
+         [ 20.     0.76   0.59   0.53]
+         [ 30.     0.35   0.49   0.63]
+         [ 40.     0.36   0.44   0.28]
+         [ 50.     0.5    0.51   0.7 ]
+         [ 60.     0.36   0.76   0.69]
+         [ 70.     0.88   0.5    0.24]
+         [ 80.     0.27   0.37   0.7 ]
+         [ 90.     0.77   0.33   0.4 ]
+         [100.     0.36   0.25   0.43]
+         [110.     0.63   0.75   0.3 ]
+         [120.     0.91   0.64   0.24]
+         [130.     0.19   0.27   0.6 ]
+         [140.     0.28   0.61   0.32]
+         [150.     0.69   0.25   0.25]
+         [160.     0.95   0.8    0.25]
+         [170.     0.75   0.35   0.61]
+         [180.     0.     0.54   0.67]
+         [190.     0.96   0.96   0.97]
+         [200.     0.8    0.81   0.82]
+         [210.     0.63   0.65   0.66]
+         [220.     0.47   0.48   0.5 ]
+         [230.     0.33   0.35   0.36]
+         [240.     0.21   0.21   0.21]]
+
+```
+**Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/transform/standard_matrices.py)

--- a/docs/std_color_matrix.md
+++ b/docs/std_color_matrix.md
@@ -3,9 +3,19 @@
 Returns a color matrix with the standard *R*, *G*, *B* values compatible with the x-rite ColorCheker Classic,
 ColorChecker Mini, and ColorChecker Passport targets.
 
-Source: [https://en.wikipedia.org/wiki/ColorChecker](https://en.wikipedia.org/wiki/ColorChecker)
+X-Rite changed the pigment formulations of these targets in November 2014, so reference values are
+provided for both post-November 2014 targets (default) and legacy (pre-November 2014) targets, which
+can be useful when standardizing images collected with older color cards.
 
-**plantcv.transform.std_color_matrix**(*pos=0*)
+Sources:
+
+- Post-November 2014 targets: sRGB conversion of the X-Rite reference CIELAB data for targets
+manufactured November 2014 and later, converted and distributed by
+[BabelColor](https://babelcolor.com/colorchecker-2.htm)
+- Pre-November 2014 targets: average of measurements from 30 charts,
+[https://en.wikipedia.org/wiki/ColorChecker](https://en.wikipedia.org/wiki/ColorChecker)
+
+**plantcv.transform.std_color_matrix**(*pos=0, xrite_legacy=False*)
 
 **returns** color_matrix
 
@@ -17,6 +27,9 @@ Source: [https://en.wikipedia.org/wiki/ColorChecker](https://en.wikipedia.org/wi
         - pos = 1: bottom-right corner
         - pos = 2: top-right corner
         - pos = 3: top-left corner
+
+    - xrite_legacy - return the reference matrix for legacy (pre-November 2014) X-Rite
+    ColorChecker targets instead of the current (post-November 2014) targets (default = False)
 
 - **Context**
     - A standard matrix can be used most readily while doing [affine](transform_affine_color_correction.md) color correction. 
@@ -39,30 +52,30 @@ np.set_printoptions(precision=2, suppress=True)
 
 print(std_color_matrix)
 
-        [[ 10.     0.45   0.32   0.27]
-         [ 20.     0.76   0.59   0.51]
-         [ 30.     0.38   0.48   0.62]
-         [ 40.     0.34   0.42   0.26]
-         [ 50.     0.52   0.5    0.69]
-         [ 60.     0.4    0.74   0.67]
-         [ 70.     0.84   0.49   0.17]
-         [ 80.     0.31   0.36   0.65]
-         [ 90.     0.76   0.35   0.39]
-         [100.     0.37   0.24   0.42]
-         [110.     0.62   0.74   0.25]
-         [120.     0.88   0.64   0.18]
-         [130.     0.22   0.24   0.59]
-         [140.     0.27   0.58   0.29]
-         [150.     0.69   0.21   0.24]
-         [160.     0.91   0.78   0.12]
-         [170.     0.73   0.34   0.58]
-         [180.     0.03   0.52   0.63]
-         [190.     0.95   0.95   0.95]
-         [200.     0.78   0.78   0.78]
-         [210.     0.63   0.63   0.63]
-         [220.     0.48   0.48   0.47]
+        [[ 10.     0.45   0.31   0.25]
+         [ 20.     0.78   0.56   0.5 ]
+         [ 30.     0.36   0.47   0.61]
+         [ 40.     0.36   0.42   0.25]
+         [ 50.     0.51   0.5    0.69]
+         [ 60.     0.37   0.74   0.67]
+         [ 70.     0.88   0.49   0.19]
+         [ 80.     0.27   0.35   0.65]
+         [ 90.     0.78   0.31   0.37]
+         [100.     0.36   0.22   0.41]
+         [110.     0.61   0.73   0.23]
+         [120.     0.89   0.63   0.15]
+         [130.     0.15   0.24   0.57]
+         [140.     0.24   0.58   0.27]
+         [150.     0.7    0.21   0.22]
+         [160.     0.93   0.78   0.05]
+         [170.     0.75   0.31   0.58]
+         [180.     0.     0.52   0.65]
+         [190.     0.95   0.95   0.93]
+         [200.     0.79   0.8    0.79]
+         [210.     0.63   0.64   0.64]
+         [220.     0.47   0.47   0.47]
          [230.     0.33   0.33   0.33]
-         [240.     0.2    0.2    0.2 ]]
+         [240.     0.19   0.19   0.2 ]]
 
 ```
 **Source Code:** [Here](https://github.com/danforthcenter/plantcv/blob/master/plantcv/plantcv/transform/standard_matrices.py)

--- a/docs/transform_auto_correct_color.md
+++ b/docs/transform_auto_correct_color.md
@@ -2,7 +2,7 @@
 
 Corrects the color of the input image based on the target color matrix using an affine transformation
 in the RGB space after automatic detection of a color card within the image. A one-step wrapper of
-[plantcv.transform.detect_color_card](transform_detect_color_card.md), [plantcv.transform.std_color_matrix](std_color_matrix.md) or [plantcv.transform.astro_color_matrix](astro_color_matrix.md),
+[plantcv.transform.detect_color_card](transform_detect_color_card.md), [plantcv.transform.std_color_matrix](std_color_matrix.md), [plantcv.transform.cameratrax_color_matrix](cameratrax_color_matrix.md) or [plantcv.transform.astro_color_matrix](astro_color_matrix.md),
 [plantcv.transform.get_color_matrix](get_color_matrix.md), and [plantcv.transform.affine_color_correction](transform_affine_color_correction.md).
 
 **plantcv.transform.auto_correct_color**(*rgb_img, color_chip_size=None, roi=None, \*\*kwargs*)
@@ -15,8 +15,13 @@ in the RGB space after automatic detection of a color card within the image. A o
     "cameratrax", or "astro", by default `None`). Or provide `(width, height)` of your specific color card in millimeters. If
     set then the type of color card (macbeth chart or astrobotany calibration sticker) and size scalings parameters
     `pcv.params.unit`, `pcv.params.px_width`, and `pcv.params.px_height` are automatically set, and utilized throughout linear
-    and area type measurements stored to `Outputs`.
+    and area type measurements stored to `Outputs`. Macbeth chart style cards are corrected to the reference matrix matching
+    the card type: X-Rite ColorChecker targets (including "classic", "passport", "nano", and "mini") to
+    [std_color_matrix](std_color_matrix.md), CameraTrax 24ColorCard targets ("cameratrax") to
+    [cameratrax_color_matrix](cameratrax_color_matrix.md).
     - roi              - Optional rectangular ROI as returned by [`pcv.roi.rectangle`](roi_rectangle.md) within which to look for the color card. (default = None)
+    - xrite_legacy     - If color_chip_size indicates an X-Rite ColorChecker target, correct to the reference matrix
+    for legacy (pre-November 2014) targets instead of the current (post-November 2014) targets (default = False).
 	- **kwargs         - Other keyword arguments passed to `cv2.adaptiveThreshold` and `cv2.circle`.
         - adaptive_method  - Adaptive threhold method. 0 (mean) or 1 (Gaussian) (default = 1).
         - block_size       - Size of a pixel neighborhood that is used to calculate a threshold value (default = 51). We suggest using 127 if using `adaptive_method=0`.

--- a/docs/transform_auto_correct_color_nonlinear.md
+++ b/docs/transform_auto_correct_color_nonlinear.md
@@ -13,6 +13,8 @@ Corrects the color of the input image based on the target color matrix using a n
     size scalings parameters `pcv.params.unit`, `pcv.params.px_width`, and `pcv.params.px_height` are automatically set, and
     utilized throughout linear and area type measurements stored to `Outputs`.
     - roi              - Optional rectangular ROI as returned by [`pcv.roi.rectangle`](roi_rectangle.md) within which to look for the color card. (default = None)
+    - xrite_legacy     - If color_chip_size indicates an X-Rite ColorChecker target, correct to the reference matrix
+    for legacy (pre-November 2014) targets instead of the current (post-November 2014) targets (default = False).
 	- **kwargs         - Other keyword arguments passed to `cv2.adaptiveThreshold` and `cv2.circle`.
         - adaptive_method  - Adaptive threhold method. 0 (mean) or 1 (Gaussian) (default = 1).
         - block_size       - Size of a pixel neighborhood that is used to calculate a threshold value (default = 51). We suggest using 127 if using `adaptive_method=0`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -195,6 +195,7 @@ nav:
           - 'Delta E Metric': transform_deltaE.md
           - 'Affine Color Correction': transform_affine_color_correction.md
           - 'Standard Color Matrix': std_color_matrix.md
+          - 'CameraTrax Color Matrix': cameratrax_color_matrix.md
           - 'Gamma Correction': transform_gamma_correct.md
           - 'Mask Color Card': transform_mask_color_card.md
           - 'Merge Images': transform_merge_images.md

--- a/plantcv/plantcv/transform/__init__.py
+++ b/plantcv/plantcv/transform/__init__.py
@@ -14,6 +14,7 @@ from plantcv.plantcv.transform.rescale import rescale
 from plantcv.plantcv.transform.rotate import rotate
 from plantcv.plantcv.transform.standard_matrices import std_color_matrix
 from plantcv.plantcv.transform.standard_matrices import astro_color_matrix
+from plantcv.plantcv.transform.standard_matrices import cameratrax_color_matrix
 from plantcv.plantcv.transform.nonuniform_illumination import nonuniform_illumination
 from plantcv.plantcv.transform.resize import resize, resize_factor
 from plantcv.plantcv.transform.warp import warp, warp_align
@@ -28,4 +29,4 @@ __all__ = ["get_color_matrix", "get_matrix_m", "calc_transformation_matrix", "ap
            "std_color_matrix", "affine_color_correction", "rescale", "nonuniform_illumination", "resize",
            "resize_factor", "warp", "rotate", "warp", "warp_align", "gamma_correct", "deltaE",
            "detect_color_card", "checkerboard_calib", "calibrate_camera", "merge_images", "auto_correct_color",
-           "mask_color_card", "auto_correct_color_nonlinear", "astro_color_matrix"]
+           "mask_color_card", "auto_correct_color_nonlinear", "astro_color_matrix", "cameratrax_color_matrix"]

--- a/plantcv/plantcv/transform/auto_correct_color.py
+++ b/plantcv/plantcv/transform/auto_correct_color.py
@@ -6,7 +6,7 @@ from plantcv.plantcv.transform.color_correction import (
     calc_transformation_matrix
 )
 from plantcv.plantcv.transform.get_color_matrix import get_matrix_m
-from plantcv.plantcv.transform.standard_matrices import std_color_matrix, astro_color_matrix
+from plantcv.plantcv.transform.standard_matrices import std_color_matrix, astro_color_matrix, cameratrax_color_matrix
 
 
 def auto_correct_color(rgb_img, color_chip_size=None, roi=None, **kwargs):
@@ -20,6 +20,10 @@ def auto_correct_color(rgb_img, color_chip_size=None, roi=None, **kwargs):
         in millimeters (default = None)
     roi: plantcv.plantcv.Objects, optional
         Objects class rectangular ROI passed to detect_color_card (default None)
+    xrite_legacy : bool, optional
+        If color_chip_size indicates an X-Rite ColorChecker target, correct to the reference matrix
+        for legacy (pre-November 2014) targets instead of the current (post-November 2014) targets
+        (default = False)
     **kwargs
         Other keyword arguments passed to cv2.adaptiveThreshold, cv2.circle and _rect_filter.
         Valid keyword arguments:
@@ -35,12 +39,15 @@ def auto_correct_color(rgb_img, color_chip_size=None, roi=None, **kwargs):
     numpy.ndarray
         Color corrected image
     """
+    xrite_legacy = kwargs.pop("xrite_legacy", False)
     card_matrix = detect_color_card(rgb_img=rgb_img, color_chip_size=color_chip_size, roi=roi, **kwargs)
 
     if isinstance(color_chip_size, str) and color_chip_size.upper() == 'ASTRO':
         std_matrix = astro_color_matrix()
+    elif isinstance(color_chip_size, str) and color_chip_size.upper() == 'CAMERATRAX':
+        std_matrix = cameratrax_color_matrix(pos=3)
     else:
-        std_matrix = std_color_matrix(pos=3)
+        std_matrix = std_color_matrix(pos=3, xrite_legacy=xrite_legacy)
 
     corr_img = affine_color_correction(rgb_img=rgb_img, source_matrix=card_matrix, target_matrix=std_matrix)
 
@@ -54,10 +61,14 @@ def auto_correct_color_nonlinear(rgb_img, color_chip_size=None, roi=None, **kwar
     rgb_img : numpy.ndarray
         Input RGB image data containing a color card.
     color_chip_size: str, tuple, optional
-        "passport", "classic", "nano", "mini", or "cameratrax"; or tuple formatted (width, height)
+        "passport", "classic", "nano", "mini", "cameratrax", or "astro"; or tuple formatted (width, height)
         in millimeters (default = None)
     roi: plantcv.plantcv.Objects, optional
         Objects class rectangular ROI passed to detect_color_card (default None)
+    xrite_legacy : bool, optional
+        If color_chip_size indicates an X-Rite ColorChecker target, correct to the reference matrix
+        for legacy (pre-November 2014) targets instead of the current (post-November 2014) targets
+        (default = False)
     **kwargs
         Other keyword arguments passed to cv2.adaptiveThreshold, cv2.circle and _rect_filter.
         Valid keyword arguments:
@@ -72,8 +83,15 @@ def auto_correct_color_nonlinear(rgb_img, color_chip_size=None, roi=None, **kwar
     numpy.ndarray
         Color corrected image
     """
+    xrite_legacy = kwargs.pop("xrite_legacy", False)
     card_matrix = detect_color_card(rgb_img=rgb_img, color_chip_size=color_chip_size, roi=roi, **kwargs)
-    std_matrix = std_color_matrix(pos=3)
+
+    if isinstance(color_chip_size, str) and color_chip_size.upper() == 'ASTRO':
+        std_matrix = astro_color_matrix()
+    elif isinstance(color_chip_size, str) and color_chip_size.upper() == 'CAMERATRAX':
+        std_matrix = cameratrax_color_matrix(pos=3)
+    else:
+        std_matrix = std_color_matrix(pos=3, xrite_legacy=xrite_legacy)
     _, matrix_m, matrix_b = get_matrix_m(target_matrix=std_matrix, source_matrix=card_matrix)
     # calculate transformation_matrix and save
     _, transformation_matrix = calc_transformation_matrix(matrix_m, matrix_b)

--- a/plantcv/plantcv/transform/delta_e.py
+++ b/plantcv/plantcv/transform/delta_e.py
@@ -5,7 +5,7 @@ from skimage import color
 from matplotlib import pyplot as plt
 from plantcv.plantcv._globals import params, outputs
 from plantcv.plantcv.fatal_error import fatal_error
-from plantcv.plantcv.transform.standard_matrices import std_color_matrix, astro_color_matrix
+from plantcv.plantcv.transform.standard_matrices import std_color_matrix, astro_color_matrix, cameratrax_color_matrix
 
 
 def _delta_e(obs_rgb, card_type=None, obs="uncalibrated"):
@@ -16,7 +16,8 @@ def _delta_e(obs_rgb, card_type=None, obs="uncalibrated"):
     obs_rgb : numpy.ndarray
         Observed RGB color chip values as returned from plantcv.transform.detect_color_card
     card_type : str
-        either "macbeth" or "astro" for color card type, defaults to None for compatibility with detection.
+        either "macbeth", "astro", or "cameratrax" for color card type, defaults to None for
+        compatibility with detection.
     obs : str
         string describing what the obs_rgb data is, typically "uncalibrated" for an image input into color correction
         or "calibrated" for an image that has been through color correction.
@@ -33,7 +34,10 @@ def _delta_e(obs_rgb, card_type=None, obs="uncalibrated"):
         obs_mat = (255 * np.delete(obs_rgb, 0, axis=1).reshape(3, 5, 3)).astype("uint8")
         exp_mat = (255 * np.delete(std, 0, axis=1).reshape(3, 5, 3)).astype("uint8")
     else:
-        std = std_color_matrix(pos=3)
+        if card_type.upper() == "CAMERATRAX":
+            std = cameratrax_color_matrix(pos=3)
+        else:
+            std = std_color_matrix(pos=3)
         # format both rgb colors into 6x4 uint8 image
         obs_mat = (255 * np.delete(obs_rgb, 0, axis=1).reshape(6, 4, 3)).astype("uint8")
         exp_mat = (255 * np.delete(std, 0, axis=1).reshape(6, 4, 3)).astype("uint8")

--- a/plantcv/plantcv/transform/standard_matrices.py
+++ b/plantcv/plantcv/transform/standard_matrices.py
@@ -4,17 +4,16 @@ import numpy as np
 from plantcv.plantcv.fatal_error import fatal_error
 
 
-def std_color_matrix(pos=0):
-    """Create a standard color matrix.
-
-    Standard color values compatible with the x-rite ColorChecker Classic,
-    ColorChecker Mini, and ColorChecker Passport targets.
-    Source: https://en.wikipedia.org/wiki/ColorChecker
+def _assemble_color_matrix(values_list, pos):
+    """Arrange a 4 x 6 color card values list into a color matrix given the card orientation.
 
     Parameters
     ----------
+    values_list : numpy.ndarray
+        List of 24 RGB values (0-255) in physical row-major order starting from the dark skin chip
     pos : int
-        reference value indicating orientation of the color card. The reference is based on the position of the white chip:
+        reference value indicating orientation of the color card. The reference is based on the
+        position of the white chip:
                 pos = 0: bottom-left corner (default)
                 pos = 1: bottom-right corner
                 pos = 2: top-right corner
@@ -25,34 +24,6 @@ def std_color_matrix(pos=0):
     color_matrix
         matrix containing the standard red, green, and blue values for each color chip
     """
-    # list of rgb values as indicated in the color card specs. They need to be
-    # arranged depending on the orientation of the color card of reference in the
-    # image to be corrected.
-    values_list = np.array([[115, 82, 68],  # dark skin
-                            [194, 150, 130],  # light skin
-                            [98, 122, 157],  # blue sky
-                            [87, 108, 67],  # foliage
-                            [133, 128, 177],  # blue flower
-                            [103, 189, 170],  # bluish green
-                            [214, 126, 44],  # orange
-                            [80, 91, 166],  # purplish blue
-                            [193, 90, 99],  # moderate red
-                            [94, 60, 108],  # purple
-                            [157, 188, 64],  # yellow green
-                            [224, 163, 46],  # orange yellow
-                            [56, 61, 150],  # blue
-                            [70, 148, 73],  # green
-                            [175, 54, 60],  # red
-                            [231, 199, 31],  # yellow
-                            [187, 86, 149],  # magenta
-                            [8, 133, 161],  # cyan
-                            [243, 243, 242],  # white (.05*)
-                            [200, 200, 200],  # neutral 8 (.23*)
-                            [160, 160, 160],  # neutral 6.5 (.44*)
-                            [122, 122, 121],  # neutral 5 (.7*)
-                            [85, 85, 85],  # neutral 3.5 (1.05*)
-                            [52, 52, 52]], dtype=np.float64)  # black (1.50*)
-
     pos = math.floor(pos)
     if (pos < 0) or (pos > 3):
         fatal_error("white chip position reference 'pos' must be a value among {0, 1, 2, 3}")
@@ -74,6 +45,150 @@ def std_color_matrix(pos=0):
     color_matrix = np.concatenate((chip_nb.reshape(N_chips, 1), color_matrix_wo_chip_nb), axis=1)
 
     return color_matrix
+
+
+def std_color_matrix(pos=0, xrite_legacy=False):
+    """Create a standard color matrix.
+
+    Standard color values compatible with the x-rite ColorChecker Classic,
+    ColorChecker Mini, and ColorChecker Passport targets. X-Rite changed the pigment
+    formulations of these targets in November 2014, so reference values are provided for
+    both post-2014 targets (default) and legacy (pre-November 2014) targets.
+
+    Sources:
+    Post-November 2014 targets: sRGB conversion of the X-Rite reference CIELAB data for
+    targets manufactured November 2014 and later, converted and distributed by BabelColor
+    https://babelcolor.com/colorchecker-2.htm (ColorChecker_sRGB_from_Lab_16bit_AfterNov2014)
+    Pre-November 2014 targets: average of measurements from 30 charts
+    https://en.wikipedia.org/wiki/ColorChecker
+
+    Parameters
+    ----------
+    pos : int
+        reference value indicating orientation of the color card. The reference is based on the position of the white chip:
+                pos = 0: bottom-left corner (default)
+                pos = 1: bottom-right corner
+                pos = 2: top-right corner
+                pos = 3: top-left corner
+    xrite_legacy : bool
+        Return the reference matrix for legacy (pre-November 2014) X-Rite ColorChecker targets
+        instead of the current (post-November 2014) targets (default = False)
+
+    Returns
+    -------
+    color_matrix
+        matrix containing the standard red, green, and blue values for each color chip
+    """
+    # list of rgb values as indicated in the color card specs. They need to be
+    # arranged depending on the orientation of the color card of reference in the
+    # image to be corrected.
+    if xrite_legacy:
+        # sRGB values for ColorChecker targets manufactured before November 2014
+        values_list = np.array([[115, 82, 68],  # dark skin
+                                [194, 150, 130],  # light skin
+                                [98, 122, 157],  # blue sky
+                                [87, 108, 67],  # foliage
+                                [133, 128, 177],  # blue flower
+                                [103, 189, 170],  # bluish green
+                                [214, 126, 44],  # orange
+                                [80, 91, 166],  # purplish blue
+                                [193, 90, 99],  # moderate red
+                                [94, 60, 108],  # purple
+                                [157, 188, 64],  # yellow green
+                                [224, 163, 46],  # orange yellow
+                                [56, 61, 150],  # blue
+                                [70, 148, 73],  # green
+                                [175, 54, 60],  # red
+                                [231, 199, 31],  # yellow
+                                [187, 86, 149],  # magenta
+                                [8, 133, 161],  # cyan
+                                [243, 243, 242],  # white (.05*)
+                                [200, 200, 200],  # neutral 8 (.23*)
+                                [160, 160, 160],  # neutral 6.5 (.44*)
+                                [122, 122, 121],  # neutral 5 (.7*)
+                                [85, 85, 85],  # neutral 3.5 (1.05*)
+                                [52, 52, 52]], dtype=np.float64)  # black (1.50*)
+    else:
+        # sRGB values for ColorChecker targets manufactured November 2014 and later
+        values_list = np.array([[116, 79, 65],  # dark skin
+                                [198, 144, 127],  # light skin
+                                [91, 120, 155],  # blue sky
+                                [91, 108, 63],  # foliage
+                                [131, 127, 175],  # blue flower
+                                [95, 189, 172],  # bluish green
+                                [224, 124, 48],  # orange
+                                [68, 89, 167],  # purplish blue
+                                [198, 80, 95],  # moderate red
+                                [93, 57, 104],  # purple
+                                [156, 187, 58],  # yellow green
+                                [228, 161, 39],  # orange yellow
+                                [39, 61, 145],  # blue
+                                [60, 147, 70],  # green
+                                [178, 53, 56],  # red
+                                [237, 200, 14],  # yellow
+                                [191, 79, 147],  # magenta
+                                [0, 133, 165],  # cyan
+                                [241, 242, 236],  # white (.05*)
+                                [201, 203, 201],  # neutral 8 (.23*)
+                                [161, 163, 163],  # neutral 6.5 (.44*)
+                                [121, 121, 121],  # neutral 5 (.7*)
+                                [83, 84, 84],  # neutral 3.5 (1.05*)
+                                [49, 49, 50]], dtype=np.float64)  # black (1.50*)
+
+    return _assemble_color_matrix(values_list=values_list, pos=pos)
+
+
+def cameratrax_color_matrix(pos=0):
+    """Create a standard color matrix for CameraTrax 24ColorCard color cards.
+
+    Standard color values compatible with the CameraTrax 24ColorCard targets. The 24ColorCard
+    has the same chip layout as X-Rite ColorChecker targets but uses its own color formulation,
+    so it requires its own reference matrix. The sRGB values are the print-measured values
+    printed on each card below the color chips.
+
+    Source: sRGB values printed on the CameraTrax 24ColorCard
+    https://www.cameratrax.com/color_balance_4x6.php
+
+    Parameters
+    ----------
+    pos : int
+        reference value indicating orientation of the color card. The reference is based on the position of the white chip:
+                pos = 0: bottom-left corner (default)
+                pos = 1: bottom-right corner
+                pos = 2: top-right corner
+                pos = 3: top-left corner
+
+    Returns
+    -------
+    color_matrix
+        matrix containing the standard red, green, and blue values for each color chip
+    """
+    values_list = np.array([[116, 88, 76],  # dark skin
+                            [195, 150, 136],  # light skin
+                            [88, 125, 160],  # blue sky
+                            [93, 111, 72],  # foliage
+                            [128, 131, 179],  # blue flower
+                            [91, 193, 175],  # bluish green
+                            [225, 128, 60],  # orange
+                            [68, 95, 178],  # purplish blue
+                            [196, 85, 103],  # moderate red
+                            [92, 63, 109],  # purple
+                            [161, 192, 77],  # yellow green
+                            [231, 163, 60],  # orange yellow
+                            [49, 70, 154],  # blue
+                            [72, 156, 81],  # green
+                            [175, 63, 65],  # red
+                            [242, 204, 64],  # yellow
+                            [191, 89, 155],  # magenta
+                            [0, 138, 171],  # cyan
+                            [245, 246, 248],  # white (.05*)
+                            [205, 207, 208],  # neutral 8 (.23*)
+                            [161, 166, 168],  # neutral 6.5 (.44*)
+                            [120, 123, 127],  # neutral 5 (.7*)
+                            [83, 88, 93],  # neutral 3.5 (1.05*)
+                            [53, 53, 54]], dtype=np.float64)  # black (1.50*)
+
+    return _assemble_color_matrix(values_list=values_list, pos=pos)
 
 
 def astro_color_matrix():

--- a/tests/plantcv/transform/test_auto_correct_color.py
+++ b/tests/plantcv/transform/test_auto_correct_color.py
@@ -35,6 +35,24 @@ def test_auto_correct_color_astrocard(transform_test_data):
     assert np.shape(corrected_img) == np.shape(rgb_img) and np.sum(corrected_img) != np.sum(rgb_img)
 
 
+def test_auto_correct_color_cameratrax(transform_test_data):
+    """Test for PlantCV."""
+    # Load rgb image
+    rgb_img = cv2.imread(transform_test_data.cameratrax_astro_img)
+    corrected_img = auto_correct_color(rgb_img=rgb_img, color_chip_size="CAMERATRAX")
+    params.function_args = {}
+    assert np.shape(corrected_img) == np.shape(rgb_img) and np.sum(corrected_img) != np.sum(rgb_img)
+
+
+def test_auto_correct_color_legacy_xrite(transform_test_data):
+    """Test for PlantCV."""
+    # Load rgb image
+    rgb_img = cv2.imread(transform_test_data.colorcard_img)
+    corrected_img = auto_correct_color(rgb_img=rgb_img, xrite_legacy=True)
+    params.function_args = {}
+    assert np.shape(corrected_img) == np.shape(rgb_img) and np.sum(corrected_img) != np.sum(rgb_img)
+
+
 def test_auto_correct_color_nonaffine(transform_test_data):
     """Test for PlantCV."""
     # Load rgb image

--- a/tests/plantcv/transform/test_color_correction.py
+++ b/tests/plantcv/transform/test_color_correction.py
@@ -8,7 +8,7 @@ from plantcv.plantcv.transform.color_correction import (calc_transformation_matr
                                                         apply_transformation_matrix, save_matrix, load_matrix, correct_color,
                                                         create_color_card_mask, affine_color_correction)
 from plantcv.plantcv.transform.get_color_matrix import get_color_matrix, get_matrix_m
-from plantcv.plantcv.transform.standard_matrices import std_color_matrix, astro_color_matrix
+from plantcv.plantcv.transform.standard_matrices import std_color_matrix, astro_color_matrix, cameratrax_color_matrix
 from plantcv.plantcv.transform.detect_color_card import detect_color_card
 
 
@@ -59,7 +59,64 @@ def test_std_color_matrix(pos):
     white_val = std_matrix[white_idx_pos, 1:]
 
     # RGB values of the white chip in the range [0-255]
+    white_rgb = np.array([241., 242., 236.], dtype=np.float64)
+    # compare RGB values in the range [0-255]
+    assert np.sum(np.abs(255*white_val - white_rgb)) < 1
+
+
+@pytest.mark.parametrize("pos", [0, 1, 2, 3])
+def test_std_color_matrix_legacy(pos):
+    """Test for PlantCV."""
+    std_matrix = std_color_matrix(pos=pos, xrite_legacy=True)
+
+    # indices for the color matrix where the white chip should be depending on
+    # the value of pos
+    white_indices = [18, 23, 5, 0]
+    white_idx_pos = white_indices[pos]
+
+    # RGB values in white chip of the returned matrix in the range [0-1]
+    white_val = std_matrix[white_idx_pos, 1:]
+
+    # RGB values of the white chip in the range [0-255]
     white_rgb = np.array([243., 243., 242.], dtype=np.float64)
+    # compare RGB values in the range [0-255]
+    assert np.sum(np.abs(255*white_val - white_rgb)) < 1
+
+
+def test_std_color_matrix_default_differs_from_legacy():
+    """Test for PlantCV."""
+    # the post-November 2014 reference matrix should differ from the legacy one
+    assert not np.array_equal(std_color_matrix(pos=3), std_color_matrix(pos=3, xrite_legacy=True))
+
+
+def test_cameratrax_color_matrix():
+    """Test for PlantCV."""
+    ctrax_matrix = cameratrax_color_matrix(pos=3)
+
+    # the white chip is the first chip when pos = 3
+    white_val = ctrax_matrix[0, 1:]
+
+    # RGB values of the white chip in the range [0-255]
+    white_rgb = np.array([245., 246., 248.], dtype=np.float64)
+    # compare RGB values in the range [0-255]
+    assert np.sum(np.abs(255*white_val - white_rgb)) < 1
+
+
+@pytest.mark.parametrize("pos", [0, 1, 2, 3])
+def test_cameratrax_color_matrix_orientation(pos):
+    """Test for PlantCV."""
+    ctrax_matrix = cameratrax_color_matrix(pos=pos)
+
+    # indices for the color matrix where the white chip should be depending on
+    # the value of pos
+    white_indices = [18, 23, 5, 0]
+    white_idx_pos = white_indices[pos]
+
+    # RGB values in white chip of the returned matrix in the range [0-1]
+    white_val = ctrax_matrix[white_idx_pos, 1:]
+
+    # RGB values of the white chip in the range [0-255]
+    white_rgb = np.array([245., 246., 248.], dtype=np.float64)
     # compare RGB values in the range [0-255]
     assert np.sum(np.abs(255*white_val - white_rgb)) < 1
 
@@ -68,6 +125,12 @@ def test_std_color_matrix_bad_pos():
     """Test for PlantCV."""
     with pytest.raises(RuntimeError):
         _ = std_color_matrix(pos=4.5)
+
+
+def test_cameratrax_color_matrix_bad_pos():
+    """Test for PlantCV."""
+    with pytest.raises(RuntimeError):
+        _ = cameratrax_color_matrix(pos=4.5)
 
 
 def test_astro_color_matrix():
@@ -320,7 +383,10 @@ def test_cameratrax_and_astro_consistent_color_calibration(transform_test_data):
     astro_std_mat = astro_color_matrix()
     astro_corr_img = affine_color_correction(rgb_img=rgb_img, source_matrix=astro_mat, target_matrix=astro_std_mat)
 
-    diff = np.abs(ctrax_corr_img - astro_corr_img)
+    diff = np.abs(ctrax_corr_img.astype(np.int64) - astro_corr_img.astype(np.int64))
     channel_diffs = np.sum(diff, axis=(0, 1)) / (diff.shape[0] * diff.shape[1])
-    # Check for similarity in corrected color: mean absolute color difference less than 2.5 (1% of range)
-    assert all(channel_diffs < 3) and np.mean(channel_diffs) < 2.5
+    # Check for similarity in corrected color: mean absolute color difference less than 2.5 (1% of range).
+    # The per-channel threshold is slightly relaxed (3.5) since updating the default X-Rite reference
+    # matrix to the post-November 2014 values shifts the blue channel marginally. The matrices are cast
+    # to int before subtracting to avoid uint8 overflow wrapping the absolute differences
+    assert all(channel_diffs < 3.5) and np.mean(channel_diffs) < 2.5

--- a/tests/plantcv/transform/test_deltaE.py
+++ b/tests/plantcv/transform/test_deltaE.py
@@ -20,7 +20,7 @@ def test_deltaE_macbeth(transform_test_data):
     rgb_img = cv2.imread(transform_test_data.colorcard_img)
     de_matrix = deltaE(rgb_img=rgb_img, obs="testname", color_chip_size="classic")
     assert np.shape(de_matrix) == (6, 4)
-    assert np.max(outputs.metadata["deltaE_testname"]["value"]) == [pytest.approx(np.float64(15.279), 0.001)]
+    assert np.max(outputs.metadata["deltaE_testname"]["value"]) == [pytest.approx(np.float64(15.161), 0.001)]
 
 
 def test_deltaE_astro(transform_test_data):
@@ -30,6 +30,18 @@ def test_deltaE_astro(transform_test_data):
     de_matrix = deltaE(rgb_img=rgb_img, color_chip_size="astro")
     assert np.shape(de_matrix) == (3, 5)
     assert np.max(outputs.metadata["deltaE_calibrated"]["value"]) == [pytest.approx(np.float64(35.899), 0.001)]
+
+
+def test_deltaE_cameratrax(transform_test_data):
+    """Test for PlantCV."""
+    outputs.clear()
+    params.function_args = {}
+    rgb_img = cv2.imread(transform_test_data.cameratrax_astro_img)
+    de_matrix = deltaE(rgb_img=rgb_img, obs="testname", color_chip_size="cameratrax")
+    assert np.shape(de_matrix) == (6, 4)
+    # delta E against the CameraTrax reference values should be computed and finite
+    assert np.all(np.isfinite(de_matrix))
+    assert np.max(de_matrix) >= 0
 
 
 def test_deltaE_bad_param(transform_test_data, monkeypatch):


### PR DESCRIPTION
Closes #2000.

## Summary

The single "standard matrix" used for Macbeth-style color cards is based on pre-2014 X-Rite data, but X-Rite changed the pigment formulations of the ColorChecker Classic/SG in November 2014, and CameraTrax 24ColorCard targets use their own color formulation with different sRGB values.

Following the direction discussed in #2000:

- **`std_color_matrix` now defaults to the post-November 2014 X-Rite reference values** (sRGB conversion of the X-Rite reference CIELAB data for targets manufactured Nov 2014 and later, as converted and distributed by BabelColor; I cross-checked BabelColor's conversion against an independent Lab(D50)→XYZ→Bradford→sRGB conversion and they agree within rounding). The pre-2014 values are preserved via a new `xrite_legacy=True` keyword, so workflows with legacy image collections can keep exact backward compatibility.
- **New `cameratrax_color_matrix`** with the print-measured sRGB values from the CameraTrax 24ColorCard (transcribed from the card photo linked in the issue — the values are printed on each card). Selected automatically in `auto_correct_color`/`auto_correct_color_nonlinear` via `color_chip_size="cameratrax"`, and in `delta_e` via `card_type="cameratrax"`, the same way astro cards are picked.
- Docs: updated `std_color_matrix` page (new default, sources, `xrite_legacy` param), new `cameratrax_color_matrix` page, `mkdocs.yml` nav, and both auto-correct pages.

### Test changes

- New tests: legacy/default matrix distinction (per `pos`), CameraTrax matrix values and orientation handling, cameratrax selection in `auto_correct_color` and `delta_e`, legacy kwarg through `auto_correct_color`.
- `test_deltaE_macbeth` expected value updated 15.279 → 15.161 (max delta E against the new default reference).
- `test_cameratrax_and_astro_consistent_color_calibration`: the diff was computed with `np.abs` on uint8 arrays, which wraps around on underflow and silently understates differences (with the new default it overflowed to ~[41, 32, 107]). Fixed by casting to int before subtracting; the true per-channel diffs are [1.01, 1.39, 3.10], so the per-channel threshold is relaxed 3 → 3.5 with the overall mean threshold unchanged (mean improves from 2.22 to 1.83 with the new default). Happy to adjust if you'd rather keep the strict threshold.

## Testing

```
.venv/bin/python -m pytest tests/plantcv/transform/ tests/plantcv/qc/ -q
114 passed, 34 warnings in 12.38s
```

Note for reviewers: the CameraTrax values are transcribed from the printed values on the 4x6 card (same chip layout as ColorChecker). If you have a measured set from a specific card, swapping the values in `cameratrax_color_matrix` is a one-place change.